### PR TITLE
docs: enforce MD040 and tag existing fenced code blocks

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -26,7 +26,7 @@ For contributor-facing docs (how to run tests locally, release process, dependen
 
 ## Layout
 
-```
+```text
 .github/
 ├── actions/
 │   └── build-lambda-package/       # Composite action: stage Lambda build dirs
@@ -218,7 +218,7 @@ To turn the check on without introducing long-lived access keys, configure a Git
 
 1. **Create the OIDC identity provider in the target AWS account** (one-time, skip if already present):
 
-   ```
+   ```text
    URL:      https://token.actions.githubusercontent.com
    Audience: sts.amazonaws.com
    Thumbprint: (auto-fetched by AWS; no manual step)
@@ -287,7 +287,7 @@ Configuration for the `lint:markdownlint:md` job lives in **`.markdownlint-cli2.
 
 The config does two things worth calling out:
 
-1. **Rules** — starts from the markdownlint defaults and disables a few that fire a lot of aesthetic noise against this repo's style (`MD013` line-length, `MD033` inline HTML, `MD036` emphasis-as-heading, `MD040` missing code-fence language, `MD041` first-line heading, `MD060` table column style). Every override is commented inline so future maintainers can audit the reason. `MD044` (proper-names) is intentionally left unconfigured: it does a case-insensitive substring match and mangles legitimate lowercase identifiers that share letters with product names (`cdk.json` becomes `cdk.JSON`, `kubernetes-sigs/karpenter` becomes `Kubernetes-sigs/...`, and so on).
+1. **Rules** — starts from the markdownlint defaults and disables a few that fire a lot of aesthetic noise against this repo's style (`MD013` line-length, `MD033` inline HTML, `MD036` emphasis-as-heading, `MD041` first-line heading, `MD060` table column style). Every override is commented inline so future maintainers can audit the reason. `MD044` (proper-names) is intentionally left unconfigured: it does a case-insensitive substring match and mangles legitimate lowercase identifiers that share letters with product names (`cdk.json` becomes `cdk.JSON`, `kubernetes-sigs/karpenter` becomes `Kubernetes-sigs/...`, and so on).
 2. **Globs** — the `globs` list targets `**/*.md`; the `ignores` list excludes `cdk.out/`, `build/`, `node_modules/`, Lambda build-staging directories, every tool cache, and `.kiro/` (IDE-local workspace content). `gitignore: true` additionally pulls in everything the repo's `.gitignore` already excludes.
 
 To add a new exclusion (e.g. a generated-docs folder), extend the `ignores` list. To loosen or tighten a rule, adjust the `config:` block — see the [markdownlint rule reference](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md) for the full catalog.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,7 +34,7 @@ labels: ["bug"]
 
 <!-- What actually happened? Include error messages and stack traces. -->
 
-```
+```text
 <paste logs / error output here>
 ```
 

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -72,13 +72,6 @@ config:
   # clutter the ToC.
   MD036: false
 
-  # MD040 (fenced-code-language) — disabled for now. Enforcing a language
-  # tag on every fenced code block is a good aspiration, but several
-  # existing fences are plain copy output (tree views, kubectl output,
-  # terminal transcripts) where no language applies. Revisit once those
-  # are tagged with `text` explicitly.
-  MD040: false
-
   # MD024 (no-duplicate-heading) — allowed when headings are in different
   # sections (siblings_only). Common pattern: each workflow's section has
   # its own "## Notes" or "### Inputs" subsection.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,7 +240,7 @@ git push origin feature/your-feature-name
 
 ### Directory Structure
 
-```
+```text
 gco/
 ├── stacks/                  # CDK stack definitions
 ├── services/                # Kubernetes services (Python/FastAPI)

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Regenerate this diagram and every per-stack view on demand with `python diagrams
 
 > The regional stack can be deployed to any AWS region. Add or remove regions by editing the `deployment_regions.regional` array in `cdk.json`.
 
-```
+```text
 ┌───────────────────────────────────────────────────┐
 │              User Request                         │
 │        (AWS SigV4 Authentication)                 │
@@ -216,7 +216,7 @@ Five layers protect every request:
 4. **Header Validation** — Backend services verify the secret token
 5. **IRSA** — Pods use IAM roles for AWS access (no static credentials)
 
-```
+```text
 Request flow: User → API Gateway (SigV4) → Lambda (adds secret) → Global Accelerator
   → ALB (GA IPs only) → Services (validate secret)
 ```
@@ -312,7 +312,7 @@ docker run -it --rm -v ~/.aws:/root/.aws:ro -v $(pwd):/workspace -w /workspace g
 
 ## Project Structure
 
-```
+```text
 .
 ├── app.py                               # CDK app entry point
 ├── cdk.json                             # CDK configuration (regions, features, thresholds)

--- a/cli/capacity/README.md
+++ b/cli/capacity/README.md
@@ -13,7 +13,7 @@ GPU capacity checking, region recommendation, and AI-powered advisory. This pack
 
 Three layers, each building on the previous:
 
-```
+```text
 CapacityChecker (single-region AWS queries)
     ↓
 MultiRegionCapacityChecker (cross-region aggregation + weighted scoring)

--- a/demo/DEMO_WALKTHROUGH.md
+++ b/demo/DEMO_WALKTHROUGH.md
@@ -398,7 +398,7 @@ gco inference deploy my-model \
 
 ## Architecture Overview
 
-```
+```text
 User ──► API Gateway (IAM/SigV4 Auth)
               │
               ▼

--- a/demo/INFERENCE_WALKTHROUGH.md
+++ b/demo/INFERENCE_WALKTHROUGH.md
@@ -346,7 +346,7 @@ gco inference list
 
 ## Architecture
 
-```
+```text
                     gco inference deploy
                              |
                              v

--- a/docs/API.md
+++ b/docs/API.md
@@ -46,7 +46,7 @@ This document describes the REST API for the GCO Manifest Processor service.
 
 The API is available at the API Gateway endpoint configured during deployment:
 
-```
+```http
 https://<api-gateway-endpoint>/api/v1
 ```
 
@@ -211,7 +211,7 @@ The job queue provides centralized job submission with region targeting via Dyna
 
 ### Global Jobs List
 
-```
+```http
 GET /api/v1/global/jobs
 ```
 
@@ -259,7 +259,7 @@ gco jobs list -a --namespace gco-jobs --status running
 
 ### Global Health Status
 
-```
+```http
 GET /api/v1/global/health
 ```
 
@@ -295,7 +295,7 @@ gco jobs health --all-regions
 
 ### Global Bulk Delete
 
-```
+```http
 DELETE /api/v1/global/jobs
 ```
 
@@ -336,7 +336,7 @@ gco jobs bulk-delete --all-regions --status failed --older-than-days 30 --execut
 
 ### List Jobs
 
-```
+```http
 GET /api/v1/jobs
 ```
 
@@ -411,7 +411,7 @@ gco jobs list -r us-east-1 --limit 10
 
 ### Get Job Logs
 
-```
+```http
 GET /api/v1/jobs/{namespace}/{name}/logs
 ```
 
@@ -461,7 +461,7 @@ gco jobs logs multi-container-job -r us-east-1 --container sidecar
 
 ### Get Job Events
 
-```
+```http
 GET /api/v1/jobs/{namespace}/{name}/events
 ```
 
@@ -508,7 +508,7 @@ gco jobs events training-job -n ml-jobs -r us-west-2
 
 ### Get Job Pods
 
-```
+```http
 GET /api/v1/jobs/{namespace}/{name}/pods
 ```
 
@@ -569,7 +569,7 @@ gco jobs pods training-job -n ml-jobs -r us-west-2
 
 ### Get Job Metrics
 
-```
+```http
 GET /api/v1/jobs/{namespace}/{name}/metrics
 ```
 
@@ -615,7 +615,7 @@ gco jobs metrics training-job -n ml-jobs -r us-west-2
 
 ### Bulk Delete Jobs
 
-```
+```http
 DELETE /api/v1/jobs
 ```
 
@@ -675,7 +675,7 @@ gco jobs bulk-delete --all-regions --status failed --older-than-days 30 --execut
 
 ### Retry Job
 
-```
+```http
 POST /api/v1/jobs/{namespace}/{name}/retry
 ```
 
@@ -717,7 +717,7 @@ The job queue provides centralized job submission with region targeting. Jobs ar
 
 ### Submit to Queue
 
-```
+```http
 POST /api/v1/queue/jobs
 ```
 
@@ -780,7 +780,7 @@ gco queue submit job.yaml -r us-east-1 -l team=ml -l project=training
 
 ### List Queued Jobs
 
-```
+```http
 GET /api/v1/queue/jobs
 ```
 
@@ -830,7 +830,7 @@ gco queue list -s running
 
 ### Get Queued Job
 
-```
+```http
 GET /api/v1/queue/jobs/{job_id}
 ```
 
@@ -873,7 +873,7 @@ gco queue get abc123-def456 --region us-east-1
 
 ### Cancel Queued Job
 
-```
+```http
 DELETE /api/v1/queue/jobs/{job_id}
 ```
 
@@ -903,7 +903,7 @@ gco queue cancel abc123-def456 --reason "No longer needed"
 
 ### Queue Statistics
 
-```
+```http
 GET /api/v1/queue/stats
 ```
 
@@ -950,7 +950,7 @@ Templates allow you to define reusable job configurations with parameter substit
 
 ### List Templates
 
-```
+```http
 GET /api/v1/templates
 ```
 
@@ -962,7 +962,7 @@ gco templates list
 
 ### Create Template
 
-```
+```http
 POST /api/v1/templates
 ```
 
@@ -1010,7 +1010,7 @@ gco templates create job.yaml -n my-template -p image=pytorch:latest -p gpus=4
 
 ### Create Job from Template
 
-```
+```http
 POST /api/v1/jobs/from-template/{name}
 ```
 
@@ -1138,7 +1138,7 @@ def verify_signature(payload: bytes, signature: str, secret: str) -> bool:
 
 ### List Webhooks
 
-```
+```http
 GET /api/v1/webhooks
 ```
 
@@ -1151,7 +1151,7 @@ gco webhooks list --namespace gco-jobs
 
 ### Register Webhook
 
-```
+```http
 POST /api/v1/webhooks
 ```
 
@@ -1202,7 +1202,7 @@ gco webhooks create -u https://example.com/webhook -e job.completed --secret my-
 
 ### Delete Webhook
 
-```
+```http
 DELETE /api/v1/webhooks/{id}
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -179,7 +179,7 @@ Each region contains:
 
 ### Manifest Submission
 
-```
+```text
 User → API Gateway (IAM Auth) → Lambda Proxy → Global Accelerator
   → Regional ALB → Kubernetes Ingress → Manifest Processor Pod
   → Kubernetes API → Workload Scheduled → Node Provisioned
@@ -187,7 +187,7 @@ User → API Gateway (IAM Auth) → Lambda Proxy → Global Accelerator
 
 ### Authentication Flow
 
-```
+```text
 User Request (SigV4 signed) → API Gateway (IAM Auth)
   → Validates SigV4 signature and IAM permissions
   → Lambda Proxy retrieves secret from Secrets Manager
@@ -199,7 +199,7 @@ User Request (SigV4 signed) → API Gateway (IAM Auth)
 
 ### Node Provisioning (EKS Auto Mode)
 
-```
+```text
 Pod Pending → Karpenter detects unschedulable pod
   → Evaluates nodepool requirements
   → Provisions EC2 instance matching requirements
@@ -380,7 +380,7 @@ Amazon EFS provides shared, persistent storage for all pods in the cluster. This
 
 ### Architecture
 
-```
+```text
 ┌─────────────────────────────────────────────────────────┐
 │                    EFS File System                      │
 │                  (Encrypted at rest)                    │
@@ -455,19 +455,19 @@ This section provides a theoretical upper bound for GCO's throughput when deploy
 
 **Conservative estimate (g5.xlarge, 1 GPU each):**
 
-```
+```text
 34 regions × 100,000 nodes × 1 GPU = 3,400,000 concurrent GPU jobs
 ```
 
 **High-density estimate (g5.48xlarge, 8 GPUs each):**
 
-```
+```text
 34 regions × 100,000 nodes × 8 GPUs = 27,200,000 concurrent GPUs
 ```
 
 ### Submission Throughput (assuming 1,000 manifests/sec)
 
-```
+```text
 34 regions × 1,000 manifests/sec = 34,000 job submissions/second
 ```
 

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -54,7 +54,7 @@ Running GPU workloads at scale on Kubernetes is hard:
 
 GCO deploys identical infrastructure to multiple AWS regions:
 
-```
+```text
                     ┌─────────────────────┐
                     │   Global Endpoint   │
                     │  (API Gateway +     │
@@ -152,7 +152,7 @@ Inference serving uses a reconciliation pattern similar to Kubernetes controller
 5. If anything drifts (pod deleted, resource missing), the monitor self-heals by recreating it
 6. Global Accelerator routes user requests to the nearest healthy region
 
-```
+```text
 gco inference deploy
         │
         ▼
@@ -256,7 +256,7 @@ volumes:
 
 GCO uses multiple security layers:
 
-```
+```text
 ┌─────────────────────────────────────────────────────────┐
 │ Layer 1: IAM Authentication                             │
 │ - API Gateway validates AWS credentials (SigV4)         │
@@ -297,7 +297,7 @@ GCO supports two API access modes:
 
 The default mode routes all requests through a global API Gateway and Global Accelerator:
 
-```
+```text
 User → Global API Gateway → Global Accelerator → Regional ALB → EKS
 ```
 
@@ -316,7 +316,7 @@ User → Global API Gateway → Global Accelerator → Regional ALB → EKS
 
 When public access is disabled, regional API Gateways provide direct access via VPC Lambdas:
 
-```
+```text
 User → Regional API Gateway → VPC Lambda → Internal ALB → EKS
 ```
 
@@ -357,7 +357,7 @@ gco jobs list --region us-east-1
 
 Here's what happens when you submit a job:
 
-```
+```text
 1. You run: gco jobs submit my-job.yaml
 
 2. CLI signs request with your AWS credentials (SigV4)

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -661,7 +661,7 @@ spec:
 Manifests are applied in sorted filename order. The naming convention encodes both
 the deployment phase and the resource group:
 
-```
+```text
 NN-group-name.yaml      # Main pass (applied before Helm)
 post-helm-name.yaml     # Post-Helm pass (applied after Helm installs CRDs)
 ```
@@ -1577,7 +1577,7 @@ gco stacks deploy-all -y
 
 Regional API Gateways deploy a VPC Lambda in each region that can reach the internal ALB directly:
 
-```
+```text
 User → Regional API Gateway (IAM Auth) → VPC Lambda → Internal ALB → EKS pods
 ```
 

--- a/docs/INFERENCE.md
+++ b/docs/INFERENCE.md
@@ -32,7 +32,7 @@ Key capabilities:
 
 Inference serving uses a reconciliation pattern similar to Kubernetes controllers:
 
-```
+```text
 User → gco inference deploy
          │
          ▼
@@ -121,7 +121,7 @@ gco models list
 
 Output:
 
-```
+```text
   Models (2 found)
   ----------------------------------------------------------------------
   NAME                      FILES  SIZE (GB) S3 URI
@@ -553,7 +553,7 @@ For the retrieval component of RAG, GCO doesn't include a built-in vector databa
 
 A typical RAG flow with GCO:
 
-```
+```text
 User query
     → Valkey cache check (semantic cache hit?)
     → If miss: embed query (Bedrock Titan)
@@ -587,7 +587,7 @@ gco inference deploy my-llm \
 
 Once deployed, inference endpoints are accessible through Global Accelerator at:
 
-```
+```text
 https://<GA_ENDPOINT>/inference/<endpoint-name>/
 ```
 
@@ -601,7 +601,7 @@ Each region independently reconciles and reports its status:
 gco inference status my-llm
 ```
 
-```
+```text
   Endpoint: my-llm
   ------------------------------------------------------------
   State:     running

--- a/docs/KEDA.md
+++ b/docs/KEDA.md
@@ -30,7 +30,7 @@ The KEDA operator has an IRSA role with permissions to read SQS queue metrics fo
 
 GCO's built-in SQS queue processor (`manifests/post-helm-sqs-consumer.yaml`) is a KEDA ScaledJob:
 
-```
+```text
 User runs: gco jobs submit-sqs manifest.yaml --region us-east-1
   → Manifest sent to regional SQS queue
   → KEDA detects message, spins up consumer pod

--- a/docs/KUEUE.md
+++ b/docs/KUEUE.md
@@ -29,7 +29,7 @@ The `enablePlainPod: true` setting is on by default, which lets Kueue manage sta
 
 ### Resource Model
 
-```
+```text
 ClusterQueue (cluster-wide quotas)
   └── ResourceFlavor (maps to node types)
   └── LocalQueue (namespace-scoped, points to ClusterQueue)

--- a/docs/SCHEDULERS.md
+++ b/docs/SCHEDULERS.md
@@ -19,7 +19,7 @@ GCO ships with six scheduling and orchestration tools, each designed for differe
 
 These tools operate at different layers and can be combined:
 
-```
+```text
                     ┌─────────────────────────────────┐
                     │         Job Submission          │
                     │  kubectl / gco CLI / REST API   │
@@ -137,7 +137,7 @@ This is the most important thing to get right. GPU quotas are defined independen
 
 **Recommended approach:** Partition GPU capacity across the systems you actually use:
 
-```
+```text
 Example: 8 physical GPUs
 ├── Slurm GPU workers: 0 (CPU-only by default, no GPU conflict)
 ├── Volcano Queue cap: 4 GPUs (for gang-scheduled training)

--- a/docs/SLURM_OPERATOR.md
+++ b/docs/SLURM_OPERATOR.md
@@ -49,7 +49,7 @@ The `gco-jobs` namespace is created automatically by GCO during stack deployment
 
 **Note on HA:** The default deployment runs a single controller replica. If the controller pod restarts, Kubernetes regenerates it quickly (typically faster than Slurm's native HA failover). The Slinky operator monitors the controller and restarts it automatically. For production workloads, monitor the controller pod and enable Slurm accounting to persist job state across restarts.
 
-```
+```text
 ┌─────────────────────────────────────────────────────┐
 │                    EKS Cluster                      │
 │                                                     │

--- a/docs/YUNIKORN.md
+++ b/docs/YUNIKORN.md
@@ -29,7 +29,7 @@ The `gco-jobs` namespace is created automatically by GCO during stack deployment
 
 ## How It Works
 
-```
+```text
 ┌──────────────────────────────────────────────────────┐
 │                    EKS Cluster                       │
 │                                                      │

--- a/gco/stacks/README.md
+++ b/gco/stacks/README.md
@@ -16,7 +16,7 @@ GCO deploys four stack layers in order: Global → API Gateway → Regional (per
 
 ## Stack Dependency Order
 
-```
+```text
 1. GCOGlobalStack          → Global Accelerator, DynamoDB tables, S3 model bucket
 2. GCOApiGatewayGlobalStack → API Gateway, auth secret, Lambda proxy
 3. GCORegionalStack (×N)   → VPC, EKS, ALB, EFS/FSx, Lambdas, container images

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -32,7 +32,7 @@ The GCO CLI handles this automatically during `gco stacks deploy`.
 
 ## Architecture
 
-```
+```text
 API Gateway → api-gateway-proxy → Global Accelerator → ALB → EKS
                                                          ↑
                                               alb-header-validator

--- a/lambda/kubectl-applier-simple/manifests/README.md
+++ b/lambda/kubectl-applier-simple/manifests/README.md
@@ -13,7 +13,7 @@ Files are applied in **sorted filename order**, so the numeric prefix controls s
 
 ## Naming Convention
 
-```
+```text
 NN-group-name.yaml          # main pass (applied before Helm)
 post-helm-name.yaml         # post-Helm pass (applied after Helm installs CRDs)
 ```

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -364,7 +364,7 @@ From there, you can branch into job submission, inference deployments, or cost t
 
 The MCP server is organized as a modular package under `mcp/`:
 
-```
+```text
 mcp/
 ├── run_mcp.py         — Thin entrypoint (python mcp/run_mcp.py)
 ├── server.py          — FastMCP instance and instructions
@@ -401,7 +401,7 @@ Each tool shells out to the `gco` CLI. This approach:
 - Avoids duplicating complex AWS client setup
 - Uses `--output json` for structured responses where supported
 
-```
+```text
 LLM ←→ MCP Protocol (stdio) ←→ run_mcp.py ←→ gco CLI ←→ AWS APIs
 ```
 


### PR DESCRIPTION
Drop the `MD040: false` override from .markdownlint-cli2.yaml so markdownlint now enforces a language tag on every fenced code block (previously opt-in aspiration, noted in the config comment).

Tag the 63 existing fences that were missed:

- docs/API.md endpoint specs (`GET /api/v1/...`) -> `http`
- ASCII architecture diagrams, directory trees, terminal transcripts, and copy-paste placeholders across the rest of the repo -> `text`

Also refresh the "Markdownlint config" section in .github/CI.md to drop the stale mention of MD040 being disabled.

Verified with `npx markdownlint-cli2`: 0 errors across all 68 tracked markdown files.

<!--
Thanks for contributing to GCO! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [ ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
