### PR TITLE
feat: add CLI toggles for Valkey and Aurora, refactor FSx to shared h…

### DIFF
--- a/cli/commands/README.md
+++ b/cli/commands/README.md
@@ -23,7 +23,7 @@ This separation keeps the Click wiring thin and the business logic testable with
 |------|----------|-------------|
 | `jobs_cmd.py` | `gco jobs submit`, `submit-sqs`, `submit-direct`, `list`, `get`, `logs`, `events`, `delete`, `health`, `queue-status` | Job submission and lifecycle |
 | `inference_cmd.py` | `gco inference deploy`, `list`, `status`, `scale`, `update-image`, `stop`, `start`, `delete`, `canary`, `promote`, `rollback`, `invoke`, `chat`, `health`, `models` | Inference endpoint management |
-| `stacks_cmd.py` | `gco stacks deploy`, `deploy-all`, `destroy`, `destroy-all`, `list`, `status`, `access`, `bootstrap`, `fsx` | CDK stack deployment and management |
+| `stacks_cmd.py` | `gco stacks deploy`, `deploy-all`, `destroy`, `destroy-all`, `list`, `status`, `access`, `bootstrap`, `fsx`, `valkey`, `aurora` | CDK stack deployment and management |
 | `capacity_cmd.py` | `gco capacity check`, `status`, `recommend-region`, `spot-prices`, `ai-recommend`, `reservations`, `reservation-check`, `reserve` | GPU capacity and recommendations |
 | `queue_cmd.py` | `gco queue submit`, `list`, `get`, `stats` | Global DynamoDB job queue |
 | `costs_cmd.py` | `gco costs summary`, `regions`, `trend`, `workloads`, `forecast` | Cost tracking via Cost Explorer |

--- a/cli/commands/stacks_cmd.py
+++ b/cli/commands/stacks_cmd.py
@@ -746,3 +746,245 @@ def fsx_disable(config: Any, region: Any, yes: Any) -> None:
     except Exception as e:
         formatter.print_error(f"Failed to disable FSx: {e}")
         sys.exit(1)
+
+
+# =============================================================================
+# Valkey commands
+# =============================================================================
+
+
+@stacks.group("valkey")
+@pass_config
+def valkey_cmd(config: Any) -> None:
+    """Manage Valkey Serverless cache configuration."""
+    pass
+
+
+@valkey_cmd.command("status")
+@pass_config
+def valkey_status(config: Any) -> None:
+    """Show current Valkey Serverless configuration status."""
+    from ..stacks import get_valkey_config
+
+    formatter = get_output_formatter(config)
+
+    try:
+        valkey_config = get_valkey_config()
+        formatter.print_info("Valkey config:")
+        formatter.print(valkey_config)
+    except Exception as e:
+        formatter.print_error(f"Failed to get Valkey config: {e}")
+        sys.exit(1)
+
+
+@valkey_cmd.command("enable")
+@click.option("--max-storage", default=5, help="Max data storage in GB (default: 5)")
+@click.option("--max-ecpu", default=5000, help="Max eCPU per second (default: 5000)")
+@click.option("--snapshot-retention", default=1, help="Snapshot retention in days (default: 1)")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation")
+@pass_config
+def valkey_enable(
+    config: Any,
+    max_storage: Any,
+    max_ecpu: Any,
+    snapshot_retention: Any,
+    yes: Any,
+) -> None:
+    """Enable Valkey Serverless cache in the stack configuration.
+
+    Valkey provides a serverless key-value cache for prompt caching,
+    feature stores, session state, and low-latency data access.
+
+    Examples:
+        gco stacks valkey enable
+        gco stacks valkey enable --max-storage 10 --max-ecpu 10000
+    """
+    from ..stacks import update_valkey_config
+
+    formatter = get_output_formatter(config)
+
+    if not yes:
+        formatter.print_info("Valkey Serverless configuration:")
+        formatter.print_info(f"  Max Data Storage: {max_storage} GB")
+        formatter.print_info(f"  Max eCPU/second: {max_ecpu}")
+        formatter.print_info(f"  Snapshot Retention: {snapshot_retention} days")
+        click.confirm("\nEnable Valkey Serverless?", abort=True)
+
+    try:
+        valkey_settings = {
+            "enabled": True,
+            "max_data_storage_gb": max_storage,
+            "max_ecpu_per_second": max_ecpu,
+            "snapshot_retention_limit": snapshot_retention,
+        }
+
+        update_valkey_config(valkey_settings)
+        formatter.print_success("Valkey Serverless enabled in cdk.json")
+        formatter.print_info("Run 'gco stacks deploy-all -y' to apply changes")
+
+    except Exception as e:
+        formatter.print_error(f"Failed to enable Valkey: {e}")
+        sys.exit(1)
+
+
+@valkey_cmd.command("disable")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation")
+@pass_config
+def valkey_disable(config: Any, yes: Any) -> None:
+    """Disable Valkey Serverless cache in the stack configuration.
+
+    Note: This only updates the configuration. Run 'gco stacks deploy-all -y'
+    to apply changes. Existing Valkey caches will be deleted.
+
+    Examples:
+        gco stacks valkey disable
+    """
+    from ..stacks import update_valkey_config
+
+    formatter = get_output_formatter(config)
+
+    if not yes:
+        formatter.print_warning("This will disable Valkey Serverless.")
+        formatter.print_warning("Existing Valkey caches will be deleted on next deploy.")
+        click.confirm("Are you sure?", abort=True)
+
+    try:
+        update_valkey_config({"enabled": False})
+        formatter.print_success("Valkey Serverless disabled in cdk.json")
+        formatter.print_info("Run 'gco stacks deploy-all -y' to apply changes")
+
+    except Exception as e:
+        formatter.print_error(f"Failed to disable Valkey: {e}")
+        sys.exit(1)
+
+
+# =============================================================================
+# Aurora pgvector commands
+# =============================================================================
+
+
+@stacks.group("aurora")
+@pass_config
+def aurora_cmd(config: Any) -> None:
+    """Manage Aurora PostgreSQL (pgvector) configuration."""
+    pass
+
+
+@aurora_cmd.command("status")
+@pass_config
+def aurora_status(config: Any) -> None:
+    """Show current Aurora PostgreSQL (pgvector) configuration status."""
+    from ..stacks import get_aurora_config
+
+    formatter = get_output_formatter(config)
+
+    try:
+        aurora_config = get_aurora_config()
+        formatter.print_info("Aurora pgvector config:")
+        formatter.print(aurora_config)
+    except Exception as e:
+        formatter.print_error(f"Failed to get Aurora config: {e}")
+        sys.exit(1)
+
+
+@aurora_cmd.command("enable")
+@click.option("--min-acu", default=0, help="Minimum ACU (0 = scale to zero, default: 0)")
+@click.option("--max-acu", default=16, help="Maximum ACU (default: 16)")
+@click.option("--backup-retention", default=7, help="Backup retention in days (default: 7)")
+@click.option(
+    "--deletion-protection/--no-deletion-protection",
+    default=False,
+    help="Enable deletion protection",
+)
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation")
+@pass_config
+def aurora_enable(
+    config: Any,
+    min_acu: Any,
+    max_acu: Any,
+    backup_retention: Any,
+    deletion_protection: Any,
+    yes: Any,
+) -> None:
+    """Enable Aurora PostgreSQL with pgvector in the stack configuration.
+
+    Aurora Serverless v2 with pgvector provides vector similarity search
+    for RAG applications, semantic search, and embedding storage.
+
+    Examples:
+        gco stacks aurora enable
+        gco stacks aurora enable --min-acu 2 --max-acu 32 --deletion-protection
+    """
+    from ..stacks import update_aurora_config
+
+    formatter = get_output_formatter(config)
+
+    if min_acu < 0:
+        formatter.print_error("Minimum ACU must be >= 0")
+        sys.exit(1)
+    if max_acu < 1:
+        formatter.print_error("Maximum ACU must be >= 1")
+        sys.exit(1)
+    if max_acu < min_acu:
+        formatter.print_error("Maximum ACU must be >= minimum ACU")
+        sys.exit(1)
+
+    if not yes:
+        formatter.print_info("Aurora pgvector configuration:")
+        formatter.print_info(f"  Min ACU: {min_acu} {'(scale to zero)' if min_acu == 0 else ''}")
+        formatter.print_info(f"  Max ACU: {max_acu}")
+        formatter.print_info(f"  Backup Retention: {backup_retention} days")
+        formatter.print_info(f"  Deletion Protection: {deletion_protection}")
+        click.confirm("\nEnable Aurora pgvector?", abort=True)
+
+    try:
+        aurora_settings = {
+            "enabled": True,
+            "min_acu": min_acu,
+            "max_acu": max_acu,
+            "backup_retention_days": backup_retention,
+            "deletion_protection": deletion_protection,
+        }
+
+        update_aurora_config(aurora_settings)
+        formatter.print_success("Aurora pgvector enabled in cdk.json")
+        formatter.print_info("Run 'gco stacks deploy-all -y' to apply changes")
+
+    except Exception as e:
+        formatter.print_error(f"Failed to enable Aurora: {e}")
+        sys.exit(1)
+
+
+@aurora_cmd.command("disable")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation")
+@pass_config
+def aurora_disable(config: Any, yes: Any) -> None:
+    """Disable Aurora PostgreSQL (pgvector) in the stack configuration.
+
+    Note: This only updates the configuration. Run 'gco stacks deploy-all -y'
+    to apply changes. Existing Aurora clusters will be deleted unless
+    deletion protection is enabled.
+
+    Examples:
+        gco stacks aurora disable
+    """
+    from ..stacks import update_aurora_config
+
+    formatter = get_output_formatter(config)
+
+    if not yes:
+        formatter.print_warning("This will disable Aurora pgvector.")
+        formatter.print_warning(
+            "Existing Aurora clusters will be deleted on next deploy "
+            "(unless deletion protection is enabled)."
+        )
+        click.confirm("Are you sure?", abort=True)
+
+    try:
+        update_aurora_config({"enabled": False})
+        formatter.print_success("Aurora pgvector disabled in cdk.json")
+        formatter.print_info("Run 'gco stacks deploy-all -y' to apply changes")
+
+    except Exception as e:
+        formatter.print_error(f"Failed to disable Aurora: {e}")
+        sys.exit(1)

--- a/cli/stacks.py
+++ b/cli/stacks.py
@@ -1506,110 +1506,20 @@ def get_stack_destroy_order(stacks: list[str]) -> list[str]:
     return list(reversed(deployment_order))
 
 
-def get_fsx_config(region: str | None = None) -> dict[str, Any]:
-    """Get current FSx for Lustre configuration from cdk.json.
+# =============================================================================
+# Feature toggle helpers
+# =============================================================================
 
-    Args:
-        region: Optional region to get config for. If provided, checks for
-                region-specific overrides first.
-
-    Returns:
-        FSx configuration dictionary
-    """
-    cdk_json_path = _find_cdk_json()
-    if not cdk_json_path:
-        raise RuntimeError("cdk.json not found")
-
-    import json
-
-    with open(cdk_json_path, encoding="utf-8") as f:
-        cdk_config = json.load(f)
-
-    # Default FSx config
-    default_config = {
-        "enabled": False,
-        "storage_capacity_gib": 1200,
-        "deployment_type": "SCRATCH_2",
-        "per_unit_storage_throughput": 200,
-        "data_compression_type": "LZ4",
-        "import_path": None,
-        "export_path": None,
-        "auto_import_policy": "NEW_CHANGED_DELETED",
-    }
-
-    # Get global FSx config
-    global_config = cdk_config.get("context", {}).get("fsx_lustre", default_config)
-
-    # Check for region-specific override
-    if region:
-        region_overrides = cdk_config.get("context", {}).get("fsx_lustre_regions", {})
-        if region in region_overrides:
-            # Merge region config over global config
-            region_config = region_overrides[region]
-            merged = {**global_config, **region_config}
-            merged["region"] = region
-            merged["is_region_specific"] = True
-            return merged
-
-    result = {**default_config, **global_config}
-    result["is_region_specific"] = False
-    return result
-
-
-def update_fsx_config(settings: dict[str, Any], region: str | None = None) -> None:
-    """Update FSx for Lustre configuration in cdk.json.
-
-    Args:
-        settings: FSx settings to update
-        region: Optional region for region-specific config. If None, updates global config.
-    """
-    cdk_json_path = _find_cdk_json()
-    if not cdk_json_path:
-        raise RuntimeError("cdk.json not found")
-
-    import json
-
-    with open(cdk_json_path, encoding="utf-8") as f:
-        cdk_config = json.load(f)
-
-    # Ensure context exists
-    if "context" not in cdk_config:
-        cdk_config["context"] = {}
-
-    if region:
-        # Update region-specific config
-        if "fsx_lustre_regions" not in cdk_config["context"]:
-            cdk_config["context"]["fsx_lustre_regions"] = {}
-
-        if region not in cdk_config["context"]["fsx_lustre_regions"]:
-            cdk_config["context"]["fsx_lustre_regions"][region] = {}
-
-        # Update with new settings
-        for key, value in settings.items():
-            if value is not None or key == "enabled":
-                cdk_config["context"]["fsx_lustre_regions"][region][key] = value
-    else:
-        # Update global config
-        if "fsx_lustre" not in cdk_config["context"]:
-            cdk_config["context"]["fsx_lustre"] = {
-                "enabled": False,
-                "storage_capacity_gib": 1200,
-                "deployment_type": "SCRATCH_2",
-                "per_unit_storage_throughput": 200,
-                "data_compression_type": "LZ4",
-                "import_path": None,
-                "export_path": None,
-                "auto_import_policy": "NEW_CHANGED_DELETED",
-            }
-
-        # Update with new settings
-        for key, value in settings.items():
-            if value is not None or key == "enabled":
-                cdk_config["context"]["fsx_lustre"][key] = value
-
-    # Write back
-    with open(cdk_json_path, "w", encoding="utf-8") as f:
-        json.dump(cdk_config, f, indent=2)
+_FSX_DEFAULTS: dict[str, Any] = {
+    "enabled": False,
+    "storage_capacity_gib": 1200,
+    "deployment_type": "SCRATCH_2",
+    "per_unit_storage_throughput": 200,
+    "data_compression_type": "LZ4",
+    "import_path": None,
+    "export_path": None,
+    "auto_import_policy": "NEW_CHANGED_DELETED",
+}
 
 
 def _find_cdk_json() -> Path | None:
@@ -1620,3 +1530,162 @@ def _find_cdk_json() -> Path | None:
         if cdk_path.exists():
             return cdk_path
     return None
+
+
+def get_fsx_config(region: str | None = None) -> dict[str, Any]:
+    """Get current FSx for Lustre configuration from cdk.json.
+
+    Args:
+        region: Optional region to get config for. If provided, checks for
+                region-specific overrides first.
+
+    Returns:
+        FSx configuration dictionary
+    """
+    return _get_feature_config("fsx_lustre", _FSX_DEFAULTS, region)
+
+
+def update_fsx_config(settings: dict[str, Any], region: str | None = None) -> None:
+    """Update FSx for Lustre configuration in cdk.json.
+
+    Args:
+        settings: FSx settings to update
+        region: Optional region for region-specific config. If None, updates global config.
+    """
+    _update_feature_config("fsx_lustre", settings, _FSX_DEFAULTS, region)
+
+
+# =============================================================================
+# Generic feature toggle helpers (used by FSx, Valkey, Aurora, and future features)
+# =============================================================================
+
+
+def _get_feature_config(
+    feature_key: str,
+    default_config: dict[str, Any],
+    region: str | None = None,
+) -> dict[str, Any]:
+    """Get configuration for a toggleable feature from cdk.json.
+
+    Args:
+        feature_key: The cdk.json context key (e.g. "valkey", "aurora_pgvector").
+        default_config: Default configuration values when the key is missing.
+        region: Optional region for region-specific overrides.
+
+    Returns:
+        Merged configuration dictionary.
+    """
+    cdk_json_path = _find_cdk_json()
+    if not cdk_json_path:
+        raise RuntimeError("cdk.json not found")
+
+    import json
+
+    with open(cdk_json_path, encoding="utf-8") as f:
+        cdk_config = json.load(f)
+
+    global_config = cdk_config.get("context", {}).get(feature_key, default_config)
+
+    if region:
+        region_key = f"{feature_key}_regions"
+        region_overrides = cdk_config.get("context", {}).get(region_key, {})
+        if region in region_overrides:
+            merged = {**global_config, **region_overrides[region]}
+            merged["region"] = region
+            merged["is_region_specific"] = True
+            return merged
+
+    result = {**default_config, **global_config}
+    result["is_region_specific"] = False
+    return result
+
+
+def _update_feature_config(
+    feature_key: str,
+    settings: dict[str, Any],
+    default_config: dict[str, Any],
+    region: str | None = None,
+) -> None:
+    """Update configuration for a toggleable feature in cdk.json.
+
+    Args:
+        feature_key: The cdk.json context key (e.g. "valkey", "aurora_pgvector").
+        settings: Settings to update.
+        default_config: Default configuration values when the key is missing.
+        region: Optional region for region-specific config.
+    """
+    cdk_json_path = _find_cdk_json()
+    if not cdk_json_path:
+        raise RuntimeError("cdk.json not found")
+
+    import json
+
+    with open(cdk_json_path, encoding="utf-8") as f:
+        cdk_config = json.load(f)
+
+    if "context" not in cdk_config:
+        cdk_config["context"] = {}
+
+    if region:
+        region_key = f"{feature_key}_regions"
+        if region_key not in cdk_config["context"]:
+            cdk_config["context"][region_key] = {}
+        if region not in cdk_config["context"][region_key]:
+            cdk_config["context"][region_key][region] = {}
+        for key, value in settings.items():
+            if value is not None or key == "enabled":
+                cdk_config["context"][region_key][region][key] = value
+    else:
+        if feature_key not in cdk_config["context"]:
+            cdk_config["context"][feature_key] = {**default_config}
+        for key, value in settings.items():
+            if value is not None or key == "enabled":
+                cdk_config["context"][feature_key][key] = value
+
+    with open(cdk_json_path, "w", encoding="utf-8") as f:
+        json.dump(cdk_config, f, indent=2)
+
+
+# =============================================================================
+# Valkey configuration
+# =============================================================================
+
+_VALKEY_DEFAULTS: dict[str, Any] = {
+    "enabled": False,
+    "max_data_storage_gb": 5,
+    "max_ecpu_per_second": 5000,
+    "snapshot_retention_limit": 1,
+}
+
+
+def get_valkey_config(region: str | None = None) -> dict[str, Any]:
+    """Get current Valkey Serverless configuration from cdk.json."""
+    return _get_feature_config("valkey", _VALKEY_DEFAULTS, region)
+
+
+def update_valkey_config(settings: dict[str, Any], region: str | None = None) -> None:
+    """Update Valkey Serverless configuration in cdk.json."""
+    _update_feature_config("valkey", settings, _VALKEY_DEFAULTS, region)
+
+
+# =============================================================================
+# Aurora pgvector configuration
+# =============================================================================
+
+_AURORA_DEFAULTS: dict[str, Any] = {
+    "enabled": False,
+    "min_acu": 0,
+    "max_acu": 16,
+    "backup_retention_days": 7,
+    "deletion_protection": False,
+}
+
+
+def get_aurora_config(region: str | None = None) -> dict[str, Any]:
+    """Get current Aurora pgvector configuration from cdk.json."""
+    return _get_feature_config("aurora_pgvector", _AURORA_DEFAULTS, region)
+
+
+def update_aurora_config(settings: dict[str, Any], region: str | None = None) -> None:
+    """Update Aurora pgvector configuration in cdk.json."""
+    _update_feature_config("aurora_pgvector", settings, _AURORA_DEFAULTS, region)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -867,6 +867,46 @@ gco stacks fsx enable --storage-capacity 1200 -y
 gco stacks fsx disable -y
 ```
 
+#### `gco stacks valkey`
+
+Manage Valkey Serverless cache.
+
+```bash
+gco stacks valkey COMMAND [OPTIONS]
+```
+
+**Subcommands:**
+- `status` - Show Valkey configuration status
+- `enable` - Enable Valkey Serverless cache
+- `disable` - Disable Valkey Serverless cache
+
+**Example:**
+```bash
+gco stacks valkey status
+gco stacks valkey enable --max-storage 10 --max-ecpu 10000 -y
+gco stacks valkey disable -y
+```
+
+#### `gco stacks aurora`
+
+Manage Aurora PostgreSQL (pgvector) database.
+
+```bash
+gco stacks aurora COMMAND [OPTIONS]
+```
+
+**Subcommands:**
+- `status` - Show Aurora pgvector configuration status
+- `enable` - Enable Aurora Serverless v2 with pgvector
+- `disable` - Disable Aurora pgvector
+
+**Example:**
+```bash
+gco stacks aurora status
+gco stacks aurora enable --min-acu 2 --max-acu 32 --deletion-protection -y
+gco stacks aurora disable -y
+```
+
 ---
 
 ### DAG Commands

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -1093,7 +1093,26 @@ See `examples/fsx-lustre-job.yaml` for a complete example.
 
 GCO can deploy an ElastiCache Serverless Valkey cache in each regional stack for low-latency key-value storage. Use cases include prompt caching for inference, session state, feature stores, and shared state across pods.
 
-Edit `cdk.json` to enable:
+Enable via CLI:
+
+```bash
+# Enable Valkey
+gco stacks valkey enable -y
+
+# Enable with custom settings
+gco stacks valkey enable --max-storage 10 --max-ecpu 10000 -y
+
+# Check current status
+gco stacks valkey status
+
+# Disable
+gco stacks valkey disable -y
+
+# Redeploy to apply
+gco stacks deploy-all -y
+```
+
+Or edit `cdk.json` directly:
 
 ```json
 {
@@ -1151,7 +1170,26 @@ GCO can deploy an Aurora Serverless v2 PostgreSQL cluster with the pgvector exte
 
 Aurora Serverless v2 supports scaling to 0 ACU — the cluster automatically pauses after a period of inactivity and resumes in ~15 seconds on the first connection. You pay only for storage while paused. This is ideal for dev/test environments and workloads that can tolerate a brief cold start.
 
-Edit `cdk.json` to enable:
+Enable via CLI:
+
+```bash
+# Enable Aurora pgvector
+gco stacks aurora enable -y
+
+# Enable with custom settings
+gco stacks aurora enable --min-acu 2 --max-acu 32 --deletion-protection -y
+
+# Check current status
+gco stacks aurora status
+
+# Disable
+gco stacks aurora disable -y
+
+# Redeploy to apply
+gco stacks deploy-all -y
+```
+
+Or edit `cdk.json` directly:
 
 ```json
 {

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,6 +52,8 @@ Tests are organized by the component they test:
 | CDK Stacks | `test_*_stack*.py` | Infrastructure-as-code tests |
 | Storage | `test_template_store.py` | DynamoDB storage layer tests |
 | Integration | `test_integration.py`, `test_sqs_integration.py` | End-to-end integration tests |
+| MCP Server | `test_mcp_server.py`, `test_mcp_audit.py`, `test_mcp_resources_new.py`, `test_mcp_integration.py` | MCP tools, resources, audit logging, protocol tests |
+| Infrastructure | `test_oidc_stack.py`, `test_feature_toggles.py` | OIDC provider stack, feature toggle helpers (Valkey, Aurora, FSx) |
 
 ## Test Files by Category
 
@@ -244,6 +246,22 @@ actually deploy anything, hit AWS, or spawn long-running subprocesses.
 | `test_bump_version.py` | `scripts/bump_version.py` | SemVer parsing, bump paths (major/minor/patch), dry-run mode, argparse dispatch, keeping `VERSION`, `gco/_version.py`, and `cli/__init__.py` in sync |
 | `test_webhook_delivery_script.py` | `scripts/test_webhook_delivery.py` | `WebhookHandler` do_POST capture and 200 response, silenced `log_message`, `start_local_server` port binding + daemon thread + clean shutdown, `create_mock_job` fixture shape, `main()` argparse branches between local-server and external-URL modes |
 | `test_cdk_synthesis_script.py` | `scripts/test_cdk_synthesis.py` | `CONFIGS` matrix structural integrity (unique names, correct tuple shape, baseline first), `synth_with_config` overlay merging for dict vs scalar values, cdk.json restoration after success/error/exception, return-code classification (real error vs NOTICES-only), TimeoutExpired handling, `main()` aggregation/exit code |
+
+### MCP Server Tests
+
+| File | Description |
+|------|-------------|
+| `test_mcp_server.py` | Unit tests for the MCP server — `_run_cli` wrapper, tool registration, tool argument passing, resource registration, resource content reading |
+| `test_mcp_audit.py` | Audit logging — argument sanitization (redaction, truncation), `@audit_logged` decorator, startup log, Hypothesis property tests for completeness and sanitization |
+| `test_mcp_resources_new.py` | Tests for `tests://`, `config://`, and `docs://gco/examples/guide` resource groups, enhanced example metadata, module structure verification |
+| `test_mcp_integration.py` | End-to-end MCP protocol tests via FastMCP Client — tool discovery, tool call round trips, resource reading, schema validation, stdio subprocess transport |
+
+### Infrastructure Tests
+
+| File | Description |
+|------|-------------|
+| `test_oidc_stack.py` | GitHub OIDC provider CDK stack — synthesis, OIDC provider config, trust policy (wildcard/branch/custom repo), IAM policy actions, role properties, `policy.json` validation |
+| `test_feature_toggles.py` | Generic feature toggle helpers, Valkey config (get/update/enable/disable), Aurora config (get/update/enable/disable), FSx refactor regression |
 
 ### Configuration Files
 

--- a/tests/test_feature_toggles.py
+++ b/tests/test_feature_toggles.py
@@ -1,0 +1,432 @@
+"""
+Tests for the Valkey and Aurora CLI feature toggles.
+
+Covers the generic _get_feature_config / _update_feature_config helpers,
+the Valkey and Aurora config functions, and verifies the FSx refactor
+to use the same generic helpers still works.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+class TestGenericFeatureConfig:
+    """Tests for the generic _get_feature_config / _update_feature_config helpers."""
+
+    def test_get_feature_config_reads_from_context(self):
+        from cli.stacks import _get_feature_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cdk_path = Path(tmpdir) / "cdk.json"
+            cdk_path.write_text(
+                json.dumps({"context": {"my_feature": {"enabled": True, "size": 10}}})
+            )
+
+            with patch("cli.stacks._find_cdk_json", return_value=cdk_path):
+                result = _get_feature_config("my_feature", {"enabled": False, "size": 5})
+                assert result["enabled"] is True
+                assert result["size"] == 10
+
+    def test_get_feature_config_uses_defaults_when_missing(self):
+        from cli.stacks import _get_feature_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cdk_path = Path(tmpdir) / "cdk.json"
+            cdk_path.write_text(json.dumps({"context": {}}))
+
+            with patch("cli.stacks._find_cdk_json", return_value=cdk_path):
+                result = _get_feature_config("my_feature", {"enabled": False, "size": 5})
+                assert result["enabled"] is False
+                assert result["size"] == 5
+
+    def test_get_feature_config_no_cdk_json(self):
+        from cli.stacks import _get_feature_config
+
+        with (
+            patch("cli.stacks._find_cdk_json", return_value=None),
+            pytest.raises(RuntimeError, match="cdk.json not found"),
+        ):
+            _get_feature_config("my_feature", {"enabled": False})
+
+    def test_get_feature_config_region_override(self):
+        from cli.stacks import _get_feature_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cdk_path = Path(tmpdir) / "cdk.json"
+            cdk_path.write_text(
+                json.dumps(
+                    {
+                        "context": {
+                            "my_feature": {"enabled": True, "size": 5},
+                            "my_feature_regions": {"us-west-2": {"size": 20}},
+                        }
+                    }
+                )
+            )
+
+            with patch("cli.stacks._find_cdk_json", return_value=cdk_path):
+                result = _get_feature_config(
+                    "my_feature", {"enabled": False, "size": 5}, "us-west-2"
+                )
+                assert result["enabled"] is True
+                assert result["size"] == 20
+                assert result["is_region_specific"] is True
+
+    def test_get_feature_config_no_region_override_falls_back(self):
+        from cli.stacks import _get_feature_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cdk_path = Path(tmpdir) / "cdk.json"
+            cdk_path.write_text(
+                json.dumps({"context": {"my_feature": {"enabled": True, "size": 10}}})
+            )
+
+            with patch("cli.stacks._find_cdk_json", return_value=cdk_path):
+                result = _get_feature_config(
+                    "my_feature", {"enabled": False, "size": 5}, "us-west-2"
+                )
+                assert result["enabled"] is True
+                assert result["size"] == 10
+                assert result["is_region_specific"] is False
+
+    def test_update_feature_config_writes_to_context(self):
+        from cli.stacks import _update_feature_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cdk_path = Path(tmpdir) / "cdk.json"
+            cdk_path.write_text(json.dumps({"context": {"my_feature": {"enabled": False}}}))
+
+            with patch("cli.stacks._find_cdk_json", return_value=cdk_path):
+                _update_feature_config(
+                    "my_feature", {"enabled": True, "size": 10}, {"enabled": False}
+                )
+
+            result = json.loads(cdk_path.read_text())
+            assert result["context"]["my_feature"]["enabled"] is True
+            assert result["context"]["my_feature"]["size"] == 10
+
+    def test_update_feature_config_creates_section(self):
+        from cli.stacks import _update_feature_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cdk_path = Path(tmpdir) / "cdk.json"
+            cdk_path.write_text(json.dumps({"context": {}}))
+
+            with patch("cli.stacks._find_cdk_json", return_value=cdk_path):
+                _update_feature_config(
+                    "my_feature", {"enabled": True}, {"enabled": False, "size": 5}
+                )
+
+            result = json.loads(cdk_path.read_text())
+            assert result["context"]["my_feature"]["enabled"] is True
+
+    def test_update_feature_config_no_cdk_json(self):
+        from cli.stacks import _update_feature_config
+
+        with (
+            patch("cli.stacks._find_cdk_json", return_value=None),
+            pytest.raises(RuntimeError, match="cdk.json not found"),
+        ):
+            _update_feature_config("my_feature", {"enabled": True}, {"enabled": False})
+
+    def test_update_feature_config_skips_none_values(self):
+        from cli.stacks import _update_feature_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cdk_path = Path(tmpdir) / "cdk.json"
+            cdk_path.write_text(
+                json.dumps({"context": {"my_feature": {"enabled": True, "size": 10}}})
+            )
+
+            with patch("cli.stacks._find_cdk_json", return_value=cdk_path):
+                _update_feature_config(
+                    "my_feature", {"enabled": True, "optional": None}, {"enabled": False}
+                )
+
+            result = json.loads(cdk_path.read_text())
+            assert "optional" not in result["context"]["my_feature"]
+            assert result["context"]["my_feature"]["size"] == 10
+
+
+class TestValkeyConfig:
+    """Tests for Valkey configuration functions."""
+
+    def test_get_valkey_config(self):
+        from cli.stacks import get_valkey_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cdk_path = Path(tmpdir) / "cdk.json"
+            cdk_path.write_text(
+                json.dumps(
+                    {
+                        "context": {
+                            "valkey": {
+                                "enabled": True,
+                                "max_data_storage_gb": 10,
+                                "max_ecpu_per_second": 10000,
+                            }
+                        }
+                    }
+                )
+            )
+
+            with patch("cli.stacks._find_cdk_json", return_value=cdk_path):
+                result = get_valkey_config()
+                assert result["enabled"] is True
+                assert result["max_data_storage_gb"] == 10
+                assert result["max_ecpu_per_second"] == 10000
+
+    def test_get_valkey_config_defaults(self):
+        from cli.stacks import get_valkey_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cdk_path = Path(tmpdir) / "cdk.json"
+            cdk_path.write_text(json.dumps({"context": {}}))
+
+            with patch("cli.stacks._find_cdk_json", return_value=cdk_path):
+                result = get_valkey_config()
+                assert result["enabled"] is False
+                assert result["max_data_storage_gb"] == 5
+                assert result["max_ecpu_per_second"] == 5000
+                assert result["snapshot_retention_limit"] == 1
+
+    def test_get_valkey_config_no_cdk_json(self):
+        from cli.stacks import get_valkey_config
+
+        with (
+            patch("cli.stacks._find_cdk_json", return_value=None),
+            pytest.raises(RuntimeError, match="cdk.json not found"),
+        ):
+            get_valkey_config()
+
+    def test_update_valkey_config_enable(self):
+        from cli.stacks import update_valkey_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cdk_path = Path(tmpdir) / "cdk.json"
+            cdk_path.write_text(json.dumps({"context": {"valkey": {"enabled": False}}}))
+
+            with patch("cli.stacks._find_cdk_json", return_value=cdk_path):
+                update_valkey_config(
+                    {"enabled": True, "max_data_storage_gb": 10, "max_ecpu_per_second": 8000}
+                )
+
+            result = json.loads(cdk_path.read_text())
+            assert result["context"]["valkey"]["enabled"] is True
+            assert result["context"]["valkey"]["max_data_storage_gb"] == 10
+            assert result["context"]["valkey"]["max_ecpu_per_second"] == 8000
+
+    def test_update_valkey_config_disable(self):
+        from cli.stacks import update_valkey_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cdk_path = Path(tmpdir) / "cdk.json"
+            cdk_path.write_text(json.dumps({"context": {"valkey": {"enabled": True}}}))
+
+            with patch("cli.stacks._find_cdk_json", return_value=cdk_path):
+                update_valkey_config({"enabled": False})
+
+            result = json.loads(cdk_path.read_text())
+            assert result["context"]["valkey"]["enabled"] is False
+
+    def test_update_valkey_config_creates_section(self):
+        from cli.stacks import update_valkey_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cdk_path = Path(tmpdir) / "cdk.json"
+            cdk_path.write_text(json.dumps({"context": {}}))
+
+            with patch("cli.stacks._find_cdk_json", return_value=cdk_path):
+                update_valkey_config({"enabled": True})
+
+            result = json.loads(cdk_path.read_text())
+            assert "valkey" in result["context"]
+            assert result["context"]["valkey"]["enabled"] is True
+
+    def test_update_valkey_config_no_cdk_json(self):
+        from cli.stacks import update_valkey_config
+
+        with (
+            patch("cli.stacks._find_cdk_json", return_value=None),
+            pytest.raises(RuntimeError, match="cdk.json not found"),
+        ):
+            update_valkey_config({"enabled": True})
+
+
+class TestAuroraConfig:
+    """Tests for Aurora pgvector configuration functions."""
+
+    def test_get_aurora_config(self):
+        from cli.stacks import get_aurora_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cdk_path = Path(tmpdir) / "cdk.json"
+            cdk_path.write_text(
+                json.dumps(
+                    {
+                        "context": {
+                            "aurora_pgvector": {
+                                "enabled": True,
+                                "min_acu": 2,
+                                "max_acu": 32,
+                                "deletion_protection": True,
+                            }
+                        }
+                    }
+                )
+            )
+
+            with patch("cli.stacks._find_cdk_json", return_value=cdk_path):
+                result = get_aurora_config()
+                assert result["enabled"] is True
+                assert result["min_acu"] == 2
+                assert result["max_acu"] == 32
+                assert result["deletion_protection"] is True
+
+    def test_get_aurora_config_defaults(self):
+        from cli.stacks import get_aurora_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cdk_path = Path(tmpdir) / "cdk.json"
+            cdk_path.write_text(json.dumps({"context": {}}))
+
+            with patch("cli.stacks._find_cdk_json", return_value=cdk_path):
+                result = get_aurora_config()
+                assert result["enabled"] is False
+                assert result["min_acu"] == 0
+                assert result["max_acu"] == 16
+                assert result["backup_retention_days"] == 7
+                assert result["deletion_protection"] is False
+
+    def test_get_aurora_config_no_cdk_json(self):
+        from cli.stacks import get_aurora_config
+
+        with (
+            patch("cli.stacks._find_cdk_json", return_value=None),
+            pytest.raises(RuntimeError, match="cdk.json not found"),
+        ):
+            get_aurora_config()
+
+    def test_update_aurora_config_enable(self):
+        from cli.stacks import update_aurora_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cdk_path = Path(tmpdir) / "cdk.json"
+            cdk_path.write_text(json.dumps({"context": {"aurora_pgvector": {"enabled": False}}}))
+
+            with patch("cli.stacks._find_cdk_json", return_value=cdk_path):
+                update_aurora_config(
+                    {
+                        "enabled": True,
+                        "min_acu": 2,
+                        "max_acu": 32,
+                        "backup_retention_days": 14,
+                        "deletion_protection": True,
+                    }
+                )
+
+            result = json.loads(cdk_path.read_text())
+            assert result["context"]["aurora_pgvector"]["enabled"] is True
+            assert result["context"]["aurora_pgvector"]["min_acu"] == 2
+            assert result["context"]["aurora_pgvector"]["max_acu"] == 32
+            assert result["context"]["aurora_pgvector"]["backup_retention_days"] == 14
+            assert result["context"]["aurora_pgvector"]["deletion_protection"] is True
+
+    def test_update_aurora_config_disable(self):
+        from cli.stacks import update_aurora_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cdk_path = Path(tmpdir) / "cdk.json"
+            cdk_path.write_text(json.dumps({"context": {"aurora_pgvector": {"enabled": True}}}))
+
+            with patch("cli.stacks._find_cdk_json", return_value=cdk_path):
+                update_aurora_config({"enabled": False})
+
+            result = json.loads(cdk_path.read_text())
+            assert result["context"]["aurora_pgvector"]["enabled"] is False
+
+    def test_update_aurora_config_creates_section(self):
+        from cli.stacks import update_aurora_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cdk_path = Path(tmpdir) / "cdk.json"
+            cdk_path.write_text(json.dumps({"context": {}}))
+
+            with patch("cli.stacks._find_cdk_json", return_value=cdk_path):
+                update_aurora_config({"enabled": True})
+
+            result = json.loads(cdk_path.read_text())
+            assert "aurora_pgvector" in result["context"]
+            assert result["context"]["aurora_pgvector"]["enabled"] is True
+
+    def test_update_aurora_config_no_cdk_json(self):
+        from cli.stacks import update_aurora_config
+
+        with (
+            patch("cli.stacks._find_cdk_json", return_value=None),
+            pytest.raises(RuntimeError, match="cdk.json not found"),
+        ):
+            update_aurora_config({"enabled": True})
+
+
+class TestFsxRefactored:
+    """Verify FSx still works after refactoring to use generic helpers."""
+
+    def test_get_fsx_config_still_works(self):
+        from cli.stacks import get_fsx_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cdk_path = Path(tmpdir) / "cdk.json"
+            cdk_path.write_text(
+                json.dumps(
+                    {"context": {"fsx_lustre": {"enabled": True, "storage_capacity_gib": 2400}}}
+                )
+            )
+
+            with patch("cli.stacks._find_cdk_json", return_value=cdk_path):
+                result = get_fsx_config()
+                assert result["enabled"] is True
+                assert result["storage_capacity_gib"] == 2400
+
+    def test_update_fsx_config_still_works(self):
+        from cli.stacks import update_fsx_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cdk_path = Path(tmpdir) / "cdk.json"
+            cdk_path.write_text(json.dumps({"context": {"fsx_lustre": {"enabled": False}}}))
+
+            with patch("cli.stacks._find_cdk_json", return_value=cdk_path):
+                update_fsx_config({"enabled": True, "storage_capacity_gib": 2400})
+
+            result = json.loads(cdk_path.read_text())
+            assert result["context"]["fsx_lustre"]["enabled"] is True
+            assert result["context"]["fsx_lustre"]["storage_capacity_gib"] == 2400
+
+    def test_fsx_region_override_returns_merged_config(self):
+        from cli.stacks import get_fsx_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cdk_path = Path(tmpdir) / "cdk.json"
+            cdk_path.write_text(
+                json.dumps(
+                    {
+                        "context": {
+                            "fsx_lustre": {"enabled": True, "storage_capacity_gib": 1200},
+                            "fsx_lustre_regions": {"us-west-2": {"storage_capacity_gib": 4800}},
+                        }
+                    }
+                )
+            )
+
+            with patch("cli.stacks._find_cdk_json", return_value=cdk_path):
+                result = get_fsx_config("us-west-2")
+                assert result["storage_capacity_gib"] == 4800
+                assert result["is_region_specific"] is True
+
+                global_result = get_fsx_config()
+                assert global_result["storage_capacity_gib"] == 1200
+                assert global_result["is_region_specific"] is False


### PR DESCRIPTION
…elpers

New CLI commands:
- gco stacks valkey enable/disable/status
- gco stacks aurora enable/disable/status

Refactored feature toggle infrastructure:
- Extracted _get_feature_config() and _update_feature_config() generic helpers that read/write cdk.json context for any toggleable feature
- FSx, Valkey, and Aurora all use the same helpers (one place to fix bugs)
- FSx per-region support preserved; Valkey/Aurora are global-only (CDK stack doesn't support per-region overrides for these yet)

Valkey options: --max-storage, --max-ecpu, --snapshot-retention
Aurora options: --min-acu, --max-acu, --backup-retention, --deletion-protection

Documentation updated:
- docs/CLI.md: added valkey and aurora command reference
- docs/CUSTOMIZATION.md: added CLI examples to Valkey and Aurora sections
- cli/commands/README.md: updated stacks_cmd.py command list

Tests: 26 new (generic helpers, Valkey config, Aurora config, FSx refactor verification) + 11 existing FSx tests still passing

<!--
Thanks for contributing to GCO! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [ ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
