### PR TITLE
Scope blanket IAM5 suppressions to individual constructs

### DIFF
--- a/gco/stacks/api_gateway_global_stack.py
+++ b/gco/stacks/api_gateway_global_stack.py
@@ -202,6 +202,28 @@ class GCOApiGatewayGlobalStack(Stack):
         # Grant Secrets Manager permission to invoke the rotation Lambda
         rotation_lambda.grant_invoke(iam.ServicePrincipal("secretsmanager.amazonaws.com"))
 
+        # cdk-nag suppression: CDK's grant methods generate Resource: * for
+        # the rotation function's execution role.
+        from cdk_nag import NagSuppressions
+
+        NagSuppressions.add_resource_suppressions(
+            rotation_role,
+            [
+                {
+                    "id": "AwsSolutions-IAM5",
+                    "reason": (
+                        "The secret rotation Lambda needs secretsmanager:GetSecretValue "
+                        "and PutSecretValue on the rotation secret. CDK's grant methods "
+                        "generate Resource: * for the rotation function's execution role "
+                        "because the secret ARN includes a random suffix not known at "
+                        "synth time."
+                    ),
+                    "appliesTo": ["Resource::*"],
+                },
+            ],
+            apply_to_children=True,
+        )
+
         return rotation_lambda
 
     def _create_proxy_lambda(self) -> lambda_.Function:
@@ -246,6 +268,27 @@ class GCOApiGatewayGlobalStack(Stack):
             },
             log_group=proxy_lambda_log_group,
             tracing=lambda_.Tracing.ACTIVE,
+        )
+
+        # cdk-nag suppression: the proxy Lambda's execution role needs
+        # broad network access for VPC Lambda execution.
+        from cdk_nag import NagSuppressions
+
+        NagSuppressions.add_resource_suppressions(
+            lambda_role,
+            [
+                {
+                    "id": "AwsSolutions-IAM5",
+                    "reason": (
+                        "The API Gateway proxy Lambda forwards requests to regional ALBs. "
+                        "Its execution role needs broad network access "
+                        "(ec2:CreateNetworkInterface, etc.) for VPC Lambda execution. "
+                        "These APIs do not support resource-level scoping."
+                    ),
+                    "appliesTo": ["Resource::*"],
+                },
+            ],
+            apply_to_children=True,
         )
 
         return proxy_lambda
@@ -306,6 +349,27 @@ class GCOApiGatewayGlobalStack(Stack):
             log_group=aggregator_log_group,
             description="Aggregates data from all regional GCO clusters",
             tracing=lambda_.Tracing.ACTIVE,
+        )
+
+        # cdk-nag suppression: the aggregator Lambda reads SSM parameters
+        # and invokes regional endpoints.
+        from cdk_nag import NagSuppressions
+
+        NagSuppressions.add_resource_suppressions(
+            aggregator_role,
+            [
+                {
+                    "id": "AwsSolutions-IAM5",
+                    "reason": (
+                        "The cross-region aggregator Lambda reads SSM parameters and "
+                        "invokes regional endpoints. Its execution role needs "
+                        "ssm:GetParameter on the project's parameter namespace and "
+                        "secretsmanager:GetSecretValue for the auth token."
+                    ),
+                    "appliesTo": ["Resource::*"],
+                },
+            ],
+            apply_to_children=True,
         )
 
         return aggregator_lambda

--- a/gco/stacks/nag_suppressions.py
+++ b/gco/stacks/nag_suppressions.py
@@ -182,36 +182,7 @@ def add_iam_suppressions(
         global_region: Global region for SSM parameters and DynamoDB tables
     """
     # Build dynamic applies_to list based on configured regions
-    #
-    # NOTE ON BLANKET ENTRIES:
-    # "Resource::*" and "Action::eks:*" are intentionally broad at the
-    # stack-suppression level. They match the cdk-nag finding string
-    # "Resource::*" (or "Action::eks:*"), which is identical for every
-    # construct that uses ``Resource: "*"`` in its IAM policy. There's
-    # no way to distinguish between (say) the kubectl Lambda's
-    # ``Resource: *`` and the VPC Flow Logs role's ``Resource: *`` at
-    # this layer — both produce the same finding string.
-    #
-    # To tighten these further, each would need to be moved to a
-    # construct-level ``NagSuppressions.add_resource_suppressions``
-    # call on the specific IAM role. That's a larger refactor tracked
-    # separately. The ``tests/test_nag_compliance.py`` gate prevents
-    # new unsuppressed wildcards from shipping regardless.
-    #
-    # Constructs currently covered by "Resource::*":
-    #   - KubectlApplierFunction Lambda execution role (EKS admin)
-    #   - HelmInstallerFunction Lambda execution role (EKS admin)
-    #   - GaRegistrationFunction Lambda execution role (GA + SSM)
-    #   - CDK Provider Framework Lambda roles (invoke target Lambda)
-    #   - VPC Flow Logs role (CloudWatch Logs)
-    #   - ServiceAccountRole ec2:Describe*/elasticloadbalancing:Describe*
-    #     (AWS APIs that don't support resource-level scoping)
-    #
-    # Constructs currently covered by "Action::eks:*":
-    #   - EKS cluster admin access entries for kubectl and helm Lambdas
     applies_to = [
-        "Resource::*",
-        "Action::eks:*",
         "Resource::<KubectlApplierFunction6147DA0C.Arn>:*",
         "Resource::<GaRegistrationFunction4A12C41B.Arn>:*",
         "Resource::<HelmInstallerFunction3FEB04EF.Arn>:*",

--- a/gco/stacks/regional_stack.py
+++ b/gco/stacks/regional_stack.py
@@ -1061,6 +1061,29 @@ class GCORegionalStack(Stack):
             apply_to_children=True,
         )
 
+        # cdk-nag suppression: the ServiceAccountRole grants ec2:Describe*
+        # and elasticloadbalancing:Describe* for the AWS Load Balancer
+        # Controller. These AWS APIs do not support resource-level IAM
+        # scoping — Resource: * is the only valid form.
+        NagSuppressions.add_resource_suppressions(
+            self.service_account_role,
+            [
+                {
+                    "id": "AwsSolutions-IAM5",
+                    "reason": (
+                        "The ServiceAccountRole grants ec2:Describe* and "
+                        "elasticloadbalancing:Describe* for the AWS Load Balancer "
+                        "Controller. These AWS APIs do not support resource-level "
+                        "IAM scoping — Resource: * is the only valid form. See "
+                        "https://docs.aws.amazon.com/service-authorization/latest/"
+                        "reference/list_amazonec2.html"
+                    ),
+                    "appliesTo": ["Resource::*"],
+                },
+            ],
+            apply_to_children=True,
+        )
+
         # Add permissions for AWS Load Balancer Controller
         self.service_account_role.add_to_policy(
             iam.PolicyStatement(
@@ -1491,6 +1514,28 @@ class GCORegionalStack(Stack):
             "KubectlProvider",
             on_event_handler=self.kubectl_lambda,
             log_group=kubectl_provider_log_group,
+        )
+
+        # cdk-nag suppression: the kubectl-applier Lambda requires broad
+        # EKS and Kubernetes API access to apply arbitrary manifests.
+        from cdk_nag import NagSuppressions
+
+        NagSuppressions.add_resource_suppressions(
+            kubectl_lambda_role,
+            [
+                {
+                    "id": "AwsSolutions-IAM5",
+                    "reason": (
+                        "The kubectl-applier Lambda requires broad EKS and Kubernetes API "
+                        "access to apply arbitrary manifests (RBAC, ServiceAccounts, "
+                        "Deployments, Jobs, NetworkPolicies) across multiple namespaces. "
+                        "Resource: * is required because the set of Kubernetes resources "
+                        "is dynamic and not known at synth time."
+                    ),
+                    "appliesTo": ["Resource::*"],
+                },
+            ],
+            apply_to_children=True,
         )
 
     def _apply_kubernetes_manifests(self) -> None:
@@ -1955,6 +2000,27 @@ class GCORegionalStack(Stack):
         self.ga_registration_provider = ga_provider
         self.endpoint_group_arn = endpoint_group_arn
 
+        # cdk-nag suppression: the GA registration Lambda needs broad
+        # Global Accelerator and ELB Describe access with Resource: *.
+        from cdk_nag import NagSuppressions
+
+        NagSuppressions.add_resource_suppressions(
+            ga_registration_lambda,
+            [
+                {
+                    "id": "AwsSolutions-IAM5",
+                    "reason": (
+                        "The GA registration Lambda needs elasticloadbalancing:Describe* "
+                        "and globalaccelerator:* to discover the Ingress-created ALB and "
+                        "register it with Global Accelerator. These APIs do not support "
+                        "resource-level IAM scoping — Resource: * is the only valid form."
+                    ),
+                    "appliesTo": ["Resource::*"],
+                },
+            ],
+            apply_to_children=True,
+        )
+
     def _get_enabled_helm_charts(self) -> list[str]:
         """Return the list of Helm charts to install based on cdk.json helm config.
 
@@ -2104,6 +2170,28 @@ class GCORegionalStack(Stack):
             "HelmInstallerProvider",
             on_event_handler=self.helm_installer_lambda,
             log_group=helm_provider_log_group,
+        )
+
+        # cdk-nag suppression: the Helm installer Lambda requires broad
+        # EKS and Kubernetes API access to install Helm charts.
+        from cdk_nag import NagSuppressions
+
+        NagSuppressions.add_resource_suppressions(
+            helm_lambda_role,
+            [
+                {
+                    "id": "AwsSolutions-IAM5",
+                    "reason": (
+                        "The Helm installer Lambda requires broad EKS and Kubernetes API "
+                        "access to install Helm charts (KEDA, NVIDIA DRA, etc.) that create "
+                        "CRDs, RBAC rules, and workloads across multiple namespaces. "
+                        "Resource: * is required because the set of Kubernetes resources "
+                        "is dynamic and not known at synth time."
+                    ),
+                    "appliesTo": ["Resource::*"],
+                },
+            ],
+            apply_to_children=True,
         )
 
     def _create_efs(self) -> None:
@@ -2453,6 +2541,27 @@ class GCORegionalStack(Stack):
                 ],
                 resources=["*"],
             )
+        )
+
+        # cdk-nag suppression: the FSx CSI driver role grants
+        # ec2:Describe* APIs that don't support resource-level scoping.
+        from cdk_nag import NagSuppressions
+
+        NagSuppressions.add_resource_suppressions(
+            self.fsx_csi_role,
+            [
+                {
+                    "id": "AwsSolutions-IAM5",
+                    "reason": (
+                        "The FSx CSI driver role grants ec2:Describe* for volume "
+                        "and network discovery. These AWS APIs do not support "
+                        "resource-level IAM scoping — Resource: * is the only "
+                        "valid form."
+                    ),
+                    "appliesTo": ["Resource::*"],
+                },
+            ],
+            apply_to_children=True,
         )
 
         # Create FSx CSI Driver add-on


### PR DESCRIPTION
Move "Resource::*" and "Action::eks:*" from the stack-level add_iam_suppressions() applies_to list to construct-level NagSuppressions.add_resource_suppressions() calls on each specific IAM role that needs them.

Before: a single "Resource::*" entry in the stack-level suppression silently covered every construct that used Resource: * in its IAM policy. If someone added a new role with Resource: *, it would be automatically suppressed without any review.

After: each role has its own scoped suppression with a reason string explaining WHY that specific role needs Resource: *. A new role with Resource: * will fail the test_nag_compliance.py gate unless the developer explicitly adds a suppression with a justification.

Construct-level suppressions added (8 total):

  regional_stack.py:
  - ServiceAccountRole — ec2:Describe*/elasticloadbalancing:Describe* for AWS Load Balancer Controller (APIs don't support resource scoping)
  - KubectlLambdaRole — broad EKS/K8s API access for manifest application
  - HelmInstallerLambdaRole — broad EKS/K8s API access for Helm charts
  - GaRegistrationFunction — GA + ELB Describe for endpoint registration
  - FsxCsiDriverRole — ec2:Describe* for volume/network discovery (only created when FSx is enabled)

  api_gateway_global_stack.py:
  - RotationLambdaRole — Secrets Manager rotation with random-suffix ARN
  - ProxyLambdaRole — VPC Lambda execution (ec2:CreateNetworkInterface)
  - AggregatorLambdaRole — SSM + Secrets Manager for cross-region queries

Also removed "Action::eks:*" — no construct in any stack actually uses the eks:* action wildcard. The EKS admin access entries use specific actions (eks:UpdateAddon, eks:DescribeAddon, etc.).

Verification:
  * 5/5 nag compliance configs pass (default, multi-region, fsx-enabled, all-features-enabled, three-regions).
  * 3597 serial tests pass.
  * black, ruff, flake8 clean on all 3 modified files.

<!--
Thanks for contributing to GCO! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [ ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
