### PR TITLE
docs(examples): fix inference endpoint guidance and standardize headers

### DIFF
--- a/examples/analytics-database-export-job.yaml
+++ b/examples/analytics-database-export-job.yaml
@@ -1,4 +1,5 @@
-# Analytics Database Export Example Job
+# Analytics Database Export Job Example
+#
 # Exports rows from the regional Aurora Serverless v2 PostgreSQL cluster
 # (pgvector) to Cluster_Shared_Bucket as CSV, so a SageMaker Studio
 # notebook can analyse the export without direct database credentials.
@@ -8,7 +9,7 @@
 #     sharedBucketArn, sharedBucketRegion). Always present.
 #   - gco-aurora-pgvector — source (endpoint, port, database, secret_arn,
 #     region, role_arn). Only present when aurora_pgvector.enabled = true
-#     in cdk.json and the regional stack has been redeployed.
+#     and the regional stack has been redeployed.
 #
 # An init container checks for the Aurora ConfigMap on disk and exits 0
 # when Aurora is not enabled, turning this job into a safe no-op on
@@ -24,8 +25,10 @@
 #   3. (Optional, for the notebook reader)
 #      gco analytics enable && gco stacks deploy gco-analytics
 #
-# Submit with:
+# Usage:
 #   gco jobs submit-direct examples/analytics-database-export-job.yaml -r us-east-1
+#
+# Docs: ../docs/ANALYTICS.md
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/examples/analytics-s3-upload-job.yaml
+++ b/examples/analytics-s3-upload-job.yaml
@@ -1,38 +1,41 @@
-# Analytics S3 Upload Example Job
+# Analytics S3 Upload Job Example
+#
 # Cluster-side half of the analytics workflow: publishes a small dataset
 # snapshot plus its schema manifest to Cluster_Shared_Bucket under the
 # analytics-data/ prefix so a SageMaker Studio notebook can read it via
-# the notebook's SageMaker execution role (which is granted RW on the
-# shared bucket when the analytics environment is enabled).
+# the notebook's SageMaker execution role (granted RW on the shared bucket
+# when the analytics environment is enabled).
 #
-# Same ConfigMap as examples/cluster-shared-bucket-upload-job.yaml —
-# gco-cluster-shared-bucket, exposing sharedBucketName / sharedBucketArn /
-# sharedBucketRegion via envFrom. The difference is the prerequisites:
-# the Studio reader counterpart only exists when the analytics stack is
-# deployed and a Studio user has been provisioned.
+# Uses the same gco-cluster-shared-bucket ConfigMap as
+# cluster-shared-bucket-upload-job.yaml (envFrom exposes sharedBucketName
+# / sharedBucketArn / sharedBucketRegion). The extra prerequisites are
+# only needed for the Studio reader counterpart.
 #
 # Prerequisites:
 #   1. gco analytics enable
 #      Sets analytics_environment.enabled = true in cdk.json.
 #   2. gco stacks deploy gco-analytics
-#      Provisions SageMaker Studio domain, Cognito user pool, KMS key,
-#      Studio_Only_Bucket, and EFS home folders. Also grants the
-#      SageMaker execution role RW on the shared bucket.
+#      Provisions the Studio domain, Cognito user pool, KMS key,
+#      Studio_Only_Bucket, and EFS home folders. Grants the SageMaker
+#      execution role RW on the shared bucket.
 #   3. gco analytics users add <username>
 #      Creates a Cognito user and associated Studio user profile with a
 #      per-user EFS access point under /home/<username>.
 #
-# Studio reader snippet (paste into a notebook cell after this job runs):
-#   import boto3, os, pandas
-#   df = pandas.read_csv(
-#       boto3.client('s3').get_object(
-#           Bucket=os.environ['sharedBucketName'],
-#           Key='analytics-data/dataset.csv',
-#       )['Body']
-#   )
-#
-# Submit with:
+# Usage:
 #   gco jobs submit-direct examples/analytics-s3-upload-job.yaml -r us-east-1
+#
+# Notes:
+#   - Studio reader snippet (paste into a notebook cell after this job runs):
+#       import boto3, os, pandas
+#       df = pandas.read_csv(
+#           boto3.client('s3').get_object(
+#               Bucket=os.environ['sharedBucketName'],
+#               Key='analytics-data/dataset.csv',
+#           )['Body']
+#       )
+#
+# Docs: ../docs/ANALYTICS.md
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/examples/analytics-s3-upload-job.yaml
+++ b/examples/analytics-s3-upload-job.yaml
@@ -26,7 +26,13 @@
 #   gco jobs submit-direct examples/analytics-s3-upload-job.yaml -r us-east-1
 #
 # Notes:
-#   - Studio reader snippet (paste into a notebook cell after this job runs):
+#   - Studio reader snippet. Studio kernels don't mount the
+#     gco-cluster-shared-bucket ConfigMap (that's a pod-side env), and the
+#     SageMaker execution role doesn't have ssm:GetParameter, so export the
+#     bucket name once from a JupyterLab terminal (the value is stable
+#     across deploys):
+#       export sharedBucketName=gco-cluster-shared-<account>-<global-region>
+#     Then paste this into a notebook cell:
 #       import boto3, os, pandas
 #       df = pandas.read_csv(
 #           boto3.client('s3').get_object(
@@ -120,6 +126,8 @@ spec:
 
           # Print the copy-pasteable notebook snippet.
           print("\nStudio notebook snippet:")
+          print("  # Export once from a JupyterLab terminal (value is stable):")
+          print(f"  #   export sharedBucketName={bucket}")
           print("  import boto3, os, pandas")
           print("  df = pandas.read_csv(")
           print("      boto3.client('s3').get_object(")

--- a/examples/aurora-pgvector-job.yaml
+++ b/examples/aurora-pgvector-job.yaml
@@ -1,17 +1,19 @@
-# Aurora pgvector Example Job
-# Demonstrates connecting to the regional Aurora Serverless v2 PostgreSQL
-# cluster with pgvector for vector similarity search (RAG, semantic search).
+# Aurora pgvector Job Example
 #
-# The Aurora endpoint and credentials are injected automatically via the
-# gco-aurora-pgvector ConfigMap and AWS Secrets Manager — no need to
-# hardcode connection strings. The same manifest works in any region.
+# Connects to the regional Aurora Serverless v2 PostgreSQL cluster with
+# pgvector for vector similarity search (RAG, semantic search). Endpoint
+# and credentials are injected via the gco-aurora-pgvector ConfigMap and
+# AWS Secrets Manager — no hardcoded connection strings. The same
+# manifest works in any region.
 #
 # Prerequisites:
 #   - aurora_pgvector.enabled = true in cdk.json
-#   - The regional stack deployed with Aurora enabled
+#   - Regional stack deployed with Aurora enabled
 #
-# Submit with:
+# Usage:
 #   gco jobs submit-direct examples/aurora-pgvector-job.yaml -r us-east-1
+#
+# Docs: ../docs/CUSTOMIZATION.md#configure-aurora-pgvector
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/examples/cluster-shared-bucket-upload-job.yaml
+++ b/examples/cluster-shared-bucket-upload-job.yaml
@@ -1,26 +1,26 @@
-# Cluster Shared Bucket Upload Example Job
-# Demonstrates the always-on Cluster_Shared_Bucket: every regional GCO
-# cluster can read and write this bucket regardless of whether the
-# analytics environment is enabled. The bucket's name, ARN, and region
-# are injected via the gco-cluster-shared-bucket ConfigMap using envFrom,
-# which exposes the keys sharedBucketName, sharedBucketArn, and
-# sharedBucketRegion directly as env vars — no ConfigMap key lookup or
-# hardcoded bucket name.
+# Cluster Shared Bucket Upload Job Example
 #
-# Cross-region caveat:
-#   The shared bucket lives in the global region (default us-east-2)
-#   where GCOGlobalStack is deployed, NOT in the regional cluster's own
-#   region. This job runs in whatever region you submit it to, but the
-#   boto3 S3 client below is pointed at os.environ["sharedBucketRegion"]
-#   so the request goes to the bucket's home region. Expect small
-#   cross-region egress charges on large uploads.
+# Writes a small JSON artifact to the always-on Cluster_Shared_Bucket using
+# envFrom against the gco-cluster-shared-bucket ConfigMap. The bucket's
+# name, ARN, and region are exposed as env vars (sharedBucketName,
+# sharedBucketArn, sharedBucketRegion) — no hardcoded bucket names. Works
+# regardless of whether the analytics environment is enabled.
 #
 # Prerequisites:
-#   None — Cluster_Shared_Bucket is always on. This example works with
-#   analytics_environment.enabled = false.
+#   - None — Cluster_Shared_Bucket is always provisioned with
+#     `gco stacks deploy gco-global`.
 #
-# Submit with:
+# Usage:
 #   gco jobs submit-direct examples/cluster-shared-bucket-upload-job.yaml -r us-east-1
+#
+# Notes:
+#   - Cross-region caveat: the shared bucket lives in the global region
+#     (default us-east-2) where GCOGlobalStack is deployed, not in the
+#     regional cluster's own region. The boto3 client below is pointed at
+#     os.environ["sharedBucketRegion"] so requests go to the bucket's home
+#     region. Expect small cross-region egress charges on large uploads.
+#
+# Docs: ../docs/CLUSTER_SHARED_BUCKET.md
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/examples/dag-step-preprocess.yaml
+++ b/examples/dag-step-preprocess.yaml
@@ -1,5 +1,8 @@
-# DAG Pipeline Step 1: Preprocess
-# Writes output to shared EFS for the next step to consume.
+# DAG Pipeline Step: Preprocess
+#
+# Step 1 of examples/pipeline-dag.yaml. Writes output to shared EFS at
+# /mnt/shared for the train step to consume. Not intended to be submitted
+# standalone — invoke via `gco dag run examples/pipeline-dag.yaml`.
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/examples/dag-step-train.yaml
+++ b/examples/dag-step-train.yaml
@@ -1,5 +1,8 @@
-# DAG Pipeline Step 2: Train
-# Reads preprocess output from EFS, writes model artifacts.
+# DAG Pipeline Step: Train
+#
+# Step 2 of examples/pipeline-dag.yaml. Reads preprocess output from shared
+# EFS and writes model artifacts back to EFS. Not intended to be submitted
+# standalone — invoke via `gco dag run examples/pipeline-dag.yaml`.
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/examples/efa-distributed-training.yaml
+++ b/examples/efa-distributed-training.yaml
@@ -1,17 +1,27 @@
 # EFA-Enabled Distributed Training Example
-# Uses Elastic Fabric Adapter for high-bandwidth inter-node communication
+#
+# Uses Elastic Fabric Adapter for high-bandwidth, low-latency inter-node
+# communication — up to 3.2 Tbps on P5/Trn2 and up to 28.8 Tbps on
+# P6e-GB200. Required for large-scale NCCL-based multi-node training.
 #
 # Prerequisites:
-#   1. EFA is enabled by default via the helm config in cdk.json.
-#      If disabled, re-enable: "helm": { "nvidia_network_operator": { "enabled": true } }
-#      and redeploy: gco stacks deploy-all -y
+#   - EFA-capable instance type (see list below)
+#   - NVIDIA Network Operator enabled in cdk.json (on by default):
+#       "helm": { "nvidia_network_operator": { "enabled": true } }
+#   - Regional stack deployed: `gco stacks deploy-all -y`
 #
-# Deploy with:
+# Usage:
 #   gco jobs submit-direct examples/efa-distributed-training.yaml -r us-east-1
 #
-# Supported instance types: p4d.24xlarge (4x EFA), p5.48xlarge (32x EFA), p6 (B200/B300)
-# EFA bandwidth: P4d 400 Gbps, P5/P5e/P5en/Trn2 3,200 Gbps, P6-B200 3.2 Tbps, P6e-GB200 28.8 Tbps
-# EKS Auto Mode uses EKS-optimized AMIs which include host-level EFA components
+# Notes:
+#   - Supported instance types: p4d.24xlarge (4x EFA), p5.48xlarge (32x EFA),
+#     p6 (B200/B300), trn1.32xlarge, trn2.48xlarge.
+#   - EFA bandwidth: P4d 400 Gbps, P5/P5e/P5en/Trn2 3,200 Gbps,
+#     P6-B200 3.2 Tbps, P6e-GB200 28.8 Tbps.
+#   - EKS Auto Mode uses EKS-optimized AMIs with host-level EFA components
+#     already present.
+#
+# Docs: ../docs/INFERENCE.md
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/examples/efs-output-job.yaml
+++ b/examples/efs-output-job.yaml
@@ -1,14 +1,18 @@
-# Example job that writes output to shared EFS storage
-# This demonstrates how to use the gco-shared-storage PVC for job outputs
+# EFS Output Job Example
 #
-# The job:
-# 1. Mounts the shared EFS volume at /outputs
-# 2. Creates a timestamped output file using the JOB_NAME (not pod name)
-# 3. Writes job results to the file
+# Writes a timestamped output file to shared EFS via the gco-shared-storage
+# PVC. Demonstrates how to persist job results so they survive pod termination
+# and can be read by other pods or downloaded with `gco files`.
 #
-# Download results with: gco files download efs-output-example ./results -r <region>
+# Prerequisites:
+#   - Shared EFS PVC (provisioned by default as gco-shared-storage)
 #
-# Other jobs or pods can read these outputs by mounting the same PVC
+# Usage:
+#   gco jobs submit-direct examples/efs-output-job.yaml -r us-east-1
+#   gco files ls -r us-east-1
+#   gco files download efs-output-example ./results -r us-east-1
+#
+# Docs: ../docs/CUSTOMIZATION.md
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/examples/fsx-lustre-job.yaml
+++ b/examples/fsx-lustre-job.yaml
@@ -1,17 +1,19 @@
-# Example job that uses FSx for Lustre high-performance storage
-# FSx for Lustre provides high-throughput, low-latency storage ideal for:
-# - Large dataset processing (ML training data)
-# - High-performance computing (HPC) workloads
-# - Checkpoint/restart for long-running jobs
+# FSx for Lustre Job Example
+#
+# Uses FSx for Lustre high-performance parallel storage for I/O-intensive
+# workloads — large dataset processing, HPC, and long-running training with
+# frequent checkpoints. Mounts the FSx volume at /scratch.
 #
 # Prerequisites:
-# 1. FSx must be enabled: gco stacks fsx enable
-# 2. Stack must be redeployed after enabling FSx
+#   - FSx enabled and regional stack redeployed:
+#       gco stacks fsx enable -y
+#       gco stacks deploy gco-us-east-1 -y
 #
-# The job:
-# 1. Mounts the FSx Lustre volume at /scratch
-# 2. Demonstrates high-throughput I/O operations
-# 3. Shows how to use FSx for ML training data and checkpoints
+# Usage:
+#   gco jobs submit-direct examples/fsx-lustre-job.yaml -r us-east-1
+#   gco files download fsx-lustre-example ./fsx-results -r us-east-1 -t fsx
+#
+# Docs: ../docs/CUSTOMIZATION.md#configure-fsx-storage
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/examples/gpu-job.yaml
+++ b/examples/gpu-job.yaml
@@ -1,5 +1,17 @@
 # GPU Job Example
-# This job requests GPU resources and runs on GPU nodes
+#
+# Runs nvidia-smi on a GPU-enabled node to verify GPU scheduling and driver
+# visibility. A good smoke test after enabling GPU nodepools.
+#
+# Prerequisites:
+#   - GPU nodepool (enabled by default)
+#   - NVIDIA device plugin (enabled by default)
+#
+# Usage:
+#   gco jobs submit-sqs examples/gpu-job.yaml --region us-east-1
+#   gco jobs logs gpu-test-job -r us-east-1
+#
+# Docs: ../docs/CLI.md
 
 apiVersion: batch/v1
 kind: Job

--- a/examples/gpu-timeslicing-job.yaml
+++ b/examples/gpu-timeslicing-job.yaml
@@ -1,33 +1,30 @@
-# GPU Time-Slicing Example
+# GPU Time-Slicing Job Example
 #
-# This example shows how to run a job using a fractional (shared) GPU via
-# NVIDIA GPU time-slicing. Time-slicing lets multiple pods share a single
-# physical GPU by taking turns, similar to how a CPU handles multiple processes.
+# Runs a job on a fractional (shared) GPU via NVIDIA time-slicing — multiple
+# pods share a single physical GPU by taking turns. Good for lightweight
+# inference or dev/test where a full GPU per pod is wasteful.
 #
-# PREREQUISITES:
-#   Time-slicing must be enabled on the cluster. Apply the ConfigMap below
-#   to configure the NVIDIA device plugin to advertise multiple "replicas"
-#   per physical GPU. Each replica represents a time-slice that a pod can
-#   request. For example, replicas=4 means one physical GPU is exposed as
-#   4 schedulable nvidia.com/gpu units.
+# Prerequisites:
+#   - GPU nodepool (enabled by default)
+#   - NVIDIA device plugin configured for time-slicing. Apply the ConfigMap
+#     below, which advertises multiple `nvidia.com/gpu` replicas per physical
+#     GPU. For example, replicas=4 exposes one GPU as 4 schedulable units.
 #
-#   1. Apply the time-slicing ConfigMap:
-#
-#      kubectl apply -f - <<'EOF'
-#      apiVersion: v1
-#      kind: ConfigMap
-#      metadata:
-#        name: nvidia-device-plugin-config
-#        namespace: kube-system
-#      data:
-#        config.yaml: |
-#          version: v1
-#          sharing:
-#            timeSlicing:
-#              renameByDefault: false
-#              resources:
-#                - name: nvidia.com/gpu
-#                  replicas: 4
+#     kubectl apply -f - <<'EOF'
+#     apiVersion: v1
+#     kind: ConfigMap
+#     metadata:
+#       name: nvidia-device-plugin-config
+#       namespace: kube-system
+#     data:
+#       config.yaml: |
+#         version: v1
+#         sharing:
+#           timeSlicing:
+#             renameByDefault: false
+#             resources:
+#               - name: nvidia.com/gpu
+#                 replicas: 4
 #      EOF
 #
 #   2. Restart the NVIDIA device plugin to pick up the config:

--- a/examples/inference-sglang.yaml
+++ b/examples/inference-sglang.yaml
@@ -1,12 +1,20 @@
 # SGLang Inference Endpoint Example
-# Uses Phi-3.5-mini-instruct (ungated, no HF token required)
 #
-# Deploy with: gco inference deploy sglang-phi3 \
-#   -i lmsysorg/sglang:v0.5.10 \
-#   --gpu-count 1 --replicas 1 \
-#   -e MODEL=microsoft/Phi-3.5-mini-instruct
+# High-throughput LLM serving with RadixAttention. Deploys a Phi-3.5-mini
+# endpoint (ungated, no HF token required) reachable through the
+# authenticated API Gateway.
 #
-# Deploy with autoscaling:
+# Prerequisites:
+#   - GPU node
+#   - HF_TOKEN env var if switching to a gated model
+#
+# Usage (recommended, multi-region aware):
+#   gco inference deploy sglang-phi3 \
+#     -i lmsysorg/sglang:v0.5.10 \
+#     --gpu-count 1 --replicas 1 \
+#     -e MODEL=microsoft/Phi-3.5-mini-instruct
+#
+# Usage with autoscaling:
 #   gco inference deploy sglang-phi3 \
 #     -i lmsysorg/sglang:v0.5.10 \
 #     --gpu-count 1 --replicas 2 \
@@ -14,16 +22,15 @@
 #     --autoscale-metric cpu:70 --autoscale-metric memory:80 \
 #     -e MODEL=microsoft/Phi-3.5-mini-instruct
 #
-# Or deploy this manifest directly (single region):
+# Usage (single region, deploy this manifest directly):
 #   gco jobs submit-direct examples/inference-sglang.yaml -r us-east-1
 #
-# Test the endpoint (OpenAI-compatible):
+# Test the endpoint (SigV4-authenticated via API Gateway; OpenAI-compatible):
 #   curl https://<API-Gateway-endpoint>/inference/sglang-phi3/v1/completions \
 #     -H "Content-Type: application/json" \
 #     -d '{"model": "microsoft/Phi-3.5-mini-instruct", "prompt": "Hello", "max_tokens": 50}'
 #
-# For gated models (e.g. Llama), add HF_TOKEN env var:
-#   -e HF_TOKEN=hf_your_token_here
+# Docs: ../docs/INFERENCE.md
 
 apiVersion: apps/v1
 kind: Deployment

--- a/examples/inference-tgi.yaml
+++ b/examples/inference-tgi.yaml
@@ -1,17 +1,29 @@
 # Text Generation Inference (TGI) Endpoint Example
-# HuggingFace's optimized inference server for LLMs
 #
-# Deploy with: gco inference deploy tgi-mistral \
-#   -i ghcr.io/huggingface/text-generation-inference:3.3.7 \
-#   --gpu-count 1 --replicas 1 \
-#   -e MODEL_ID=mistralai/Mistral-7B-Instruct-v0.3 \
-#   -e MAX_INPUT_TOKENS=2048 \
-#   -e MAX_TOTAL_TOKENS=4096
+# HuggingFace's optimized LLM inference server. Deploys a Mistral 7B endpoint
+# reachable through the authenticated API Gateway.
 #
-# Test the endpoint:
-#   curl https://<GA-endpoint>/inference/tgi-mistral/generate \
+# Prerequisites:
+#   - GPU node with enough memory for the model (1x 24GB+ for Mistral-7B)
+#   - HF_TOKEN env var if the model is gated
+#
+# Usage (recommended, multi-region aware):
+#   gco inference deploy tgi-mistral \
+#     -i ghcr.io/huggingface/text-generation-inference:3.3.7 \
+#     --gpu-count 1 --replicas 1 \
+#     -e MODEL_ID=mistralai/Mistral-7B-Instruct-v0.3 \
+#     -e MAX_INPUT_TOKENS=2048 \
+#     -e MAX_TOTAL_TOKENS=4096
+#
+# Usage (single region, deploy this manifest directly):
+#   gco jobs submit-direct examples/inference-tgi.yaml -r us-east-1
+#
+# Test the endpoint (SigV4-authenticated via API Gateway; see docs/INFERENCE.md):
+#   curl https://<API-Gateway-endpoint>/inference/tgi-mistral/generate \
 #     -H "Content-Type: application/json" \
 #     -d '{"inputs": "What is deep learning?", "parameters": {"max_new_tokens": 100}}'
+#
+# Docs: ../docs/INFERENCE.md
 
 apiVersion: apps/v1
 kind: Deployment

--- a/examples/inference-torchserve.yaml
+++ b/examples/inference-torchserve.yaml
@@ -1,21 +1,32 @@
 # TorchServe Inference Endpoint Example
-# PyTorch's native model serving framework
 #
-# Deploy with: gco inference deploy torchserve-resnet \
-#   -i pytorch/torchserve:0.12.0-gpu \
-#   --gpu-count 1 --replicas 1 \
-#   --model-path /mnt/gco/models/torchserve \
-#   --health-path /ping \
-#   --port 8080
+# PyTorch's native model serving framework. Deploys a ResNet50 endpoint
+# reachable through the authenticated API Gateway.
 #
-# Pre-requisite: Package your model as a .mar file and upload to EFS:
-#   torch-model-archiver --model-name resnet50 \
-#     --version 1.0 --serialized-file model.pt \
-#     --handler image_classifier --export-path /mnt/gco/models/torchserve/model-store
+# Prerequisites:
+#   - GPU node
+#   - Model packaged as a .mar file on EFS:
+#       torch-model-archiver --model-name resnet50 \
+#         --version 1.0 --serialized-file model.pt \
+#         --handler image_classifier \
+#         --export-path /mnt/gco/models/torchserve/model-store
 #
-# Test the endpoint:
-#   curl https://<GA-endpoint>/inference/torchserve-resnet/predictions/resnet50 \
+# Usage (recommended, multi-region aware):
+#   gco inference deploy torchserve-resnet \
+#     -i pytorch/torchserve:0.12.0-gpu \
+#     --gpu-count 1 --replicas 1 \
+#     --model-path /mnt/gco/models/torchserve \
+#     --health-path /ping \
+#     --port 8080
+#
+# Usage (single region, deploy this manifest directly):
+#   gco jobs submit-direct examples/inference-torchserve.yaml -r us-east-1
+#
+# Test the endpoint (SigV4-authenticated via API Gateway; see docs/INFERENCE.md):
+#   curl https://<API-Gateway-endpoint>/inference/torchserve-resnet/predictions/resnet50 \
 #     -T image.jpg
+#
+# Docs: ../docs/INFERENCE.md
 
 apiVersion: apps/v1
 kind: Deployment

--- a/examples/inference-triton.yaml
+++ b/examples/inference-triton.yaml
@@ -1,14 +1,26 @@
 # NVIDIA Triton Inference Server Example
-# Supports multiple frameworks: TensorRT, ONNX, PyTorch, TensorFlow
 #
-# Deploy with: gco inference deploy triton-models \
-#   -i nvcr.io/nvidia/tritonserver:25.01-py3 \
-#   --gpu-count 1 --replicas 2 \
-#   --model-path /mnt/gco/models/triton-repo \
-#   --health-path /v2/health/ready
+# Multi-framework model serving (TensorRT, ONNX, PyTorch, TensorFlow).
+# Deploys a Triton endpoint reachable through the authenticated API Gateway.
 #
-# Test the endpoint:
-#   curl https://<GA-endpoint>/inference/triton-models/v2/models
+# Prerequisites:
+#   - GPU node
+#   - Model repository staged on EFS at /mnt/gco/models/triton-repo
+#
+# Usage (recommended, multi-region aware):
+#   gco inference deploy triton-models \
+#     -i nvcr.io/nvidia/tritonserver:25.01-py3 \
+#     --gpu-count 1 --replicas 2 \
+#     --model-path /mnt/gco/models/triton-repo \
+#     --health-path /v2/health/ready
+#
+# Usage (single region, deploy this manifest directly):
+#   gco jobs submit-direct examples/inference-triton.yaml -r us-east-1
+#
+# Test the endpoint (SigV4-authenticated via API Gateway; see docs/INFERENCE.md):
+#   curl https://<API-Gateway-endpoint>/inference/triton-models/v2/models
+#
+# Docs: ../docs/INFERENCE.md
 
 apiVersion: apps/v1
 kind: Deployment

--- a/examples/inference-vllm.yaml
+++ b/examples/inference-vllm.yaml
@@ -1,11 +1,20 @@
 # vLLM Inference Endpoint Example
-# Deploy with: gco inference deploy vllm-llama3 \
-#   -i vllm/vllm-openai:v0.20.1 \
-#   --gpu-count 1 --replicas 1 \
-#   -e MODEL=meta-llama/Llama-3.1-8B-Instruct \
-#   -e MAX_MODEL_LEN=4096
 #
-# Deploy with autoscaling:
+# OpenAI-compatible LLM serving with PagedAttention. Deploys a Llama 3.1 8B
+# endpoint reachable through the authenticated API Gateway.
+#
+# Prerequisites:
+#   - GPU node with enough memory for the model (1x 24GB+ for Llama-3.1-8B)
+#   - HF_TOKEN env var if the model is gated
+#
+# Usage (recommended, multi-region aware):
+#   gco inference deploy vllm-llama3 \
+#     -i vllm/vllm-openai:v0.20.1 \
+#     --gpu-count 1 --replicas 1 \
+#     -e MODEL=meta-llama/Llama-3.1-8B-Instruct \
+#     -e MAX_MODEL_LEN=4096
+#
+# Usage with autoscaling:
 #   gco inference deploy vllm-llama3 \
 #     -i vllm/vllm-openai:v0.20.1 \
 #     --gpu-count 1 --replicas 2 \
@@ -13,13 +22,15 @@
 #     --autoscale-metric cpu:70 --autoscale-metric memory:80 \
 #     -e MODEL=meta-llama/Llama-3.1-8B-Instruct
 #
-# Or deploy this manifest directly (single region):
+# Usage (single region, deploy this manifest directly):
 #   gco jobs submit-direct examples/inference-vllm.yaml -r us-east-1
 #
-# Test the endpoint:
-#   curl https://<GA-endpoint>/inference/vllm-llama3/v1/completions \
+# Test the endpoint (SigV4-authenticated via API Gateway; see docs/INFERENCE.md):
+#   curl https://<API-Gateway-endpoint>/inference/vllm-llama3/v1/completions \
 #     -H "Content-Type: application/json" \
 #     -d '{"model": "meta-llama/Llama-3.1-8B-Instruct", "prompt": "Hello", "max_tokens": 50}'
+#
+# Docs: ../docs/INFERENCE.md
 
 apiVersion: apps/v1
 kind: Deployment

--- a/examples/inferentia-job.yaml
+++ b/examples/inferentia-job.yaml
@@ -1,32 +1,26 @@
-# AWS Inferentia Inference Example
+# AWS Inferentia Job Example
 #
-# This example runs a job on an AWS Inferentia2 instance (inf2).
-# Inferentia is a purpose-built ML inference accelerator designed by AWS,
-# using the Neuron SDK. It's optimized for low-cost, high-throughput
-# inference workloads.
+# Runs a job on an AWS Inferentia2 (inf2) instance using the Neuron SDK.
+# Inferentia is a purpose-built, low-cost, high-throughput ML inference
+# accelerator. Pods request Neuron devices via aws.amazon.com/neuron and
+# Karpenter provisions inf2 nodes from the Neuron nodepool.
 #
-# HOW IT WORKS:
-#   Pods request Neuron devices via aws.amazon.com/neuron. The Neuron
-#   device plugin (installed via Helm chart) advertises these resources.
-#   Karpenter provisions inf2 instances from the Neuron nodepool when a
-#   pod requests Neuron devices and tolerates the taint.
+# Prerequisites:
+#   - Neuron device plugin (installed by default via Helm chart)
+#   - Neuron nodepool (manifests/44-nodepool-neuron.yaml, applied by default)
+#   - Container image built with the Neuron SDK (not CUDA)
 #
-# USAGE:
-#   gco jobs submit examples/inferentia-job.yaml --region us-east-1
+# Usage:
+#   gco jobs submit-direct examples/inferentia-job.yaml --region us-east-1
 #   gco jobs logs inferentia-test -r us-east-1
 #   gco jobs delete inferentia-test -r us-east-1
 #
-# PREREQUISITES:
-#   - Neuron device plugin (installed by default via Helm chart)
-#   - Neuron nodepool (manifests/44-nodepool-neuron.yaml, applied by default)
-#
-# INSTANCE TYPES:
-#   inf2.xlarge    — 1 Inferentia2 chip,  2 NeuronCores, 32 GB
-#   inf2.8xlarge   — 1 Inferentia2 chip,  2 NeuronCores, 32 GB
-#   inf2.24xlarge  — 6 Inferentia2 chips, 12 NeuronCores, 192 GB
-#   inf2.48xlarge  — 12 Inferentia2 chips, 24 NeuronCores, 384 GB
-#
-# NOTES:
+# Notes:
+#   - Instance types:
+#       inf2.xlarge    — 1 Inferentia2 chip,  2 NeuronCores,  32 GB
+#       inf2.8xlarge   — 1 Inferentia2 chip,  2 NeuronCores,  32 GB
+#       inf2.24xlarge  — 6 Inferentia2 chips, 12 NeuronCores, 192 GB
+#       inf2.48xlarge  — 12 Inferentia2 chips, 24 NeuronCores, 384 GB
 #   - Inferentia uses the Neuron SDK, not CUDA. Your container images must
 #     include the Neuron runtime. Use images from public.ecr.aws/neuron/.
 #   - inf2 instances are cost-optimized for inference — for training,

--- a/examples/keda-scaled-job.yaml
+++ b/examples/keda-scaled-job.yaml
@@ -1,18 +1,24 @@
 # KEDA ScaledJob Example — Custom SQS Consumer
 #
-# NOTE: GCO ships with a built-in SQS consumer (post-helm-sqs-consumer.yaml) that
-# automatically processes manifests submitted via `gco jobs submit-sqs`.
-# You do NOT need this example for basic SQS job submission.
+# A starting point for CUSTOM SQS-triggered workloads. NOT required for
+# basic SQS job submission — GCO ships with a built-in SQS consumer
+# (post-helm-sqs-consumer.yaml) that automatically processes manifests
+# submitted via `gco jobs submit-sqs`.
 #
-# Use this example as a starting point if you want to build a CUSTOM
-# SQS-triggered job — e.g., processing messages from your own queue,
-# running a different consumer logic, or scaling a different workload.
+# Use this example when you want to process messages from your own queue,
+# run different consumer logic, or scale a different workload on queue depth.
 #
 # Prerequisites:
-#   - KEDA must be installed (enabled by default in GCO)
-#   - GCO regional stack deployed (creates SQS queue automatically)
+#   - KEDA (enabled by default)
+#   - Regional stack deployed (creates the built-in SQS queue)
 #
-# Documentation: https://keda.sh/docs/latest/scalers/aws-sqs/
+# Usage:
+#   # Edit the manifest to set JOB_QUEUE_URL and REGION, then:
+#   kubectl apply -f examples/keda-scaled-job.yaml
+#
+# Docs:
+#   - KEDA SQS scaler: https://keda.sh/docs/latest/scalers/aws-sqs/
+#   - GCO guide: ../docs/KEDA.md
 
 ---
 # ScaledJob - scales job replicas based on regional SQS queue depth

--- a/examples/kueue-job.yaml
+++ b/examples/kueue-job.yaml
@@ -1,24 +1,23 @@
 # Kueue Job Queueing Example
-# This example demonstrates job queueing with quotas and fair-sharing
-# Jobs are queued and scheduled based on available cluster resources
+#
+# Demonstrates job queueing with resource quotas and fair-sharing. Creates a
+# ClusterQueue, LocalQueue, ResourceFlavors, and sample CPU + GPU jobs that
+# are queued and scheduled based on available cluster resources.
 #
 # Prerequisites:
-#   - Kueue must be installed (enabled by default in GCO)
+#   - Kueue (enabled by default)
 #
 # Usage:
-#   # First, create the ClusterQueue and LocalQueue
 #   kubectl apply -f examples/kueue-job.yaml
-#
-#   # Submit jobs (they will be queued if resources are limited)
+#   # Submit jobs (they will be queued if resources are limited):
 #   kubectl create job test-job-1 --image=python:3.14.4-slim -n gco-jobs -- sleep 60
 #   kubectl create job test-job-2 --image=python:3.14.4-slim -n gco-jobs -- sleep 60
-#
-#   # Check queue status
+#   # Inspect queue state:
 #   kubectl get clusterqueue
 #   kubectl get localqueue -n gco-jobs
 #   kubectl get workloads -n gco-jobs
 #
-# Documentation: https://kueue.sigs.k8s.io/docs/
+# Docs: ../docs/KUEUE.md
 
 ---
 # ResourceFlavor - defines the type of resources available

--- a/examples/megatrain-sft-job.yaml
+++ b/examples/megatrain-sft-job.yaml
@@ -1,58 +1,50 @@
 # MegaTrain SFT Training Job
-# Fine-tunes Qwen2.5-1.5B on the built-in alpaca demo dataset using MegaTrain.
-# MegaTrain stores parameters in CPU RAM and streams one layer at a time to the
-# GPU, enabling training of models larger than GPU memory on a single device.
 #
-# How it works:
-#   1. Init container downloads model weights to shared EFS (skipped if cached)
-#   2. Main container clones MegaTrain, installs it with CUDA extensions,
-#      then runs examples/sft/train.py against the downloaded model
-#
-# Notes from testing:
-#   - The devel image is required (not runtime) because MegaTrain builds a
-#     CUDA extension at install time
-#   - The trainer runs as root because conda's site-packages aren't writable
-#     as non-root in the PyTorch devel image
-#   - flash_attention_2 is installed at runtime and requires Ampere+ GPUs
-#     (i.e. A10G, L4, A100, H100, etc.) — T4/Turing GPUs are not supported
-#   - For larger models (7B+), increase memory requests and ensure the GPU
-#     nodepool includes instances with enough RAM (e.g., g5.12xlarge for 7B)
-#
-# ⚠️ Resource quota:
-#   This example REQUIRES raising the shipped per-manifest caps before
-#   submission. MegaTrain holds the full model in CPU RAM and materializes
-#   optimizer state lazily, so it needs more memory than the default 32Gi
-#   cap allows. Submission will fail with:
-#
-#     "Memory <N>Gi exceeds max 32Gi"
-#
-#   To raise the caps, edit the shared policy in cdk.json and redeploy
-#   (both the REST manifest processor and the SQS queue processor read
-#   from the same section):
-#
-#     context.job_validation_policy.resource_quotas.max_memory_per_manifest: "64Gi"
-#     context.job_validation_policy.resource_quotas.max_cpu_per_manifest:    "16"
-#
-#   The quota is summed across init + main containers, so a manifest with
-#   a 2Gi init + 48Gi trainer needs at least a 50Gi per-manifest cap.
-#
-# Why 48Gi:
-#   MegaTrain holds the full model in CPU RAM and materializes optimizer
-#   state lazily on the first backward pass. Observed peaks during the 5-step
-#   Qwen2.5-1.5B demo are ~19GB mid-step-1 but climb further between steps
-#   as optimizer state fully allocates. 28Gi was not enough in practice
-#   (OOMKilled between step 1 and step 2). 48Gi leaves comfortable headroom.
-#   Scale this up for larger models.
+# Fine-tunes Qwen2.5-1.5B on the built-in alpaca demo dataset using
+# MegaTrain, which stores parameters in CPU RAM and streams one layer at a
+# time to the GPU — letting you train models larger than GPU memory on a
+# single device.
 #
 # Prerequisites:
-#   - A GPU node with enough CPU RAM for the model (~20GB for 1.5B)
-#   - Shared storage (EFS) mounted via gco-shared-storage PVC
+#   - GPU node with enough CPU RAM for the model (~20 GB for 1.5B)
+#   - Shared EFS PVC (gco-shared-storage, default)
+#   - Raised per-manifest memory cap (default 32Gi is too small — see Notes)
 #
 # Usage:
 #   gco jobs submit-direct examples/megatrain-sft-job.yaml -r us-east-1
 #   gco jobs logs megatrain-sft -r us-east-1 -f
 #
-# To train a different model, change MODEL_NAME in both the init container
+# Notes:
+#   - The devel image is required (not runtime) because MegaTrain builds a
+#     CUDA extension at install time.
+#   - The trainer runs as root because conda's site-packages aren't
+#     writable as non-root in the PyTorch devel image.
+#   - flash_attention_2 is installed at runtime and requires Ampere+ GPUs
+#     (A10G, L4, A100, H100, …) — T4/Turing is not supported.
+#   - For larger models (7B+), raise memory requests and use an instance
+#     type with enough CPU RAM (e.g. g5.12xlarge for 7B).
+#
+#   - Quota caveat: MegaTrain holds the full model in CPU RAM and
+#     materializes optimizer state lazily, so it needs more memory than the
+#     default 32Gi per-manifest cap allows. Submission will fail with:
+#
+#       "Memory <N>Gi exceeds max 32Gi"
+#
+#     Raise the caps in cdk.json (both the REST manifest processor and the
+#     SQS queue processor read the same section) and redeploy:
+#
+#       context.job_validation_policy.resource_quotas.max_memory_per_manifest: "64Gi"
+#       context.job_validation_policy.resource_quotas.max_cpu_per_manifest:    "16"
+#
+#     The quota sums init + main containers, so 2Gi init + 48Gi trainer
+#     needs at least a 50Gi cap.
+#
+#   - Why 48Gi: observed peaks during the 5-step Qwen2.5-1.5B demo are
+#     ~19 GB mid-step-1 but climb further as optimizer state fully
+#     allocates. 28Gi OOMKilled between step 1 and step 2. 48Gi has
+#     comfortable headroom. Scale up for larger models.
+#
+#   - To train a different model, change MODEL_NAME in both the init container
 # and main container env vars.
 #
 # Reference: https://github.com/DLYuanGod/MegaTrain

--- a/examples/model-download-job.yaml
+++ b/examples/model-download-job.yaml
@@ -1,18 +1,26 @@
 # Model Download Job
-# Downloads model weights to shared EFS so inference endpoints can mount them.
-# This example downloads facebook/opt-125m (small, public, no token needed).
-# For gated models like Llama, uncomment the HF_TOKEN env var.
+#
+# Downloads model weights from HuggingFace to shared EFS so inference
+# endpoints can mount them instantly. Defaults to facebook/opt-125m
+# (small, public, no token needed) — change MODEL_ID for other models,
+# or uncomment HF_TOKEN for gated models.
+#
+# Prerequisites:
+#   - Shared EFS PVC (gco-shared-storage, default)
+#   - HF_TOKEN env var if the model is gated
 #
 # Usage:
 #   kubectl apply -f examples/model-download-job.yaml
-#
-# After completion, deploy inference with:
+#   # After completion, deploy inference with the cached model:
 #   gco inference deploy my-model \
 #     -i vllm/vllm-openai:v0.20.1 \
 #     --model-path /models/opt-125m
 #
-# To download from S3 instead of HuggingFace, change the command to:
-#   aws s3 sync s3://my-bucket/models/llama3 /mnt/gco/models/llama3
+# Notes:
+#   - To pull from S3 instead of HuggingFace, swap the command for:
+#       aws s3 sync s3://my-bucket/models/llama3 /mnt/gco/models/llama3
+#
+# Docs: ../docs/INFERENCE.md
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/examples/multi-gpu-training.yaml
+++ b/examples/multi-gpu-training.yaml
@@ -1,19 +1,23 @@
 # Multi-GPU Distributed Training Example
-# This example demonstrates distributed training across multiple GPUs
-# Uses PyTorch with DistributedDataParallel (DDP)
+#
+# Distributed training across multiple GPU pods using PyTorch
+# DistributedDataParallel (DDP). Uses indexed pods with a headless service
+# for DNS-based peer discovery.
 #
 # Prerequisites:
-#   - GPU nodes must be available
-#   - NVIDIA GPU Operator installed (enabled by default)
+#   - GPU nodes available
+#   - NVIDIA GPU Operator (enabled by default)
 #
 # Usage:
 #   kubectl apply -f examples/multi-gpu-training.yaml
 #   kubectl get pods -n gco-jobs -l job-name=pytorch-ddp-training
 #   kubectl logs -f job/pytorch-ddp-training -n gco-jobs
 #
-# For production training, mount EFS or FSx for checkpoints:
-#   - Add volumeMounts for /checkpoints
-#   - Use gco files download to retrieve results
+# Notes:
+#   - For production training, mount EFS or FSx for checkpoints and use
+#     `gco files download` to retrieve results.
+#
+# Docs: ../docs/INFERENCE.md
 
 apiVersion: batch/v1
 kind: Job

--- a/examples/pipeline-dag.yaml
+++ b/examples/pipeline-dag.yaml
@@ -1,15 +1,19 @@
-# Example DAG Pipeline
-# Run with: gco dag run examples/pipeline-dag.yaml -r us-east-1
-# Validate: gco dag validate examples/pipeline-dag.yaml
-# Dry run:  gco dag run examples/pipeline-dag.yaml --dry-run
+# DAG Pipeline Example
 #
-# This pipeline runs two steps in sequence:
-# 1. preprocess - Generates training data on shared EFS
-# 2. train - Reads preprocess output, trains a model, writes results
+# A multi-step pipeline with dependency ordering. Runs preprocess (generates
+# training data on shared EFS), then train (reads the output, produces model
+# artifacts). Steps only run after their dependencies complete successfully;
+# if preprocess fails, train is skipped.
 #
-# Each step uses the shared EFS volume at /mnt/shared to pass data.
-# Steps only run after their dependencies complete successfully.
-# If preprocess fails, train is automatically skipped.
+# Prerequisites:
+#   - Shared EFS PVC (gco-shared-storage, default)
+#
+# Usage:
+#   gco dag validate examples/pipeline-dag.yaml
+#   gco dag run examples/pipeline-dag.yaml --dry-run
+#   gco dag run examples/pipeline-dag.yaml -r us-east-1
+#
+# Docs: ../docs/CLI.md
 
 name: example-pipeline
 region: us-east-1

--- a/examples/ray-cluster.yaml
+++ b/examples/ray-cluster.yaml
@@ -1,26 +1,23 @@
-# KubeRay RayCluster Example
-# This example creates a Ray cluster for distributed computing
-# Supports distributed training, hyperparameter tuning, and model serving
+# Ray Cluster Example
+#
+# Creates a KubeRay RayCluster for distributed computing — training,
+# hyperparameter tuning, and Ray Serve. Includes a head node and an
+# auto-scaling CPU worker group (1-5 replicas).
 #
 # Prerequisites:
-#   - KubeRay operator must be installed (enabled by default in GCO)
+#   - KubeRay operator (enabled by default)
 #
 # Usage:
-#   # Create the Ray cluster
 #   kubectl apply -f examples/ray-cluster.yaml
-#
-#   # Wait for cluster to be ready
 #   kubectl get raycluster -n gco-jobs
 #   kubectl get pods -n gco-jobs -l ray.io/cluster=ray-cluster
-#
-#   # Port-forward to Ray dashboard
+#   # Port-forward to the Ray dashboard:
 #   kubectl port-forward svc/ray-cluster-head-svc 8265:8265 -n gco-jobs
-#   # Open http://localhost:8265 in browser
+#   # Submit a Ray job:
+#   ray job submit --address http://localhost:8265 -- \
+#     python -c "import ray; ray.init(); print(ray.cluster_resources())"
 #
-#   # Submit a Ray job
-#   ray job submit --address http://localhost:8265 -- python -c "import ray; ray.init(); print(ray.cluster_resources())"
-#
-# Documentation: https://docs.ray.io/en/latest/cluster/kubernetes/index.html
+# Docs: ../docs/KUBERAY.md
 
 apiVersion: ray.io/v1
 kind: RayCluster

--- a/examples/simple-job.yaml
+++ b/examples/simple-job.yaml
@@ -1,5 +1,17 @@
 # Simple Kubernetes Job Example
-# This job runs a simple command and completes
+#
+# A minimal job that prints a message, sleeps briefly, and exits. Useful for
+# verifying cluster connectivity and the submission path end-to-end.
+#
+# Prerequisites:
+#   - None
+#
+# Usage:
+#   gco jobs submit-sqs examples/simple-job.yaml --region us-east-1
+#   # or apply directly:
+#   kubectl apply -f examples/simple-job.yaml
+#
+# Docs: ../docs/CLI.md
 
 apiVersion: batch/v1
 kind: Job

--- a/examples/slurm-cluster-job.yaml
+++ b/examples/slurm-cluster-job.yaml
@@ -1,11 +1,13 @@
-# Slurm Job Example — Submit a batch job to the GCO Slurm cluster
+# Slurm Job Example
 #
-# This example generates a JWT token from the Slurm auth secret, submits
-# a batch job via the Slurm REST API, waits for completion, and prints
-# the result. Fully automated — works via kubectl or API Gateway.
+# Submits a batch job to the GCO-hosted Slurm cluster via the Slurm REST API.
+# Generates a JWT token from the Slurm auth secret, submits via sbatch, waits
+# for completion, and prints the output. Works from kubectl or the GCO API
+# Gateway (the Slurm REST API is reachable in-cluster, not from the Internet).
 #
 # Prerequisites:
-#   - Enable Slurm in cdk.json: "helm": { "slurm": { "enabled": true } }
+#   - Slurm enabled in cdk.json:
+#       "helm": { "slurm": { "enabled": true } }
 #   - Deploy: gco stacks deploy-all -y
 #   - Verify: kubectl get pods -n gco-jobs -l app.kubernetes.io/part-of=slurm
 #
@@ -13,11 +15,12 @@
 #   kubectl apply -f examples/slurm-cluster-job.yaml
 #   kubectl logs job/slurm-test -n gco-jobs -f
 #
-# For interactive Slurm access:
-#   kubectl exec -it -n gco-jobs deploy/slinky-slurm-controller -- bash
-#   sinfo && srun hostname && sbatch --wrap="echo Hello"
+# Notes:
+#   - For interactive Slurm access:
+#       kubectl exec -it -n gco-jobs deploy/slinky-slurm-controller -- bash
+#       sinfo && srun hostname && sbatch --wrap="echo Hello"
 #
-# Documentation: docs/SLURM_OPERATOR.md
+# Docs: ../docs/SLURM_OPERATOR.md
 
 apiVersion: batch/v1
 kind: Job

--- a/examples/sqs-job-submission.yaml
+++ b/examples/sqs-job-submission.yaml
@@ -1,23 +1,23 @@
 # SQS-Based Job Submission Example
 #
-# Submit Kubernetes manifests to the regional SQS queue for processing.
-# The built-in queue processor (KEDA ScaledJob) automatically picks up
-# messages and applies the manifests to the cluster.
+# Submits Kubernetes manifests to the regional SQS queue. The built-in
+# queue processor (KEDA ScaledJob) picks up messages and applies them to
+# the cluster. This is the recommended submission path: decoupled,
+# fault-tolerant (DLQ after 3 retries), auto-scaling, and priority-aware.
 #
-# This is the recommended submission method because:
-#   - Decoupled: submission returns immediately, processing happens async
-#   - Fault-tolerant: messages persist in SQS if processing fails (DLQ after 3 retries)
-#   - Auto-scaling: KEDA scales consumer pods based on queue depth
-#   - Priority support: higher-priority jobs can be processed first
-#
-# This file contains two examples:
+# Contains two jobs in one file:
 #   1. CPU job — simple Python training simulation
-#   2. GPU job — PyTorch GPU computation (requires GPU compute)
+#   2. GPU job — PyTorch GPU computation (requires a GPU node)
+#
+# Prerequisites:
+#   - Regional stack deployed (creates the SQS queue and built-in consumer)
 #
 # Usage:
 #   gco jobs submit-sqs examples/sqs-job-submission.yaml --region us-east-1
 #   gco jobs submit-sqs examples/sqs-job-submission.yaml --auto-region
 #   gco jobs submit-sqs examples/sqs-job-submission.yaml --priority 10
+#
+# Docs: ../docs/CLI.md
 
 ---
 apiVersion: batch/v1

--- a/examples/trainium-job.yaml
+++ b/examples/trainium-job.yaml
@@ -1,32 +1,26 @@
 # AWS Trainium Job Example
 #
-# This example runs a job on an AWS Trainium instance (trn1 or trn2).
-# Trainium is a purpose-built ML accelerator designed by AWS, using the
-# Neuron SDK instead of CUDA. It's optimized for training deep learning
-# models at a lower cost than GPU instances.
+# Runs a job on an AWS Trainium instance (trn1 or trn2) using the Neuron
+# SDK. Trainium is a purpose-built, lower-cost training accelerator. Pods
+# request Neuron devices via aws.amazon.com/neuron and Karpenter provisions
+# trn1/trn2 nodes from the Trainium nodepool.
 #
-# HOW IT WORKS:
-#   Pods request Neuron devices via aws.amazon.com/neuron. The Neuron
-#   device plugin (installed via Helm chart) advertises these resources.
-#   Karpenter provisions trn1/trn2 instances from the Trainium nodepool
-#   when a pod requests Neuron devices and tolerates the taints.
+# Prerequisites:
+#   - Neuron device plugin (installed by default via Helm chart)
+#   - Neuron nodepool (manifests/44-nodepool-neuron.yaml, applied by default)
+#   - Container image built with the Neuron SDK (not CUDA)
 #
-# USAGE:
-#   gco jobs submit examples/trainium-job.yaml --region us-east-1
+# Usage:
+#   gco jobs submit-direct examples/trainium-job.yaml --region us-east-1
 #   gco jobs logs trainium-test -r us-east-1
 #   gco jobs delete trainium-test -r us-east-1
 #
-# PREREQUISITES:
-#   - Neuron device plugin (installed by default via Helm chart)
-#   - Neuron nodepool (manifests/44-nodepool-neuron.yaml, applied by default)
-#
-# INSTANCE TYPES:
-#   trn1.2xlarge   — 1 Trainium chip,  2 NeuronCores, 32 GB
-#   trn1.32xlarge  — 16 Trainium chips, 32 NeuronCores, 512 GB (800 Gbps EFA)
-#   trn2.3xlarge   — 1 Trainium2 chip,  8 NeuronCores, 96 GB
-#   trn2.48xlarge  — 16 Trainium2 chips, 128 NeuronCores, 1.5 TB (3.2 Tbps EFA)
-#
-# NOTES:
+# Notes:
+#   - Instance types:
+#       trn1.2xlarge   — 1  Trainium  chip,   2 NeuronCores,  32 GB
+#       trn1.32xlarge  — 16 Trainium  chips, 32 NeuronCores, 512 GB (800 Gbps EFA)
+#       trn2.3xlarge   — 1  Trainium2 chip,   8 NeuronCores,  96 GB
+#       trn2.48xlarge  — 16 Trainium2 chips, 128 NeuronCores, 1.5 TB (3.2 Tbps EFA)
 #   - Trainium uses the Neuron SDK, not CUDA. Your container images must
 #     include the Neuron runtime. Use images from public.ecr.aws/neuron/.
 #   - For distributed training across multiple nodes, use EFA with the

--- a/examples/valkey-cache-job.yaml
+++ b/examples/valkey-cache-job.yaml
@@ -1,13 +1,18 @@
-# Valkey Cache Example Job
-# Demonstrates connecting to the regional Valkey Serverless cache
-# for K/V caching, session state, or feature stores.
+# Valkey Cache Job Example
 #
-# The Valkey endpoint is injected automatically via the gco-valkey
-# ConfigMap — no need to look up or hardcode endpoint URLs.
-# The same manifest works in any region.
+# Connects to the regional Valkey Serverless cache for K/V caching, session
+# state, or feature stores. The Valkey endpoint is injected via the
+# gco-valkey ConfigMap — no hardcoded endpoint URLs. The same manifest
+# works in any region.
 #
-# Submit with:
+# Prerequisites:
+#   - valkey.enabled = true in cdk.json
+#   - Regional stack deployed with Valkey enabled
+#
+# Usage:
 #   gco jobs submit-direct examples/valkey-cache-job.yaml -r us-east-1
+#
+# Docs: ../docs/CUSTOMIZATION.md#configure-valkey-cache
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/examples/volcano-gang-job.yaml
+++ b/examples/volcano-gang-job.yaml
@@ -1,16 +1,18 @@
 # Volcano Gang Scheduling Example
-# This example demonstrates gang scheduling for distributed training
-# All pods in the job must be scheduled together or none at all
+#
+# Demonstrates gang scheduling for distributed training — all pods in the job
+# must be scheduled together or none at all. Creates a master + 2 workers
+# with automatic restart policies.
 #
 # Prerequisites:
-#   - Volcano must be installed (enabled by default in GCO)
+#   - Volcano (enabled by default)
 #
 # Usage:
 #   kubectl apply -f examples/volcano-gang-job.yaml
 #   kubectl get vcjob -n gco-jobs
 #   kubectl get pods -n gco-jobs -l volcano.sh/job-name=distributed-training
 #
-# Documentation: https://volcano.sh/en/docs/
+# Docs: ../docs/VOLCANO.md
 
 ---
 # Volcano Job with gang scheduling

--- a/examples/yunikorn-job.yaml
+++ b/examples/yunikorn-job.yaml
@@ -1,29 +1,24 @@
-# Apache YuniKorn Scheduling Example
-# Demonstrates app-aware scheduling with hierarchical queues and resource quotas.
-# YuniKorn provides fair-sharing, preemption, and gang scheduling for multi-tenant
-# AI/ML clusters.
+# YuniKorn Hierarchical Queues Example
+#
+# Demonstrates Apache YuniKorn's app-aware scheduling with hierarchical
+# queues, resource quotas, gang scheduling, and GPU queue placement. Useful
+# for multi-tenant clusters where teams need fair-sharing and preemption.
 #
 # Prerequisites:
-#   1. YuniKorn is opt-in. Enable it in cdk.json:
-#        "helm": { "yunikorn": { "enabled": true } }
-#   2. Deploy: gco stacks deploy-all -y
+#   - YuniKorn is opt-in. Enable in cdk.json:
+#       "helm": { "yunikorn": { "enabled": true } }
+#   - Deploy: gco stacks deploy-all -y
 #
 # Usage:
 #   kubectl apply -f examples/yunikorn-job.yaml
-#
-#   # Check queue status via YuniKorn REST API
+#   # Inspect queue state via the YuniKorn REST API:
 #   kubectl port-forward svc/yunikorn-service -n yunikorn 9889:9889
 #   curl http://localhost:9889/ws/v1/queues
-#
-#   # Check application status
 #   curl http://localhost:9889/ws/v1/apps
-#
-#   # Monitor pods
+#   # Monitor pods:
 #   kubectl get pods -n gco-jobs -l app=yunikorn-demo -w
 #
-# Documentation:
-#   - YuniKorn: https://yunikorn.apache.org/docs/
-#   - GCO guide: docs/YUNIKORN.md
+# Docs: ../docs/YUNIKORN.md
 
 ---
 # Job using YuniKorn scheduling with queue placement


### PR DESCRIPTION
The inference-{tgi,triton,torchserve,vllm}.yaml manifests were telling users to curl https://<GA-endpoint>/inference/... directly. The Global Accelerator is internal — requests must go through the authenticated API Gateway, which adds the SigV4 layer and proxies to GA. Updated to use <API-Gateway-endpoint> to match inference-sglang.yaml.

Also standardized the comment header across every example:

  # <Title>
  #
  # <1-3 sentence summary>
  #
  # Prerequisites:
  #   - ...
  #
  # Usage:
  #   <exact command>
  #
  # Notes:            (optional)
  # Docs: ../docs/<FILE>.md   (verified to exist; Aurora/Valkey/FSx
  #                            redirect to CUSTOMIZATION.md anchors)

Verified: yamllint clean; tests/test_analytics_examples_validation.py and tests/test_dag.py pass (45/45).

<!--
Thanks for contributing to GCO! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [ ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
