### PR TITLE
Fix IAM PassRole race on first deploy for CloudWatch addon custom resource

### DIFF
--- a/gco/stacks/regional_stack.py
+++ b/gco/stacks/regional_stack.py
@@ -815,6 +815,11 @@ class GCORegionalStack(Stack):
         # Ensure the update happens after the add-on is created
         update_cw_addon.node.add_dependency(cw_addon)
         update_cw_addon.node.add_dependency(self.cloudwatch_role)
+        # Both UpdateEfsCsiAddonRole and UpdateCloudWatchAddonRole share the same
+        # singleton Lambda (AWS679). On first deploy, IAM propagation of one
+        # policy can race with the other custom resource's invocation. Serializing
+        # them ensures all policies are fully attached before the Lambda executes.
+        update_cw_addon.node.add_dependency(self._efs_csi_addon_role_update)
 
         # Expose the update-addon resource so _apply_kubernetes_manifests can
         # make the kubectl Lambda wait for the IRSA annotation patch to land


### PR DESCRIPTION
## Summary

- The `UpdateCloudWatchAddonRole` and `UpdateEfsCsiAddonRole` custom resources share a singleton Lambda (`AWS679`). On a fresh stack create, IAM propagation of one custom resource's policy can race with the shared Lambda being invoked for the other, causing `iam:PassRole` to fail.
- Added an explicit CDK dependency so `UpdateCloudWatchAddonRole` waits for `UpdateEfsCsiAddonRole` to complete first, serializing execution and ensuring all policies are attached before the Lambda runs.
- Root cause confirmed from `gco-us-east-1` stack failure on 2026-04-27: `ROLLBACK_COMPLETE` due to `UpdateCloudWatchAddonRole` CREATE_FAILED with `iam:PassRole` unauthorized error.

## Test plan

- [ ] Deploy `gco-us-east-1` stack from scratch and verify `UpdateCloudWatchAddonRole` completes successfully
- [ ] Verify CloudWatch Observability addon is configured with the correct IRSA role ARN
- [ ] Confirm no regression on `UpdateEfsCsiAddonRole` or `GetEndpointGroupArn` custom resources

🤖 Generated with [Claude Code](https://claude.ai/claude-code)