### PR TITLE
Extend PR #8 IAM PassRole race fix to cover FSx CSI addon

### DIFF
--- a/gco/stacks/regional_stack.py
+++ b/gco/stacks/regional_stack.py
@@ -189,6 +189,18 @@ class GCORegionalStack(Stack):
         # Create FSx for Lustre (if enabled) for high-performance storage
         self._create_fsx_lustre()
 
+        # FSx CSI's ``updateAddon`` custom resource is conditionally created
+        # inside ``_create_fsx_lustre`` above. Wire its serialization edge
+        # onto the CloudWatch update custom resource retroactively so all
+        # three updateAddon custom resources (EFS, FSx, CloudWatch) never
+        # race on the AWS679 singleton Lambda. EFS→CW is wired inside
+        # ``_create_cloudwatch_observability_addon`` because both are
+        # unconditional; FSx has to be wired here because it's optional
+        # and ordered after the CloudWatch addon is created.
+        fsx_role_update = getattr(self, "_fsx_csi_addon_role_update", None)
+        if fsx_role_update is not None:
+            self._cloudwatch_addon_role_update.node.add_dependency(fsx_role_update)
+
         # Create Valkey Serverless cache (if enabled) for K/V caching
         self._create_valkey_cache()
 
@@ -815,10 +827,18 @@ class GCORegionalStack(Stack):
         # Ensure the update happens after the add-on is created
         update_cw_addon.node.add_dependency(cw_addon)
         update_cw_addon.node.add_dependency(self.cloudwatch_role)
-        # Both UpdateEfsCsiAddonRole and UpdateCloudWatchAddonRole share the same
-        # singleton Lambda (AWS679). On first deploy, IAM propagation of one
-        # policy can race with the other custom resource's invocation. Serializing
-        # them ensures all policies are fully attached before the Lambda executes.
+        # UpdateEfsCsiAddonRole, UpdateFsxCsiAddonRole (optional, only when
+        # FSx Lustre is enabled), and UpdateCloudWatchAddonRole all share
+        # the same singleton Lambda (AWS679). On first deploy, IAM
+        # propagation of one policy can race with another custom resource's
+        # invocation. Serializing them ensures all policies are fully
+        # attached before the Lambda executes for any of them.
+        #
+        # Only EFS is wired here because FSx is created later in
+        # ``__init__`` (in ``_create_fsx_lustre``) and its attribute does
+        # not exist yet when this method runs. The FSx edge is wired
+        # retroactively after ``_create_fsx_lustre`` completes — see the
+        # ``add_dependency`` call immediately after it in ``__init__``.
         update_cw_addon.node.add_dependency(self._efs_csi_addon_role_update)
 
         # Expose the update-addon resource so _apply_kubernetes_manifests can

--- a/tests/test_regional_stack.py
+++ b/tests/test_regional_stack.py
@@ -837,6 +837,142 @@ class TestRegionalStackWithFsx:
             template.resource_count_is("AWS::FSx::FileSystem", 0)
 
 
+class TestAddonRoleUpdateDependencyChain:
+    """Regression guard for the IAM PassRole race on fresh deploys.
+
+    CDK's ``AwsCustomResource`` constructs reuse a singleton Lambda
+    (logical id prefix ``AWS679``) whose execution role accumulates
+    policy statements from every custom resource in the stack. On a
+    cold stack create, IAM propagation of one policy attachment can
+    race with the Lambda being invoked for a different custom resource.
+    ``PassRole`` is the most common failure surface because the IAM
+    authorization is checked inline by the subprocess, not cached.
+
+    The regional stack creates up to three ``updateAddon``-style custom
+    resources that share this singleton: one each for EFS CSI, FSx CSI
+    (only when FSx Lustre is enabled), and CloudWatch Observability.
+    The fix is to serialize them with CDK ``add_dependency`` so
+    CloudFormation emits explicit ``DependsOn`` edges and the Lambda
+    runs against a fully-propagated role each time.
+
+    These tests assert the dependency chain is present in the
+    synthesized template both with and without FSx enabled.
+    """
+
+    def _synth_regional_stack(self, fsx_enabled: bool, logical_name: str):
+        """Synthesize the regional stack with or without FSx enabled.
+
+        Returns the ``assertions.Template`` for inspection. Mirrors the
+        Docker + helm-installer patching pattern used elsewhere in this
+        file so no real Docker daemon is required.
+        """
+        from gco.stacks.regional_stack import GCORegionalStack
+
+        app = cdk.App()
+        config = MockConfigLoader(app, fsx_enabled=fsx_enabled)
+
+        with (
+            patch("gco.stacks.regional_stack.ecr_assets.DockerImageAsset") as mock_docker,
+            patch.object(
+                GCORegionalStack,
+                "_create_helm_installer_lambda",
+                TestRegionalStackSynthesis._mock_helm_installer,
+            ),
+        ):
+            mock_image = MagicMock()
+            mock_image.image_uri = "123456789012.dkr.ecr.us-east-1.amazonaws.com/test:latest"
+            mock_docker.return_value = mock_image
+
+            stack = GCORegionalStack(
+                app,
+                logical_name,
+                config=config,
+                region="us-east-1",
+                auth_secret_arn="arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret",  # nosec B106 - test fixture ARN with fake account ID, not a real secret
+                env=cdk.Environment(account="123456789012", region="us-east-1"),
+            )
+
+            return assertions.Template.from_stack(stack)
+
+    @staticmethod
+    def _depends_on_names(resource: dict) -> list[str]:
+        """Normalize a CFN ``DependsOn`` field to a list of logical ids."""
+        dep = resource.get("DependsOn", [])
+        if isinstance(dep, str):
+            return [dep]
+        return list(dep)
+
+    @staticmethod
+    def _find_by_logical_prefix(resources: dict, prefix: str) -> tuple[str, dict]:
+        """Return the first (logical_id, resource) pair whose id starts with ``prefix``."""
+        for lid, r in resources.items():
+            if lid.startswith(prefix):
+                return lid, r
+        raise AssertionError(
+            f"No resource found with logical id prefix {prefix!r}. "
+            f"Available logical ids: {sorted(resources)[:20]}..."
+        )
+
+    def test_cw_addon_update_depends_on_efs_addon_update_fsx_disabled(self):
+        """Without FSx, CloudWatch's update must depend on EFS's update.
+
+        Prevents the IAM propagation race between the two custom
+        resources that share the AWS679 singleton Lambda.
+        """
+        template = self._synth_regional_stack(
+            fsx_enabled=False, logical_name="test-dep-chain-no-fsx"
+        )
+        resources = template.find_resources("Custom::AWS")
+
+        cw_id, cw_resource = self._find_by_logical_prefix(resources, "UpdateCloudWatchAddonRole")
+        efs_id, _ = self._find_by_logical_prefix(resources, "UpdateEfsCsiAddonRole")
+
+        depends_on = self._depends_on_names(cw_resource)
+        assert efs_id in depends_on, (
+            f"CloudWatch update custom resource must depend on EFS update to "
+            f"serialize IAM propagation on the AWS679 singleton Lambda. "
+            f"Expected {efs_id!r} in CloudWatch's DependsOn; got: {depends_on}"
+        )
+
+    def test_cw_addon_update_has_no_fsx_dependency_when_fsx_disabled(self):
+        """When FSx is disabled, no UpdateFsxCsiAddonRole should exist at all."""
+        template = self._synth_regional_stack(
+            fsx_enabled=False, logical_name="test-dep-chain-no-fsx-guard"
+        )
+        resources = template.find_resources("Custom::AWS")
+
+        fsx_matches = [lid for lid in resources if lid.startswith("UpdateFsxCsiAddonRole")]
+        assert fsx_matches == [], (
+            f"No FSx CSI update custom resource should exist when FSx is "
+            f"disabled; found: {fsx_matches}"
+        )
+
+    def test_cw_addon_update_depends_on_fsx_addon_update_fsx_enabled(self):
+        """With FSx, CloudWatch's update must depend on both EFS and FSx updates.
+
+        All three share the AWS679 singleton Lambda, so the full chain
+        has to be serialized — not just the CloudWatch → EFS pair.
+        """
+        template = self._synth_regional_stack(fsx_enabled=True, logical_name="test-dep-chain-fsx")
+        resources = template.find_resources("Custom::AWS")
+
+        cw_id, cw_resource = self._find_by_logical_prefix(resources, "UpdateCloudWatchAddonRole")
+        efs_id, _ = self._find_by_logical_prefix(resources, "UpdateEfsCsiAddonRole")
+        fsx_id, _ = self._find_by_logical_prefix(resources, "UpdateFsxCsiAddonRole")
+
+        depends_on = self._depends_on_names(cw_resource)
+
+        assert efs_id in depends_on, (
+            f"CloudWatch update must still depend on EFS update when FSx is "
+            f"enabled. Expected {efs_id!r} in DependsOn; got: {depends_on}"
+        )
+        assert fsx_id in depends_on, (
+            f"CloudWatch update must depend on FSx update when FSx is enabled, "
+            f"otherwise FSx and CloudWatch race on the AWS679 singleton Lambda. "
+            f"Expected {fsx_id!r} in DependsOn; got: {depends_on}"
+        )
+
+
 class TestRegionalStackGetters:
     """Tests for RegionalStack getter methods."""
 


### PR DESCRIPTION
PR #8 serialized the CloudWatch and EFS CSI updateAddon custom resources so they stop racing on the AWS679 singleton Lambda's IAM policy propagation. That pairing is the most common failure mode because CloudWatch + EFS are both unconditional. When FSx Lustre is enabled, however, a third updateAddon custom resource (UpdateFsxCsiAddonRole) joins the same singleton Lambda and can still race with CloudWatch on first deploy.

This change completes the serialization chain. The FSx dependency has to be wired after _create_fsx_lustre() runs because the FSx CSI updateAddon custom resource does not exist at the time _create_cloudwatch_observability_addon() runs — _create_fsx_lustre is called later in __init__. The CloudWatch→EFS edge stays in _create_cloudwatch_observability_addon since both are unconditional.

Tests (in tests/test_regional_stack.py::TestAddonRoleUpdateDependencyChain):
- test_cw_addon_update_depends_on_efs_addon_update_fsx_disabled (regression guard for PR #8's original fix)
- test_cw_addon_update_has_no_fsx_dependency_when_fsx_disabled
- test_cw_addon_update_depends_on_fsx_addon_update_fsx_enabled

<!--
Thanks for contributing to GCO! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [ ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
