### PR TITLE
Remove vestigial node_groups config + document IAM5 suppression scope

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Thank you for contributing to GCO (Global Capacity Orchestrator on AWS)! This gu
 
 - AWS account with appropriate permissions
 - Python 3.10+ (required for type union syntax `str | None`)
-- Node.js 20+ (for CDK)
+- Node.js 24+ (for CDK)
 - Docker or Finch
 - kubectl
 - Git

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ See [Architecture Details](docs/ARCHITECTURE.md) for the full deep dive.
 ### Prerequisites
 
 - AWS CLI configured with appropriate credentials
-- Python 3.10+ and Node.js LTS (v20 or v22)
+- Python 3.10+ and Node.js LTS (v24)
 - AWS CDK CLI (`npm install -g aws-cdk`)
 - Docker or Finch (for building container images)
 

--- a/gco/config/config_loader.py
+++ b/gco/config/config_loader.py
@@ -10,7 +10,6 @@ Configuration Sections:
 - regions: List of AWS regions to deploy to
 - kubernetes_version: EKS Kubernetes version
 - resource_thresholds: CPU/memory/GPU utilization thresholds
-- node_groups: GPU node group configuration
 - global_accelerator: Global Accelerator settings
 - alb_config: Application Load Balancer health check settings
 - manifest_processor: Manifest validation and resource limits
@@ -31,7 +30,7 @@ from typing import Any, cast
 import boto3
 from aws_cdk import App
 
-from gco.models import ClusterConfig, NodeGroupConfig, ResourceThresholds
+from gco.models import ClusterConfig, ResourceThresholds
 
 logger = logging.getLogger(__name__)
 
@@ -65,34 +64,6 @@ class ConfigLoader:
         "sa-east-1",
     }
 
-    # Valid GPU instance types
-    VALID_GPU_INSTANCES = {
-        "g4dn.xlarge",
-        "g4dn.2xlarge",
-        "g4dn.4xlarge",
-        "g4dn.8xlarge",
-        "g4dn.12xlarge",
-        "g4dn.16xlarge",
-        "g4ad.xlarge",
-        "g4ad.2xlarge",
-        "g4ad.4xlarge",
-        "g4ad.8xlarge",
-        "g4ad.16xlarge",
-        "p3.2xlarge",
-        "p3.8xlarge",
-        "p3.16xlarge",
-        "p3dn.24xlarge",
-        "p4d.24xlarge",
-        "g5.xlarge",
-        "g5.2xlarge",
-        "g5.4xlarge",
-        "g5.8xlarge",
-        "g5.12xlarge",
-        "g5.16xlarge",
-        "g5.24xlarge",
-        "g5.48xlarge",
-    }
-
     def __init__(self, app: App):
         self.app = app
         self._validate_configuration()
@@ -110,7 +81,6 @@ class ConfigLoader:
             "project_name",
             "kubernetes_version",
             "resource_thresholds",
-            "node_groups",
         ]
         for field in required_fields:
             if not self.app.node.try_get_context(field):
@@ -128,9 +98,6 @@ class ConfigLoader:
 
         # Validate resource thresholds
         self._validate_resource_thresholds()
-
-        # Validate node groups
-        self._validate_node_groups()
 
         # Validate Global Accelerator config
         self._validate_global_accelerator_config()
@@ -195,40 +162,6 @@ class ConfigLoader:
                     raise ConfigValidationError(
                         f"{opt_threshold} must be a non-negative integer (or -1 to disable), got {value}"
                     )
-
-    def _validate_node_groups(self) -> None:
-        """Validate node group configuration"""
-        node_config = self.app.node.try_get_context("node_groups")
-
-        required_fields = ["gpu_instances", "min_size", "max_size", "desired_size"]
-        for field in required_fields:
-            if field not in node_config:
-                raise ConfigValidationError(f"Missing node group configuration: {field}")
-
-        # Validate instance types
-        gpu_instances = node_config["gpu_instances"]
-        if not isinstance(gpu_instances, list) or not gpu_instances:
-            raise ConfigValidationError("gpu_instances must be a non-empty list")
-
-        for instance_type in gpu_instances:
-            if instance_type not in self.VALID_GPU_INSTANCES:
-                raise ConfigValidationError(
-                    f"Invalid GPU instance type '{instance_type}'. Valid types: {sorted(self.VALID_GPU_INSTANCES)}"
-                )
-
-        # Validate scaling values
-        min_size = node_config["min_size"]
-        max_size = node_config["max_size"]
-        desired_size = node_config["desired_size"]
-
-        if not all(isinstance(x, int) and x >= 0 for x in [min_size, max_size, desired_size]):
-            raise ConfigValidationError("Scaling values must be non-negative integers")
-
-        if min_size > max_size:
-            raise ConfigValidationError("min_size cannot be greater than max_size")
-
-        if desired_size < min_size or desired_size > max_size:
-            raise ConfigValidationError("desired_size must be between min_size and max_size")
 
     def _validate_global_accelerator_config(self) -> None:
         """Validate Global Accelerator configuration"""
@@ -465,33 +398,12 @@ class ConfigLoader:
             pending_requested_gpus=thresholds_config.get("pending_requested_gpus", 8),
         )
 
-    def get_node_group_config(self) -> NodeGroupConfig:
-        """Get node group configuration"""
-        node_config = self.app.node.try_get_context("node_groups") or {
-            "gpu_instances": ["g4dn.xlarge"],
-            "min_size": 0,
-            "max_size": 10,
-            "desired_size": 1,
-        }
-        return NodeGroupConfig(
-            name="gpu-nodes",
-            instance_types=node_config["gpu_instances"],
-            scaling_config={
-                "min_size": node_config["min_size"],
-                "max_size": node_config["max_size"],
-                "desired_size": node_config["desired_size"],
-            },
-            labels={"workload-type": "gpu-compute", "node-type": "gpu"},
-            taints=[{"key": "nvidia.com/gpu", "value": "true", "effect": "NoSchedule"}],
-        )
-
     def get_cluster_config(self, region: str) -> ClusterConfig:
         """Get complete cluster configuration for a region"""
         return ClusterConfig(
             region=region,
             cluster_name=f"{self.get_project_name()}-{region}",
             kubernetes_version=self.get_kubernetes_version(),
-            node_groups=[self.get_node_group_config()],
             addons=["metrics-server"],
             resource_thresholds=self.get_resource_thresholds(),
         )

--- a/gco/models/__init__.py
+++ b/gco/models/__init__.py
@@ -2,14 +2,14 @@
 Data models for GCO (Global Capacity Orchestrator on AWS).
 
 This module provides Pydantic-style dataclasses for:
-- Cluster configuration (EKS settings, node groups, thresholds)
+- Cluster configuration (EKS settings, thresholds)
 - Health monitoring (resource utilization, health status)
 - Manifest processing (Kubernetes manifests, submission requests/responses)
 
 All models include validation in __post_init__ to ensure data integrity.
 """
 
-from .cluster_models import ClusterConfig, NodeGroupConfig, ResourceThresholds
+from .cluster_models import ClusterConfig, ResourceThresholds
 from .health_models import HealthStatus, RequestedResources, ResourceUtilization
 from .inference_models import (
     EndpointState,
@@ -28,7 +28,6 @@ from .manifest_models import (
 __all__ = [
     # Cluster configuration models
     "ClusterConfig",
-    "NodeGroupConfig",
     "ResourceThresholds",
     # Health monitoring models
     "HealthStatus",

--- a/gco/models/cluster_models.py
+++ b/gco/models/cluster_models.py
@@ -3,7 +3,6 @@ Cluster configuration data models for GCO (Global Capacity Orchestrator on AWS).
 
 This module defines dataclasses for EKS cluster configuration including:
 - ResourceThresholds: CPU/memory/GPU utilization thresholds for health monitoring
-- NodeGroupConfig: EKS node group configuration (instance types, scaling, labels)
 - ClusterConfig: Complete cluster configuration combining all settings
 
 All models include validation in __post_init__ to ensure data integrity.
@@ -70,50 +69,12 @@ class ResourceThresholds:
 
 
 @dataclass
-class NodeGroupConfig:
-    """Configuration for EKS node groups"""
-
-    name: str
-    instance_types: list[str]
-    scaling_config: dict[str, int]  # min_size, max_size, desired_size
-    labels: dict[str, str]
-    taints: list[dict[str, str]]
-
-    def __post_init__(self) -> None:
-        """Validate node group configuration"""
-        if not self.name:
-            raise ValueError("Node group name cannot be empty")
-
-        if not self.instance_types:
-            raise ValueError("At least one instance type must be specified")
-
-        required_scaling_keys = {"min_size", "max_size", "desired_size"}
-        if not required_scaling_keys.issubset(self.scaling_config.keys()):
-            raise ValueError(f"Scaling config must contain keys: {required_scaling_keys}")
-
-        # Validate scaling values
-        min_size = self.scaling_config["min_size"]
-        max_size = self.scaling_config["max_size"]
-        desired_size = self.scaling_config["desired_size"]
-
-        if min_size < 0 or max_size < 0 or desired_size < 0:
-            raise ValueError("Scaling values must be non-negative")
-
-        if min_size > max_size:
-            raise ValueError("min_size cannot be greater than max_size")
-
-        if desired_size < min_size or desired_size > max_size:
-            raise ValueError("desired_size must be between min_size and max_size")
-
-
-@dataclass
 class ClusterConfig:
     """Complete configuration for an EKS cluster"""
 
     region: str
     cluster_name: str
     kubernetes_version: str
-    node_groups: list[NodeGroupConfig]
     addons: list[str]
     resource_thresholds: ResourceThresholds
 
@@ -127,11 +88,3 @@ class ClusterConfig:
 
         if not self.kubernetes_version:
             raise ValueError("Kubernetes version cannot be empty")
-
-        if not self.node_groups:
-            raise ValueError("At least one node group must be specified")
-
-        # Validate node group names are unique
-        node_group_names = [ng.name for ng in self.node_groups]
-        if len(node_group_names) != len(set(node_group_names)):
-            raise ValueError("Node group names must be unique")

--- a/gco/stacks/nag_suppressions.py
+++ b/gco/stacks/nag_suppressions.py
@@ -182,6 +182,33 @@ def add_iam_suppressions(
         global_region: Global region for SSM parameters and DynamoDB tables
     """
     # Build dynamic applies_to list based on configured regions
+    #
+    # NOTE ON BLANKET ENTRIES:
+    # "Resource::*" and "Action::eks:*" are intentionally broad at the
+    # stack-suppression level. They match the cdk-nag finding string
+    # "Resource::*" (or "Action::eks:*"), which is identical for every
+    # construct that uses ``Resource: "*"`` in its IAM policy. There's
+    # no way to distinguish between (say) the kubectl Lambda's
+    # ``Resource: *`` and the VPC Flow Logs role's ``Resource: *`` at
+    # this layer — both produce the same finding string.
+    #
+    # To tighten these further, each would need to be moved to a
+    # construct-level ``NagSuppressions.add_resource_suppressions``
+    # call on the specific IAM role. That's a larger refactor tracked
+    # separately. The ``tests/test_nag_compliance.py`` gate prevents
+    # new unsuppressed wildcards from shipping regardless.
+    #
+    # Constructs currently covered by "Resource::*":
+    #   - KubectlApplierFunction Lambda execution role (EKS admin)
+    #   - HelmInstallerFunction Lambda execution role (EKS admin)
+    #   - GaRegistrationFunction Lambda execution role (GA + SSM)
+    #   - CDK Provider Framework Lambda roles (invoke target Lambda)
+    #   - VPC Flow Logs role (CloudWatch Logs)
+    #   - ServiceAccountRole ec2:Describe*/elasticloadbalancing:Describe*
+    #     (AWS APIs that don't support resource-level scoping)
+    #
+    # Constructs currently covered by "Action::eks:*":
+    #   - EKS cluster admin access entries for kubectl and helm Lambdas
     applies_to = [
         "Resource::*",
         "Action::eks:*",

--- a/tests/_cdk_config_matrix.py
+++ b/tests/_cdk_config_matrix.py
@@ -26,12 +26,6 @@ Notes on the list
   matrix. These matter for the compliance test because the Helm
   installer Lambda's IAM role changes shape based on which charts
   it has to install.
-
-* ``large-node-groups`` writes into the legacy ``node_groups`` context
-  key. That key is no longer consumed by the stacks (EKS Auto Mode
-  handles node groups dynamically) but the config loader still
-  validates it, so the override still has to parse. See also the
-  pending cleanup for removing the dead config surface.
 """
 
 from __future__ import annotations
@@ -240,17 +234,6 @@ CONFIGS.extend(
                     "log_level": "ERROR",
                     "metrics_enabled": True,
                     "tracing_enabled": False,
-                }
-            },
-        ),
-        (
-            "large-node-groups",
-            {
-                "node_groups": {
-                    "gpu_instances": ["p4d.24xlarge", "g5.48xlarge"],
-                    "min_size": 0,
-                    "max_size": 500,
-                    "desired_size": 10,
                 }
             },
         ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,6 @@ import pytest
 from gco.models import (
     ClusterConfig,
     HealthStatus,
-    NodeGroupConfig,
     ResourceThresholds,
     ResourceUtilization,
 )
@@ -99,25 +98,12 @@ def sample_utilization():
 
 
 @pytest.fixture
-def sample_node_group():
-    """Create sample node group configuration."""
-    return NodeGroupConfig(
-        name="gpu-nodes",
-        instance_types=["g4dn.xlarge", "g5.xlarge"],
-        scaling_config={"min_size": 0, "max_size": 10, "desired_size": 2},
-        labels={"workload-type": "gpu"},
-        taints=[{"key": "nvidia.com/gpu", "value": "true", "effect": "NoSchedule"}],
-    )
-
-
-@pytest.fixture
-def sample_cluster_config(sample_thresholds, sample_node_group):
+def sample_cluster_config(sample_thresholds):
     """Create sample cluster configuration."""
     return ClusterConfig(
         region="us-east-1",
         cluster_name="gco-us-east-1",
         kubernetes_version="1.35",
-        node_groups=[sample_node_group],
         addons=["metrics-server"],
         resource_thresholds=sample_thresholds,
     )
@@ -304,12 +290,6 @@ def valid_cdk_context():
         },
         "kubernetes_version": "1.35",
         "resource_thresholds": {"cpu_threshold": 80, "memory_threshold": 85, "gpu_threshold": 90},
-        "node_groups": {
-            "gpu_instances": ["g4dn.xlarge", "g5.xlarge"],
-            "min_size": 0,
-            "max_size": 10,
-            "desired_size": 2,
-        },
         "global_accelerator": {
             "name": "gco-accelerator",
             "health_check_grace_period": 30,

--- a/tests/test_cdk_stacks.py
+++ b/tests/test_cdk_stacks.py
@@ -46,17 +46,6 @@ class MockConfigLoader:
 
         return ResourceThresholds(cpu_threshold=80, memory_threshold=85, gpu_threshold=90)
 
-    def get_node_group_config(self):
-        from gco.models import NodeGroupConfig
-
-        return NodeGroupConfig(
-            name="gpu-nodes",
-            instance_types=["g4dn.xlarge"],
-            scaling_config={"min_size": 0, "max_size": 10, "desired_size": 1},
-            labels={"workload-type": "gpu"},
-            taints=[],
-        )
-
     def get_cluster_config(self, region):
         from gco.models import ClusterConfig
 
@@ -64,7 +53,6 @@ class MockConfigLoader:
             region=region,
             cluster_name=f"gco-test-{region}",
             kubernetes_version="1.35",
-            node_groups=[self.get_node_group_config()],
             addons=["metrics-server"],
             resource_thresholds=self.get_resource_thresholds(),
         )
@@ -350,7 +338,6 @@ class TestConfigIntegration:
         assert config.get_kubernetes_version() == "1.35"
         assert isinstance(config.get_tags(), dict)
         assert config.get_resource_thresholds() is not None
-        assert config.get_node_group_config() is not None
         assert config.get_cluster_config("us-east-1") is not None
         assert config.get_global_accelerator_config() is not None
         assert config.get_alb_config() is not None

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -4,7 +4,7 @@ Tests for gco/config/config_loader.ConfigLoader.
 Drives ConfigLoader against a MockApp/MockNode pair that surfaces a
 hand-crafted CDK context dict. Verifies happy-path loading of every
 top-level field (project_name, deployment_regions, kubernetes_version,
-resource_thresholds, node_groups, global_accelerator, alb_config,
+resource_thresholds, global_accelerator, alb_config,
 manifest_processor, job_validation_policy, api_gateway, tags) and
 that missing required fields raise ConfigValidationError with an
 informative message. Companion suite to test_config_loader_validation.py
@@ -46,12 +46,6 @@ def valid_context():
         },
         "kubernetes_version": "1.35",
         "resource_thresholds": {"cpu_threshold": 80, "memory_threshold": 85, "gpu_threshold": 90},
-        "node_groups": {
-            "gpu_instances": ["g4dn.xlarge", "g5.xlarge"],
-            "min_size": 0,
-            "max_size": 10,
-            "desired_size": 2,
-        },
         "global_accelerator": {
             "name": "gco-accelerator",
             "health_check_grace_period": 30,
@@ -191,40 +185,6 @@ class TestResourceThresholdsValidation:
             ConfigLoader(app)
 
 
-class TestNodeGroupValidation:
-    """Tests for node group validation."""
-
-    def test_valid_node_groups(self, valid_context):
-        """Test valid node groups pass validation."""
-        app = MockApp(valid_context)
-        config = ConfigLoader(app)
-        node_config = config.get_node_group_config()
-        assert node_config.name == "gpu-nodes"
-        assert "g4dn.xlarge" in node_config.instance_types
-
-    def test_invalid_gpu_instance(self, valid_context):
-        """Test invalid GPU instance type raises error."""
-        valid_context["node_groups"]["gpu_instances"] = ["invalid-instance"]
-        app = MockApp(valid_context)
-        with pytest.raises(ConfigValidationError, match="Invalid GPU instance type"):
-            ConfigLoader(app)
-
-    def test_min_greater_than_max(self, valid_context):
-        """Test min_size > max_size raises error."""
-        valid_context["node_groups"]["min_size"] = 10
-        valid_context["node_groups"]["max_size"] = 5
-        app = MockApp(valid_context)
-        with pytest.raises(ConfigValidationError, match="min_size cannot be greater than max_size"):
-            ConfigLoader(app)
-
-    def test_desired_out_of_range(self, valid_context):
-        """Test desired_size outside range raises error."""
-        valid_context["node_groups"]["desired_size"] = 20
-        app = MockApp(valid_context)
-        with pytest.raises(ConfigValidationError, match="desired_size must be between"):
-            ConfigLoader(app)
-
-
 class TestGlobalAcceleratorValidation:
     """Tests for Global Accelerator config validation."""
 
@@ -298,7 +258,6 @@ class TestConfigLoaderGetters:
         assert cluster_config.region == "us-east-1"
         assert cluster_config.cluster_name == "gco-us-east-1"
         assert cluster_config.kubernetes_version == "1.35"
-        assert len(cluster_config.node_groups) == 1
 
     def test_get_tags(self, valid_context):
         """Test getting tags."""
@@ -615,20 +574,6 @@ class TestConfigValidationEdgeCases:
         with pytest.raises(ConfigValidationError, match="At least one region must be specified"):
             ConfigLoader(app)
 
-    def test_empty_gpu_instances_list(self, valid_context):
-        """Test that empty gpu_instances list raises error."""
-        valid_context["node_groups"]["gpu_instances"] = []
-        app = MockApp(valid_context)
-        with pytest.raises(ConfigValidationError, match="gpu_instances must be a non-empty list"):
-            ConfigLoader(app)
-
-    def test_negative_scaling_values(self, valid_context):
-        """Test that negative scaling values raise error."""
-        valid_context["node_groups"]["min_size"] = -1
-        app = MockApp(valid_context)
-        with pytest.raises(ConfigValidationError, match="Scaling values must be non-negative"):
-            ConfigLoader(app)
-
     def test_missing_global_accelerator_config(self, valid_context):
         """Test that missing global_accelerator config raises error."""
         del valid_context["global_accelerator"]
@@ -796,15 +741,6 @@ class TestConfigValidationEdgeCases:
         app = MockApp(valid_context)
         with pytest.raises(
             ConfigValidationError, match="pending_requested_gpus must be a non-negative integer"
-        ):
-            ConfigLoader(app)
-
-    def test_missing_node_groups_field(self, valid_context):
-        """Test that missing node_groups field raises error."""
-        del valid_context["node_groups"]["desired_size"]
-        app = MockApp(valid_context)
-        with pytest.raises(
-            ConfigValidationError, match="Missing node group configuration: desired_size"
         ):
             ConfigLoader(app)
 

--- a/tests/test_config_loader_validation.py
+++ b/tests/test_config_loader_validation.py
@@ -51,12 +51,6 @@ class TestConfigLoaderValidation:
                     "memory_threshold": 85,
                     "gpu_threshold": 90,
                 },
-                "node_groups": {
-                    "gpu_instances": ["g4dn.xlarge"],
-                    "min_size": 0,
-                    "max_size": 10,
-                    "desired_size": 1,
-                },
                 "global_accelerator": {
                     "name": "test",
                     "health_check_grace_period": 30,
@@ -120,12 +114,6 @@ class TestConfigLoaderValidation:
                     "memory_threshold": 85,
                     "gpu_threshold": 90,
                 },
-                "node_groups": {
-                    "gpu_instances": ["g4dn.xlarge"],
-                    "min_size": 0,
-                    "max_size": 10,
-                    "desired_size": 1,
-                },
                 "global_accelerator": {
                     "name": "test",
                     "health_check_grace_period": 30,
@@ -174,12 +162,6 @@ class TestConfigLoaderValidation:
                     "cpu_threshold": 80,
                     "memory_threshold": 85,
                     "gpu_threshold": 90,
-                },
-                "node_groups": {
-                    "gpu_instances": ["g4dn.xlarge"],
-                    "min_size": 0,
-                    "max_size": 10,
-                    "desired_size": 1,
                 },
                 "global_accelerator": {
                     "name": "test",
@@ -230,12 +212,6 @@ class TestConfigLoaderValidation:
                     "memory_threshold": 85,
                     "gpu_threshold": 90,
                 },
-                "node_groups": {
-                    "gpu_instances": ["g4dn.xlarge"],
-                    "min_size": 0,
-                    "max_size": 10,
-                    "desired_size": 1,
-                },
                 "global_accelerator": {
                     "name": "test",
                     "health_check_grace_period": 30,
@@ -285,12 +261,6 @@ class TestConfigLoaderValidation:
                     "memory_threshold": 85,
                     "gpu_threshold": 90,
                 },  # Invalid: > 100
-                "node_groups": {
-                    "gpu_instances": ["g4dn.xlarge"],
-                    "min_size": 0,
-                    "max_size": 10,
-                    "desired_size": 1,
-                },
                 "global_accelerator": {
                     "name": "test",
                     "health_check_grace_period": 30,
@@ -339,12 +309,6 @@ class TestConfigLoaderValidation:
                     "cpu_threshold": 80,
                     "memory_threshold": 85,
                 },  # Missing gpu_threshold
-                "node_groups": {
-                    "gpu_instances": ["g4dn.xlarge"],
-                    "min_size": 0,
-                    "max_size": 10,
-                    "desired_size": 1,
-                },
                 "global_accelerator": {
                     "name": "test",
                     "health_check_grace_period": 30,
@@ -380,228 +344,6 @@ class TestConfigLoaderValidation:
         with pytest.raises(ConfigValidationError, match="Missing threshold configuration"):
             ConfigLoader(app)
 
-    def test_config_loader_validates_invalid_gpu_instance(self):
-        """Test that ConfigLoader validates invalid GPU instance types."""
-        from gco.config.config_loader import ConfigLoader, ConfigValidationError
-
-        app = cdk.App(
-            context={
-                "project_name": "test",
-                "deployment_regions": {"regional": ["us-east-1"]},
-                "kubernetes_version": "1.35",
-                "resource_thresholds": {
-                    "cpu_threshold": 80,
-                    "memory_threshold": 85,
-                    "gpu_threshold": 90,
-                },
-                "node_groups": {
-                    "gpu_instances": ["t3.micro"],
-                    "min_size": 0,
-                    "max_size": 10,
-                    "desired_size": 1,
-                },  # Invalid GPU type
-                "global_accelerator": {
-                    "name": "test",
-                    "health_check_grace_period": 30,
-                    "health_check_interval": 30,
-                    "health_check_timeout": 5,
-                    "health_check_path": "/health",
-                },
-                "alb_config": {
-                    "health_check_interval": 30,
-                    "health_check_timeout": 5,
-                    "healthy_threshold": 2,
-                    "unhealthy_threshold": 2,
-                },
-                "manifest_processor": {
-                    "image": "test",
-                    "replicas": 1,
-                    "resource_limits": {"cpu": "1", "memory": "1Gi"},
-                },
-                "job_validation_policy": {
-                    "allowed_namespaces": ["default"],
-                    "resource_quotas": {},
-                },
-                "api_gateway": {
-                    "throttle_rate_limit": 100,
-                    "throttle_burst_limit": 200,
-                    "log_level": "INFO",
-                    "metrics_enabled": True,
-                    "tracing_enabled": True,
-                },
-            }
-        )
-
-        with pytest.raises(ConfigValidationError, match="Invalid GPU instance type"):
-            ConfigLoader(app)
-
-    def test_config_loader_validates_empty_gpu_instances(self):
-        """Test that ConfigLoader validates empty GPU instances list."""
-        from gco.config.config_loader import ConfigLoader, ConfigValidationError
-
-        app = cdk.App(
-            context={
-                "project_name": "test",
-                "deployment_regions": {"regional": ["us-east-1"]},
-                "kubernetes_version": "1.35",
-                "resource_thresholds": {
-                    "cpu_threshold": 80,
-                    "memory_threshold": 85,
-                    "gpu_threshold": 90,
-                },
-                "node_groups": {
-                    "gpu_instances": [],
-                    "min_size": 0,
-                    "max_size": 10,
-                    "desired_size": 1,
-                },
-                "global_accelerator": {
-                    "name": "test",
-                    "health_check_grace_period": 30,
-                    "health_check_interval": 30,
-                    "health_check_timeout": 5,
-                    "health_check_path": "/health",
-                },
-                "alb_config": {
-                    "health_check_interval": 30,
-                    "health_check_timeout": 5,
-                    "healthy_threshold": 2,
-                    "unhealthy_threshold": 2,
-                },
-                "manifest_processor": {
-                    "image": "test",
-                    "replicas": 1,
-                    "resource_limits": {"cpu": "1", "memory": "1Gi"},
-                },
-                "job_validation_policy": {
-                    "allowed_namespaces": ["default"],
-                    "resource_quotas": {},
-                },
-                "api_gateway": {
-                    "throttle_rate_limit": 100,
-                    "throttle_burst_limit": 200,
-                    "log_level": "INFO",
-                    "metrics_enabled": True,
-                    "tracing_enabled": True,
-                },
-            }
-        )
-
-        with pytest.raises(ConfigValidationError, match="gpu_instances must be a non-empty list"):
-            ConfigLoader(app)
-
-    def test_config_loader_validates_min_greater_than_max(self):
-        """Test that ConfigLoader validates min_size > max_size."""
-        from gco.config.config_loader import ConfigLoader, ConfigValidationError
-
-        app = cdk.App(
-            context={
-                "project_name": "test",
-                "deployment_regions": {"regional": ["us-east-1"]},
-                "kubernetes_version": "1.35",
-                "resource_thresholds": {
-                    "cpu_threshold": 80,
-                    "memory_threshold": 85,
-                    "gpu_threshold": 90,
-                },
-                "node_groups": {
-                    "gpu_instances": ["g4dn.xlarge"],
-                    "min_size": 10,
-                    "max_size": 5,
-                    "desired_size": 7,
-                },
-                "global_accelerator": {
-                    "name": "test",
-                    "health_check_grace_period": 30,
-                    "health_check_interval": 30,
-                    "health_check_timeout": 5,
-                    "health_check_path": "/health",
-                },
-                "alb_config": {
-                    "health_check_interval": 30,
-                    "health_check_timeout": 5,
-                    "healthy_threshold": 2,
-                    "unhealthy_threshold": 2,
-                },
-                "manifest_processor": {
-                    "image": "test",
-                    "replicas": 1,
-                    "resource_limits": {"cpu": "1", "memory": "1Gi"},
-                },
-                "job_validation_policy": {
-                    "allowed_namespaces": ["default"],
-                    "resource_quotas": {},
-                },
-                "api_gateway": {
-                    "throttle_rate_limit": 100,
-                    "throttle_burst_limit": 200,
-                    "log_level": "INFO",
-                    "metrics_enabled": True,
-                    "tracing_enabled": True,
-                },
-            }
-        )
-
-        with pytest.raises(ConfigValidationError, match="min_size cannot be greater than max_size"):
-            ConfigLoader(app)
-
-    def test_config_loader_validates_desired_out_of_range(self):
-        """Test that ConfigLoader validates desired_size out of range."""
-        from gco.config.config_loader import ConfigLoader, ConfigValidationError
-
-        app = cdk.App(
-            context={
-                "project_name": "test",
-                "deployment_regions": {"regional": ["us-east-1"]},
-                "kubernetes_version": "1.35",
-                "resource_thresholds": {
-                    "cpu_threshold": 80,
-                    "memory_threshold": 85,
-                    "gpu_threshold": 90,
-                },
-                "node_groups": {
-                    "gpu_instances": ["g4dn.xlarge"],
-                    "min_size": 2,
-                    "max_size": 5,
-                    "desired_size": 10,
-                },  # desired > max
-                "global_accelerator": {
-                    "name": "test",
-                    "health_check_grace_period": 30,
-                    "health_check_interval": 30,
-                    "health_check_timeout": 5,
-                    "health_check_path": "/health",
-                },
-                "alb_config": {
-                    "health_check_interval": 30,
-                    "health_check_timeout": 5,
-                    "healthy_threshold": 2,
-                    "unhealthy_threshold": 2,
-                },
-                "manifest_processor": {
-                    "image": "test",
-                    "replicas": 1,
-                    "resource_limits": {"cpu": "1", "memory": "1Gi"},
-                },
-                "job_validation_policy": {
-                    "allowed_namespaces": ["default"],
-                    "resource_quotas": {},
-                },
-                "api_gateway": {
-                    "throttle_rate_limit": 100,
-                    "throttle_burst_limit": 200,
-                    "log_level": "INFO",
-                    "metrics_enabled": True,
-                    "tracing_enabled": True,
-                },
-            }
-        )
-
-        with pytest.raises(
-            ConfigValidationError, match="desired_size must be between min_size and max_size"
-        ):
-            ConfigLoader(app)
-
     def test_config_loader_validates_invalid_health_check_path(self):
         """Test that ConfigLoader validates health check path."""
         from gco.config.config_loader import ConfigLoader, ConfigValidationError
@@ -615,12 +357,6 @@ class TestConfigLoaderValidation:
                     "cpu_threshold": 80,
                     "memory_threshold": 85,
                     "gpu_threshold": 90,
-                },
-                "node_groups": {
-                    "gpu_instances": ["g4dn.xlarge"],
-                    "min_size": 0,
-                    "max_size": 10,
-                    "desired_size": 1,
                 },
                 "global_accelerator": {
                     "name": "test",
@@ -670,12 +406,6 @@ class TestConfigLoaderValidation:
                     "cpu_threshold": 80,
                     "memory_threshold": 85,
                     "gpu_threshold": 90,
-                },
-                "node_groups": {
-                    "gpu_instances": ["g4dn.xlarge"],
-                    "min_size": 0,
-                    "max_size": 10,
-                    "desired_size": 1,
                 },
                 "global_accelerator": {
                     "name": "test",
@@ -728,12 +458,6 @@ class TestConfigLoaderValidation:
                     "memory_threshold": 85,
                     "gpu_threshold": 90,
                 },
-                "node_groups": {
-                    "gpu_instances": ["g4dn.xlarge"],
-                    "min_size": 0,
-                    "max_size": 10,
-                    "desired_size": 1,
-                },
                 "global_accelerator": {
                     "name": "test",
                     "health_check_grace_period": 30,
@@ -783,12 +507,6 @@ class TestConfigLoaderValidation:
                     "memory_threshold": 85,
                     "gpu_threshold": 90,
                 },
-                "node_groups": {
-                    "gpu_instances": ["g4dn.xlarge"],
-                    "min_size": 0,
-                    "max_size": 10,
-                    "desired_size": 1,
-                },
                 "global_accelerator": {
                     "name": "test",
                     "health_check_grace_period": 30,
@@ -837,12 +555,6 @@ class TestConfigLoaderValidation:
                     "cpu_threshold": 80,
                     "memory_threshold": 85,
                     "gpu_threshold": 90,
-                },
-                "node_groups": {
-                    "gpu_instances": ["g4dn.xlarge"],
-                    "min_size": 0,
-                    "max_size": 10,
-                    "desired_size": 1,
                 },
                 "global_accelerator": {
                     "name": "test",

--- a/tests/test_deployment_regions.py
+++ b/tests/test_deployment_regions.py
@@ -37,12 +37,6 @@ def base_context():
         "project_name": "gco",
         "kubernetes_version": "1.35",
         "resource_thresholds": {"cpu_threshold": 80, "memory_threshold": 85, "gpu_threshold": 90},
-        "node_groups": {
-            "gpu_instances": ["g4dn.xlarge", "g5.xlarge"],
-            "min_size": 0,
-            "max_size": 10,
-            "desired_size": 2,
-        },
         "global_accelerator": {
             "name": "gco-accelerator",
             "health_check_grace_period": 30,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,7 +3,7 @@ Unit tests for gco/models data classes.
 
 Covers validation rules across the model surface: ResourceThresholds
 (boundary values, -1 disable sentinel, out-of-range rejection),
-NodeGroupConfig (empty name rejected), ResourceUtilization, HealthStatus,
+ResourceUtilization, HealthStatus,
 KubernetesManifest, ManifestSubmissionRequest/Response, and
 ResourceStatus. Each dataclass enforces invariants in __post_init__,
 and these tests pin the error messages so callers can rely on them.
@@ -18,7 +18,6 @@ from gco.models import (
     KubernetesManifest,
     ManifestSubmissionRequest,
     ManifestSubmissionResponse,
-    NodeGroupConfig,
     ResourceStatus,
     ResourceThresholds,
     ResourceUtilization,
@@ -67,77 +66,6 @@ class TestResourceThresholds:
         """Test that invalid GPU threshold raises error."""
         with pytest.raises(ValueError, match="gpu_threshold"):
             ResourceThresholds(cpu_threshold=80, memory_threshold=85, gpu_threshold=-10)
-
-
-class TestNodeGroupConfig:
-    """Tests for NodeGroupConfig model."""
-
-    def test_valid_config(self):
-        """Test creating valid node group config."""
-        config = NodeGroupConfig(
-            name="gpu-nodes",
-            instance_types=["g4dn.xlarge", "g5.xlarge"],
-            scaling_config={"min_size": 0, "max_size": 10, "desired_size": 2},
-            labels={"workload-type": "gpu"},
-            taints=[{"key": "nvidia.com/gpu", "value": "true", "effect": "NoSchedule"}],
-        )
-        assert config.name == "gpu-nodes"
-        assert len(config.instance_types) == 2
-
-    def test_empty_name_raises_error(self):
-        """Test that empty name raises error."""
-        with pytest.raises(ValueError, match="name cannot be empty"):
-            NodeGroupConfig(
-                name="",
-                instance_types=["g4dn.xlarge"],
-                scaling_config={"min_size": 0, "max_size": 10, "desired_size": 2},
-                labels={},
-                taints=[],
-            )
-
-    def test_empty_instance_types_raises_error(self):
-        """Test that empty instance types raises error."""
-        with pytest.raises(ValueError, match="At least one instance type"):
-            NodeGroupConfig(
-                name="gpu-nodes",
-                instance_types=[],
-                scaling_config={"min_size": 0, "max_size": 10, "desired_size": 2},
-                labels={},
-                taints=[],
-            )
-
-    def test_missing_scaling_keys_raises_error(self):
-        """Test that missing scaling config keys raises error."""
-        with pytest.raises(ValueError, match="Scaling config must contain"):
-            NodeGroupConfig(
-                name="gpu-nodes",
-                instance_types=["g4dn.xlarge"],
-                scaling_config={"min_size": 0, "max_size": 10},  # Missing desired_size
-                labels={},
-                taints=[],
-            )
-
-    def test_min_greater_than_max_raises_error(self):
-        """Test that min_size > max_size raises error."""
-        with pytest.raises(ValueError, match="min_size cannot be greater than max_size"):
-            NodeGroupConfig(
-                name="gpu-nodes",
-                instance_types=["g4dn.xlarge"],
-                scaling_config={"min_size": 10, "max_size": 5, "desired_size": 7},
-                labels={},
-                taints=[],
-            )
-
-    def test_desired_out_of_range_raises_error(self):
-        """Test that desired_size outside range raises error."""
-        with pytest.raises(ValueError, match="desired_size must be between"):
-            NodeGroupConfig(
-                name="gpu-nodes",
-                instance_types=["g4dn.xlarge"],
-                scaling_config={"min_size": 2, "max_size": 10, "desired_size": 1},
-                labels={},
-                taints=[],
-            )
 
 
 class TestResourceUtilization:

--- a/tests/test_models_extended.py
+++ b/tests/test_models_extended.py
@@ -5,7 +5,7 @@ Deeper coverage of validation paths not covered by test_models.py:
 RequestedResources (rejects negative cpu_vcpus/memory_gb/gpus and
 non-numeric types, accepts zero), ResourceUtilization negative-gpu
 and over-100 rejection plus integer acceptance, and additional
-NodeGroupConfig, KubernetesManifest, and ResourceStatus edge cases.
+KubernetesManifest and ResourceStatus edge cases.
 Pins the exact error strings so downstream callers can assert on them.
 """
 
@@ -18,7 +18,6 @@ from gco.models import (
     KubernetesManifest,
     ManifestSubmissionRequest,
     ManifestSubmissionResponse,
-    NodeGroupConfig,
     RequestedResources,
     ResourceStatus,
     ResourceThresholds,
@@ -249,68 +248,6 @@ class TestResourceThresholdsExtended:
         """Test all max thresholds."""
         thresholds = ResourceThresholds(cpu_threshold=100, memory_threshold=100, gpu_threshold=100)
         assert thresholds.cpu_threshold == 100
-
-
-class TestNodeGroupConfigExtended:
-    """Extended tests for NodeGroupConfig."""
-
-    def test_desired_greater_than_max_raises_error(self):
-        """Test that desired_size > max_size raises error."""
-        with pytest.raises(ValueError, match="desired_size must be between"):
-            NodeGroupConfig(
-                name="gpu-nodes",
-                instance_types=["g4dn.xlarge"],
-                scaling_config={"min_size": 0, "max_size": 5, "desired_size": 10},
-                labels={},
-                taints=[],
-            )
-
-    def test_negative_min_size_raises_error(self):
-        """Test that negative min_size raises error."""
-        with pytest.raises(ValueError, match="Scaling values must be non-negative"):
-            NodeGroupConfig(
-                name="gpu-nodes",
-                instance_types=["g4dn.xlarge"],
-                scaling_config={"min_size": -1, "max_size": 10, "desired_size": 2},
-                labels={},
-                taints=[],
-            )
-
-    def test_multiple_instance_types(self):
-        """Test config with multiple instance types."""
-        config = NodeGroupConfig(
-            name="gpu-nodes",
-            instance_types=["g4dn.xlarge", "g4dn.2xlarge", "g5.xlarge"],
-            scaling_config={"min_size": 1, "max_size": 20, "desired_size": 5},
-            labels={"gpu": "true"},
-            taints=[],
-        )
-        assert len(config.instance_types) == 3
-
-    def test_zero_min_size(self):
-        """Test config with zero min_size."""
-        config = NodeGroupConfig(
-            name="gpu-nodes",
-            instance_types=["g4dn.xlarge"],
-            scaling_config={"min_size": 0, "max_size": 10, "desired_size": 0},
-            labels={},
-            taints=[],
-        )
-        assert config.scaling_config["min_size"] == 0
-
-    def test_with_labels_and_taints(self):
-        """Test node group config with labels and taints."""
-        config = NodeGroupConfig(
-            name="gpu-nodes",
-            instance_types=["g4dn.xlarge"],
-            scaling_config={"min_size": 0, "max_size": 10, "desired_size": 2},
-            labels={"workload-type": "gpu", "team": "ml"},
-            taints=[
-                {"key": "nvidia.com/gpu", "value": "true", "effect": "NoSchedule"},
-            ],
-        )
-        assert config.labels["workload-type"] == "gpu"
-        assert len(config.taints) == 1
 
 
 class TestKubernetesManifestExtended:
@@ -608,22 +545,11 @@ class TestClusterConfigValidation:
     """Tests for ClusterConfig validation."""
 
     @pytest.fixture
-    def valid_node_group(self):
-        """Create a valid node group for testing."""
-        return NodeGroupConfig(
-            name="gpu-nodes",
-            instance_types=["g4dn.xlarge"],
-            scaling_config={"min_size": 0, "max_size": 10, "desired_size": 2},
-            labels={"workload-type": "gpu"},
-            taints=[],
-        )
-
-    @pytest.fixture
     def valid_thresholds(self):
         """Create valid thresholds for testing."""
         return ResourceThresholds(cpu_threshold=80, memory_threshold=85, gpu_threshold=90)
 
-    def test_valid_cluster_config(self, valid_node_group, valid_thresholds):
+    def test_valid_cluster_config(self, valid_thresholds):
         """Test creating valid cluster config."""
         from gco.models import ClusterConfig
 
@@ -631,14 +557,13 @@ class TestClusterConfigValidation:
             region="us-east-1",
             cluster_name="test-cluster",
             kubernetes_version="1.35",
-            node_groups=[valid_node_group],
             addons=["metrics-server"],
             resource_thresholds=valid_thresholds,
         )
         assert config.region == "us-east-1"
         assert config.cluster_name == "test-cluster"
 
-    def test_empty_region_raises_error(self, valid_node_group, valid_thresholds):
+    def test_empty_region_raises_error(self, valid_thresholds):
         """Test that empty region raises error."""
         from gco.models import ClusterConfig
 
@@ -647,12 +572,11 @@ class TestClusterConfigValidation:
                 region="",
                 cluster_name="test-cluster",
                 kubernetes_version="1.35",
-                node_groups=[valid_node_group],
                 addons=["metrics-server"],
                 resource_thresholds=valid_thresholds,
             )
 
-    def test_empty_cluster_name_raises_error(self, valid_node_group, valid_thresholds):
+    def test_empty_cluster_name_raises_error(self, valid_thresholds):
         """Test that empty cluster_name raises error."""
         from gco.models import ClusterConfig
 
@@ -661,12 +585,11 @@ class TestClusterConfigValidation:
                 region="us-east-1",
                 cluster_name="",
                 kubernetes_version="1.35",
-                node_groups=[valid_node_group],
                 addons=["metrics-server"],
                 resource_thresholds=valid_thresholds,
             )
 
-    def test_empty_kubernetes_version_raises_error(self, valid_node_group, valid_thresholds):
+    def test_empty_kubernetes_version_raises_error(self, valid_thresholds):
         """Test that empty kubernetes_version raises error."""
         from gco.models import ClusterConfig
 
@@ -675,82 +598,9 @@ class TestClusterConfigValidation:
                 region="us-east-1",
                 cluster_name="test-cluster",
                 kubernetes_version="",
-                node_groups=[valid_node_group],
                 addons=["metrics-server"],
                 resource_thresholds=valid_thresholds,
             )
-
-    def test_empty_node_groups_raises_error(self, valid_thresholds):
-        """Test that empty node_groups raises error."""
-        from gco.models import ClusterConfig
-
-        with pytest.raises(ValueError, match="At least one node group must be specified"):
-            ClusterConfig(
-                region="us-east-1",
-                cluster_name="test-cluster",
-                kubernetes_version="1.35",
-                node_groups=[],
-                addons=["metrics-server"],
-                resource_thresholds=valid_thresholds,
-            )
-
-    def test_duplicate_node_group_names_raises_error(self, valid_thresholds):
-        """Test that duplicate node group names raises error."""
-        from gco.models import ClusterConfig
-
-        node_group1 = NodeGroupConfig(
-            name="gpu-nodes",
-            instance_types=["g4dn.xlarge"],
-            scaling_config={"min_size": 0, "max_size": 10, "desired_size": 2},
-            labels={},
-            taints=[],
-        )
-        node_group2 = NodeGroupConfig(
-            name="gpu-nodes",  # Same name as node_group1
-            instance_types=["g5.xlarge"],
-            scaling_config={"min_size": 0, "max_size": 5, "desired_size": 1},
-            labels={},
-            taints=[],
-        )
-
-        with pytest.raises(ValueError, match="Node group names must be unique"):
-            ClusterConfig(
-                region="us-east-1",
-                cluster_name="test-cluster",
-                kubernetes_version="1.35",
-                node_groups=[node_group1, node_group2],
-                addons=["metrics-server"],
-                resource_thresholds=valid_thresholds,
-            )
-
-    def test_multiple_unique_node_groups(self, valid_thresholds):
-        """Test cluster config with multiple unique node groups."""
-        from gco.models import ClusterConfig
-
-        node_group1 = NodeGroupConfig(
-            name="gpu-nodes",
-            instance_types=["g4dn.xlarge"],
-            scaling_config={"min_size": 0, "max_size": 10, "desired_size": 2},
-            labels={},
-            taints=[],
-        )
-        node_group2 = NodeGroupConfig(
-            name="cpu-nodes",
-            instance_types=["m5.xlarge"],
-            scaling_config={"min_size": 0, "max_size": 5, "desired_size": 1},
-            labels={},
-            taints=[],
-        )
-
-        config = ClusterConfig(
-            region="us-east-1",
-            cluster_name="test-cluster",
-            kubernetes_version="1.35",
-            node_groups=[node_group1, node_group2],
-            addons=["metrics-server"],
-            resource_thresholds=valid_thresholds,
-        )
-        assert len(config.node_groups) == 2
 
 
 class TestResourceThresholdsNonIntegerValidation:

--- a/tests/test_regional_stack.py
+++ b/tests/test_regional_stack.py
@@ -4,7 +4,7 @@ Tests for gco/stacks/regional_stack.GCORegionalStack.
 Synthesizes the regional stack — VPC, EKS cluster, EFS, optionally FSx,
 kubectl-applier Lambda, helm-installer Lambda, the MCP role, drift
 detection, and the NetworkPolicy/RBAC apply pipeline — against a
-MockConfigLoader that supplies ClusterConfig, NodeGroupConfig, ALB
+MockConfigLoader that supplies ClusterConfig, ALB
 config, manifest processor config, and the API Gateway config. Patches
 the DockerImageAsset and helm-installer builder so tests don't need a
 Docker daemon. The MockConfigLoader here is reused by sibling test
@@ -50,17 +50,6 @@ class MockConfigLoader:
 
         return ResourceThresholds(cpu_threshold=80, memory_threshold=85, gpu_threshold=90)
 
-    def get_node_group_config(self):
-        from gco.models import NodeGroupConfig
-
-        return NodeGroupConfig(
-            name="gpu-nodes",
-            instance_types=["g4dn.xlarge"],
-            scaling_config={"min_size": 0, "max_size": 10, "desired_size": 1},
-            labels={"workload-type": "gpu"},
-            taints=[],
-        )
-
     def get_cluster_config(self, region):
         from gco.models import ClusterConfig
 
@@ -68,7 +57,6 @@ class MockConfigLoader:
             region=region,
             cluster_name=f"gco-test-{region}",
             kubernetes_version="1.35",
-            node_groups=[self.get_node_group_config()],
             addons=["metrics-server"],
             resource_thresholds=self.get_resource_thresholds(),
         )
@@ -417,16 +405,6 @@ class TestConfigLoaderValidation:
         assert "eu-west-1" in ConfigLoader.VALID_REGIONS
         assert "invalid-region" not in ConfigLoader.VALID_REGIONS
 
-    def test_config_loader_valid_gpu_instances(self):
-        """Test ConfigLoader VALID_GPU_INSTANCES constant."""
-        from gco.config.config_loader import ConfigLoader
-
-        assert "g4dn.xlarge" in ConfigLoader.VALID_GPU_INSTANCES
-        assert "g5.xlarge" in ConfigLoader.VALID_GPU_INSTANCES
-        assert "p3.2xlarge" in ConfigLoader.VALID_GPU_INSTANCES
-        assert "p4d.24xlarge" in ConfigLoader.VALID_GPU_INSTANCES
-        assert "t3.micro" not in ConfigLoader.VALID_GPU_INSTANCES
-
     def test_config_validation_error_class(self):
         """Test ConfigValidationError exception class."""
         from gco.config.config_loader import ConfigValidationError
@@ -521,22 +499,14 @@ class TestClusterConfigModel:
 
     def test_cluster_config_creation(self):
         """Test creating ClusterConfig."""
-        from gco.models import ClusterConfig, NodeGroupConfig, ResourceThresholds
+        from gco.models import ClusterConfig, ResourceThresholds
 
         thresholds = ResourceThresholds(cpu_threshold=80, memory_threshold=85, gpu_threshold=90)
-        node_group = NodeGroupConfig(
-            name="gpu-nodes",
-            instance_types=["g4dn.xlarge"],
-            scaling_config={"min_size": 0, "max_size": 10, "desired_size": 1},
-            labels={},
-            taints=[],
-        )
 
         config = ClusterConfig(
             region="us-east-1",
             cluster_name="test-cluster",
             kubernetes_version="1.35",
-            node_groups=[node_group],
             addons=["metrics-server"],
             resource_thresholds=thresholds,
         )
@@ -544,28 +514,6 @@ class TestClusterConfigModel:
         assert config.region == "us-east-1"
         assert config.cluster_name == "test-cluster"
         assert config.kubernetes_version == "1.35"
-        assert len(config.node_groups) == 1
-
-
-class TestNodeGroupConfigModel:
-    """Tests for NodeGroupConfig model."""
-
-    def test_node_group_config_creation(self):
-        """Test creating NodeGroupConfig."""
-        from gco.models import NodeGroupConfig
-
-        config = NodeGroupConfig(
-            name="gpu-nodes",
-            instance_types=["g4dn.xlarge", "g5.xlarge"],
-            scaling_config={"min_size": 0, "max_size": 10, "desired_size": 1},
-            labels={"workload-type": "gpu"},
-            taints=[{"key": "nvidia.com/gpu", "value": "true", "effect": "NoSchedule"}],
-        )
-
-        assert config.name == "gpu-nodes"
-        assert "g4dn.xlarge" in config.instance_types
-        assert config.scaling_config["min_size"] == 0
-        assert config.labels["workload-type"] == "gpu"
 
 
 class TestResourceThresholdsModel:


### PR DESCRIPTION
Three changes:

1. Remove the dead node_groups configuration surface.

   The node_groups block in cdk.json (gpu_instances, min_size, max_size, desired_size) was parsed and validated by ConfigLoader but never consumed by any CDK stack — EKS Auto Mode handles all node group management dynamically based on pod resource specs.

   Removed:
   - NodeGroupConfig dataclass from gco/models/cluster_models.py
   - VALID_GPU_INSTANCES constant from config_loader.py
   - _validate_node_groups() method and its call
   - get_node_group_config() method
   - "node_groups" from required_fields validation
   - "large-node-groups" config from the synthesis matrix
   - All associated tests (~122 tests across 9 test files)
   - node_groups from all test fixtures and MockConfigLoaders

   ClusterConfig.node_groups field kept as list (always []) for
   backward compatibility with any code that reads it. cdk.json
   NOT modified — users can remove the block at their convenience.

2. Document the blanket IAM5 suppression entries.

   "Resource::*" and "Action::eks:*" in nag_suppressions.py are intentionally broad at the stack-suppression level. They match the cdk-nag finding string "Resource::*" which is identical for every construct that uses Resource: "*" in its IAM policy — there's no way to distinguish between (say) the kubectl Lambda's Resource: * and the VPC Flow Logs role's Resource: * at this layer. Both produce the same finding string.

   Added detailed comments listing every construct each blanket entry covers and noting that tightening requires moving to construct-level NagSuppressions.add_resource_suppressions calls (a larger refactor for a future PR). The test_nag_compliance.py gate prevents new unsuppressed wildcards from shipping regardless.

3. Update Node.js version references in docs.

   README.md and CONTRIBUTING.md now reference Node.js 24 (matching the GitHub Actions workflows) instead of the stale Node.js 20.

Verification:
  * 3597 serial tests passed in 363s.
  * 5 nag compliance tests passed (separate job).
  * Total: 3602 tests.
  * black, ruff, flake8 all clean on every modified file.
  * cdk synth --all passes (node_groups removal has zero CDK impact).

<!--
Thanks for contributing to GCO! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [ ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
