### PR TITLE
Analytics-stack destroy hardening + deps-scan EKS version check

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -241,14 +241,20 @@ To turn the check on without introducing long-lived access keys, configure a Git
    }
    ```
 
-3. **Attach a single-permission inline policy** (principle of least privilege — the scan needs exactly one API call):
+3. **Attach a least-privilege inline policy** listing only the read-only actions the scan needs. Keep this in sync with `.github/oidc_provider/policy.json` when you add new checks:
 
    ```json
    {
      "Version": "2012-10-17",
      "Statement": [{
        "Effect":   "Allow",
-       "Action":   "eks:DescribeAddonVersions",
+       "Action": [
+         "eks:DescribeAddonVersions",
+         "eks:DescribeClusterVersions",
+         "elasticmapreduce:ListReleaseLabels",
+         "rds:DescribeDBEngineVersions",
+         "sts:GetCallerIdentity"
+       ],
        "Resource": "*"
      }]
    }

--- a/.github/oidc_provider/README.md
+++ b/.github/oidc_provider/README.md
@@ -29,7 +29,7 @@ This stack is **standalone** — it does not depend on or affect the main GCO in
 
 1. **IAM OIDC Identity Provider** — trusts `token.actions.githubusercontent.com` (the GitHub OIDC issuer). Skipped if one already exists in the account.
 2. **IAM Role** — assumable only by GitHub Actions workflows from your repository. The trust policy restricts access to a specific GitHub org/repo.
-3. **IAM Policy** — attached to the role. By default grants read-only permissions needed for the dependency scan workflow (`eks:DescribeAddonVersions`, `elasticmapreduce:ListReleaseLabels`, `rds:DescribeDBEngineVersions`). You can expand this for your own needs.
+3. **IAM Policy** — attached to the role. By default grants read-only permissions needed for the dependency scan workflow (`eks:DescribeAddonVersions`, `eks:DescribeClusterVersions`, `elasticmapreduce:ListReleaseLabels`, `rds:DescribeDBEngineVersions`). You can expand this for your own needs.
 
 ## Prerequisites
 
@@ -66,6 +66,7 @@ The default policy in `policy.json` grants minimal read-only permissions for the
       "Effect": "Allow",
       "Action": [
         "eks:DescribeAddonVersions",
+        "eks:DescribeClusterVersions",
         "elasticmapreduce:ListReleaseLabels",
         "rds:DescribeDBEngineVersions",
         "sts:GetCallerIdentity"

--- a/.github/oidc_provider/policy.json
+++ b/.github/oidc_provider/policy.json
@@ -6,6 +6,7 @@
       "Effect": "Allow",
       "Action": [
         "eks:DescribeAddonVersions",
+        "eks:DescribeClusterVersions",
         "elasticmapreduce:ListReleaseLabels",
         "rds:DescribeDBEngineVersions",
         "sts:GetCallerIdentity"

--- a/.github/scripts/dependency-scan.sh
+++ b/.github/scripts/dependency-scan.sh
@@ -12,6 +12,7 @@
 #     and Helm chart values
 #   - Helm chart versions from charts.yaml
 #   - EKS add-on versions from gco/stacks/constants.py (AWS creds)
+#   - EKS Kubernetes minor from cdk.json (AWS creds)
 #   - Aurora PostgreSQL engine versions (AWS creds)
 #   - EMR Serverless release labels (AWS creds)
 #   - Dockerfile.dev ARG pins (Node LTS major, CDK CLI, kubectl, AWS CLI v2,
@@ -253,6 +254,85 @@ fi
 
 ADDON_COUNT="$(wc -l < "$ADDON_RESULTS" 2>/dev/null | tr -d ' ')"
 [ -z "$ADDON_COUNT" ] && ADDON_COUNT=0
+
+# ---------------------------------------------------------------------------
+# EKS Kubernetes version (best-effort — requires AWS credentials)
+#
+# Compares ``kubernetes_version`` in cdk.json against the latest minor
+# available from ``aws eks describe-cluster-versions`` (filtered to
+# ``STANDARD_SUPPORT``). If a newer minor is available, we also report
+# when standard support for the currently-pinned minor ends so the
+# upgrade urgency is visible in the PR.
+#
+# IAM action: ``eks:DescribeClusterVersions``. Same credential preflight
+# as the EKS add-on / Aurora / EMR checks.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Checking EKS Kubernetes version ==="
+
+EKS_K8S_RESULTS="$(mktemp)"
+EKS_K8S_SKIP_REASON=""
+
+if ! aws sts get-caller-identity >/dev/null 2>&1; then
+  EKS_K8S_SKIP_REASON="No AWS credentials available (scan needs eks:DescribeClusterVersions). Configure OIDC to enable."
+  echo "  $EKS_K8S_SKIP_REASON"
+else
+  # ``--include-all`` returns every cluster version, not just the
+  # default. ``--version-status STANDARD_SUPPORT`` filters to minors
+  # still in standard support — we don't want to flag the extended-
+  # support lifecycle as "newer."
+  CLUSTER_VERSIONS_JSON="$(aws eks describe-cluster-versions \
+    --include-all \
+    --version-status STANDARD_SUPPORT \
+    --output json 2>/dev/null)" || CLUSTER_VERSIONS_JSON=""
+
+  if [ -n "$CLUSTER_VERSIONS_JSON" ]; then
+    # Max of ``clusterVersion`` across all rows is the newest standard-
+    # support minor. We use Python for a proper numeric sort so 1.10
+    # beats 1.9 (sort -V already does this, but Python keeps the data
+    # wrangling in one place).
+    LATEST_K8S="$(echo "$CLUSTER_VERSIONS_JSON" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+versions = sorted(
+    {row["clusterVersion"] for row in data.get("clusterVersions", [])},
+    key=lambda v: tuple(int(p) for p in v.split(".")),
+)
+print(versions[-1] if versions else "")
+' 2>/dev/null)" || LATEST_K8S=""
+
+    CURRENT_K8S="$(extract_k8s_version "cdk.json")"
+
+    if [ -n "$LATEST_K8S" ] && [ "$CURRENT_K8S" != "$LATEST_K8S" ] \
+       && [ "$(compare_semver "$CURRENT_K8S" "$LATEST_K8S")" = "newer" ]; then
+      # Grab the standard-support end date for the currently-pinned
+      # minor. Blank when EKS hasn't published one yet (brand-new release).
+      EOS_DATE="$(echo "$CLUSTER_VERSIONS_JSON" | python3 -c "
+import json, sys
+cv = sys.argv[1]
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for row in data.get('clusterVersions', []):
+    if row.get('clusterVersion') == cv:
+        ts = row.get('endOfStandardSupportDate', '')
+        # Strip time-of-day; the date is what the report cares about.
+        print(str(ts).split('T', 1)[0].split(' ', 1)[0])
+        break
+" "$CURRENT_K8S" 2>/dev/null)" || EOS_DATE=""
+
+      echo "  - kubernetes_version: ${CURRENT_K8S} -> ${LATEST_K8S} (std support ends ${EOS_DATE:-unknown})"
+      echo "kubernetes_version|${CURRENT_K8S}|${LATEST_K8S}|${EOS_DATE:-unknown}" >> "$EKS_K8S_RESULTS"
+    fi
+  fi
+fi
+
+EKS_K8S_COUNT="$(wc -l < "$EKS_K8S_RESULTS" 2>/dev/null | tr -d ' ')"
+[ -z "$EKS_K8S_COUNT" ] && EKS_K8S_COUNT=0
 
 # ---------------------------------------------------------------------------
 # Aurora PostgreSQL engine versions (best-effort — requires AWS credentials)
@@ -497,6 +577,11 @@ if [ -n "$ADDON_SKIP_REASON" ]; then
 else
   echo "EKS add-ons outdated:     $ADDON_COUNT"
 fi
+if [ -n "$EKS_K8S_SKIP_REASON" ]; then
+  echo "EKS Kubernetes version:   (skipped)"
+else
+  echo "EKS Kubernetes version:   $EKS_K8S_COUNT"
+fi
 if [ -n "$AURORA_SKIP_REASON" ]; then
   echo "Aurora PostgreSQL:        (skipped)"
 else
@@ -511,12 +596,17 @@ echo "Dockerfile.dev pins:      $DOCKERFILE_COUNT"
 
 if [ "$PYTHON_COUNT" -eq 0 ] && [ "$DOCKER_COUNT" -eq 0 ] \
    && [ "$HELM_COUNT" -eq 0 ] && [ "$ADDON_COUNT" -eq 0 ] \
+   && [ "$EKS_K8S_COUNT" -eq 0 ] \
    && [ "$AURORA_COUNT" -eq 0 ] && [ "$EMR_COUNT" -eq 0 ] \
    && [ "$DOCKERFILE_COUNT" -eq 0 ]; then
   echo ""
   SKIP_NOTES=""
   if [ -n "$ADDON_SKIP_REASON" ]; then
     SKIP_NOTES="EKS add-ons skipped: $ADDON_SKIP_REASON"
+  fi
+  if [ -n "$EKS_K8S_SKIP_REASON" ]; then
+    [ -n "$SKIP_NOTES" ] && SKIP_NOTES="$SKIP_NOTES; "
+    SKIP_NOTES="${SKIP_NOTES}EKS Kubernetes skipped: $EKS_K8S_SKIP_REASON"
   fi
   if [ -n "$AURORA_SKIP_REASON" ]; then
     [ -n "$SKIP_NOTES" ] && SKIP_NOTES="$SKIP_NOTES; "
@@ -531,7 +621,7 @@ if [ "$PYTHON_COUNT" -eq 0 ] && [ "$DOCKER_COUNT" -eq 0 ] \
   else
     echo "All dependencies are up to date."
   fi
-  rm -f "$DOCKER_RESULTS" "$HELM_RESULTS" "$ADDON_RESULTS" "$AURORA_RESULTS" "$EMR_RESULTS" "$DOCKERFILE_RESULTS"
+  rm -f "$DOCKER_RESULTS" "$HELM_RESULTS" "$ADDON_RESULTS" "$EKS_K8S_RESULTS" "$AURORA_RESULTS" "$EMR_RESULTS" "$DOCKERFILE_RESULTS"
   if [ -n "${GITHUB_OUTPUT:-}" ]; then
     echo "has_drift=false" >> "$GITHUB_OUTPUT"
   fi
@@ -588,6 +678,29 @@ fi
     echo "## EKS Add-ons (skipped)"
     echo ""
     echo "> $ADDON_SKIP_REASON"
+    echo ""
+  fi
+
+  if [ "$EKS_K8S_COUNT" -gt 0 ]; then
+    echo "## EKS Kubernetes Version"
+    echo ""
+    echo "The Kubernetes minor pinned in \`cdk.json::kubernetes_version\`"
+    echo "is behind the latest release still in EKS **standard support**."
+    echo "Upgrade before standard support ends to avoid the extended-"
+    echo "support pricing uplift."
+    echo ""
+    echo "| Pin | Current | Latest (standard support) | Std support ends |"
+    echo "|-----|---------|---------------------------|------------------|"
+    while IFS='|' read -r pin cur lat eos; do
+      echo "| \`$pin\` | $cur | $lat | $eos |"
+    done < "$EKS_K8S_RESULTS"
+    echo ""
+  fi
+
+  if [ -n "$EKS_K8S_SKIP_REASON" ]; then
+    echo "## EKS Kubernetes Version (skipped)"
+    echo ""
+    echo "> $EKS_K8S_SKIP_REASON"
     echo ""
   fi
 
@@ -652,7 +765,7 @@ fi
   echo "_Automatically created by the \`deps-scan\` workflow._"
 } > "$REPORT_FILE"
 
-rm -f "$DOCKER_RESULTS" "$HELM_RESULTS" "$ADDON_RESULTS" "$AURORA_RESULTS" "$EMR_RESULTS" "$DOCKERFILE_RESULTS"
+rm -f "$DOCKER_RESULTS" "$HELM_RESULTS" "$ADDON_RESULTS" "$EKS_K8S_RESULTS" "$AURORA_RESULTS" "$EMR_RESULTS" "$DOCKERFILE_RESULTS"
 
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   echo "has_drift=true"            >> "$GITHUB_OUTPUT"

--- a/cli/stacks.py
+++ b/cli/stacks.py
@@ -740,7 +740,16 @@ class StackManager:
         # with consumed exports. To break the dependency, redeploy the API
         # gateway with analytics disabled first, then destroy analytics.
         if stack_name and not all_stacks and "analytics" in stack_name:
-            self._remove_api_gateway_analytics_dependency()
+            safe_to_destroy = self._remove_api_gateway_analytics_dependency()
+            if not safe_to_destroy:
+                # Restore analytics toggle before bailing out.
+                if toggle_restored:
+                    self._restore_analytics_disabled()
+                print(
+                    "  Aborting gco-analytics destroy: gco-api-gateway still "
+                    "imports analytics exports. Fix the API gateway and retry."
+                )
+                return False
 
         cmd = ["destroy"]
 
@@ -841,7 +850,7 @@ class StackManager:
                 exc_info=True,
             )
 
-    def _remove_api_gateway_analytics_dependency(self) -> None:
+    def _remove_api_gateway_analytics_dependency(self) -> bool:
         """Redeploy gco-api-gateway with analytics disabled to drop cross-stack imports.
 
         The analytics stack exports values (Cognito pool ARN, presigned-URL
@@ -850,7 +859,33 @@ class StackManager:
         disabling analytics and redeploying the API gateway, the /studio/*
         routes are removed and the imports are dropped, unblocking the
         analytics stack deletion.
+
+        Returns:
+            True if the analytics stack is safe to destroy (either because
+            no consumer remains or because the redeploy successfully
+            dropped the imports). False if a consumer of the analytics
+            exports still exists and the analytics destroy will fail.
         """
+        # Fast path: if gco-api-gateway doesn't exist (or has already been
+        # deleted/rolled-back into a non-consuming state), there's nothing
+        # importing the analytics exports. Skip the redeploy entirely.
+        if not self._stack_exists_in_cloudformation("gco-api-gateway"):
+            logger.info(
+                "gco-api-gateway does not exist in CloudFormation; "
+                "skipping redeploy before analytics destroy."
+            )
+            return True
+
+        # Second fast path: if the deployed api-gateway isn't actually
+        # importing anything from the analytics stack, we don't need to
+        # touch it. This happens when analytics was never fully wired up.
+        if not self._api_gateway_imports_from_analytics():
+            logger.info(
+                "gco-api-gateway does not import any gco-analytics exports; "
+                "skipping redeploy before analytics destroy."
+            )
+            return True
+
         try:
             # Temporarily disable analytics so CDK drops the /studio/* routes.
             current = get_analytics_config()
@@ -868,19 +903,105 @@ class StackManager:
                     exclusively=True,
                     output_dir=tmp_out,
                 )
-            if not success:
-                logger.warning("Failed to redeploy gco-api-gateway before analytics destroy")
 
             # Re-enable analytics so CDK can synthesize the analytics stack
             # for the destroy operation (custom resources need to fire).
             if was_enabled:
                 update_analytics_config({"enabled": True})
+
+            if not success:
+                # The redeploy failed. That's only a real problem if the
+                # api-gateway still imports analytics exports. Recheck:
+                # the auto-cleanup of ROLLBACK_COMPLETE stacks may have
+                # deleted the consumer entirely, in which case the destroy
+                # can still proceed.
+                if not self._api_gateway_imports_from_analytics():
+                    logger.info(
+                        "gco-api-gateway redeploy failed, but the stack no "
+                        "longer imports analytics exports (likely deleted "
+                        "during cleanup). Analytics destroy can proceed."
+                    )
+                    return True
+                logger.error(
+                    "Failed to redeploy gco-api-gateway to drop analytics "
+                    "imports, and the stack still consumes analytics exports. "
+                    "Destroying gco-analytics will fail with "
+                    "'Export ... cannot be deleted as it is in use'. Fix "
+                    "gco-api-gateway first (see events above) and retry."
+                )
+                return False
+
+            return True
         except Exception as exc:
             logger.warning(
                 "Failed to remove API gateway analytics dependency: %s",
                 exc,
                 exc_info=True,
             )
+            # On unexpected exceptions, recheck whether imports remain.
+            # Be permissive only if we can confirm the destroy is safe.
+            try:
+                return not self._api_gateway_imports_from_analytics()
+            except Exception:
+                return False
+
+    def _api_gateway_imports_from_analytics(self) -> bool:
+        """Return True if gco-api-gateway imports any exports from gco-analytics.
+
+        Uses CloudFormation's ``list_exports`` + ``list_imports`` to detect
+        cross-stack references at runtime. This is more reliable than
+        inspecting the CDK app because it reflects what's actually
+        deployed.
+        """
+        import boto3
+
+        region = self._get_deploy_region("gco-analytics")
+        if not region:
+            return False
+
+        try:
+            cfn = boto3.client("cloudformation", region_name=region)
+            # Collect every export whose owning stack is gco-analytics.
+            analytics_exports: list[str] = []
+            paginator = cfn.get_paginator("list_exports")
+            for page in paginator.paginate():
+                for export in page.get("Exports", []):
+                    owner = export.get("ExportingStackId", "")
+                    # ExportingStackId is a full ARN; match by stack name.
+                    if ":stack/gco-analytics/" in owner:
+                        analytics_exports.append(export["Name"])
+
+            if not analytics_exports:
+                return False
+
+            # For each export, check whether gco-api-gateway is listed
+            # as an importer. ``list_imports`` returns the stack names
+            # that currently import the given export.
+            import_paginator = cfn.get_paginator("list_imports")
+            for export_name in analytics_exports:
+                try:
+                    for page in import_paginator.paginate(ExportName=export_name):
+                        for importer in page.get("Imports", []):
+                            if importer == "gco-api-gateway":
+                                return True
+                except Exception as exc:
+                    # ``list_imports`` raises when an export has zero
+                    # consumers — treat that as "not imported" and move on.
+                    logger.debug(
+                        "list_imports(%s) failed (likely no consumers): %s",
+                        export_name,
+                        exc,
+                    )
+            return False
+        except Exception as exc:
+            logger.debug(
+                "Failed to check analytics imports for gco-api-gateway: %s",
+                exc,
+                exc_info=True,
+            )
+            # On failure to check, err on the side of attempting the
+            # redeploy so we don't skip necessary cleanup.
+            return True
 
     def bootstrap(
         self,

--- a/gco/stacks/analytics_stack.py
+++ b/gco/stacks/analytics_stack.py
@@ -794,7 +794,13 @@ class GCOAnalyticsStack(Stack):
             runtime=getattr(lambda_.Runtime, LAMBDA_PYTHON_RUNTIME),
             handler="handler.handler",
             code=lambda_.Code.from_asset("lambda/analytics-cleanup"),
-            timeout=Duration.minutes(5),
+            # 15 minutes covers the worst case of multiple async drain
+            # loops in series: apps (up to ~2 min), spaces (up to ~3 min),
+            # user profiles (up to ~3 min), SageMaker-managed EFS mount
+            # targets (up to ~2 min), plus incidental RPC latency and
+            # security-group cleanup. In the common case (a handful of
+            # users) this finishes in well under a minute.
+            timeout=Duration.minutes(15),
             environment={
                 "DOMAIN_ID": self.studio_domain.attr_domain_id,
                 "EFS_ID": self.studio_efs.file_system_id,

--- a/lambda/analytics-cleanup/handler.py
+++ b/lambda/analytics-cleanup/handler.py
@@ -313,10 +313,7 @@ def _delete_user_profiles(region: str, domain_id: str) -> list[str]:
             )
             time.sleep(DRAIN_POLL_INTERVAL_SECONDS)
         else:
-            msg = (
-                f"Timed out waiting for user profiles to delete in "
-                f"{domain_id}: {remaining}"
-            )
+            msg = f"Timed out waiting for user profiles to delete in " f"{domain_id}: {remaining}"
             logger.error(msg)
             errors.append(msg)
     except ClientError as e:

--- a/lambda/analytics-cleanup/handler.py
+++ b/lambda/analytics-cleanup/handler.py
@@ -1,9 +1,14 @@
 """Analytics stack cleanup handler.
 
 Runs as a CloudFormation custom resource on stack deletion. Removes all
-SageMaker user profiles from the Studio domain and all EFS access points
-from the Studio file system so CloudFormation can delete the domain and
-EFS cleanly.
+SageMaker apps, spaces and user profiles from the Studio domain (waiting
+for each to fully drain) and all EFS access points from the Studio file
+system so CloudFormation can delete the domain and EFS cleanly.
+
+If draining apps/spaces/user-profiles fails, the handler raises — this
+fails the custom resource and stops CloudFormation before it tries (and
+fails) to delete the domain. EFS/security-group cleanup errors are
+logged but non-fatal.
 
 Environment variables:
     DOMAIN_ID: SageMaker Studio domain ID
@@ -39,15 +44,28 @@ def handler(event: dict, context: object) -> dict:
     vpc_id = os.environ.get("VPC_ID", "")
 
     errors: list[str] = []
+    # Errors from deleting apps/spaces/user-profiles block the domain
+    # delete — if we return SUCCESS with these still present, CloudFormation
+    # will immediately fail on ``AWS::SageMaker::Domain`` with a
+    # ``Unable to delete Domain ... because UserProfile(s) are associated
+    # with it`` error. We track these separately so we can fail the custom
+    # resource and give the operator a useful log pointer instead.
+    critical_errors: list[str] = []
 
     # Delete all apps (must be deleted before spaces/profiles)
-    errors.extend(_delete_apps(region, domain_id))
+    app_errors = _delete_apps(region, domain_id)
+    errors.extend(app_errors)
+    critical_errors.extend(app_errors)
 
     # Delete all spaces
-    errors.extend(_delete_spaces(region, domain_id))
+    space_errors = _delete_spaces(region, domain_id)
+    errors.extend(space_errors)
+    critical_errors.extend(space_errors)
 
     # Delete all user profiles from the domain
-    errors.extend(_delete_user_profiles(region, domain_id))
+    profile_errors = _delete_user_profiles(region, domain_id)
+    errors.extend(profile_errors)
+    critical_errors.extend(profile_errors)
 
     # Remove EFS resource policies that trigger the intersection
     # authorization model. Both the CDK-managed EFS and the SageMaker-
@@ -70,8 +88,19 @@ def handler(event: dict, context: object) -> dict:
     else:
         logger.info("Cleanup completed successfully")
 
-    # Always return SUCCESS so CloudFormation can proceed with deletion.
-    # Failing here would block the entire stack destroy.
+    # If apps/spaces/user-profiles still have unresolved errors, fail the
+    # custom resource. CloudFormation will stop before attempting to
+    # delete the domain, surface the error to the operator, and the stack
+    # stays in a retriable state. EFS/security-group errors are logged
+    # but non-fatal — they don't block the domain delete and are cleaned
+    # up best-effort on the next attempt.
+    if critical_errors:
+        raise RuntimeError(
+            "Analytics cleanup failed to fully drain the SageMaker domain "
+            f"({len(critical_errors)} error(s)). See CloudWatch Logs for "
+            f"details: {critical_errors}"
+        )
+
     return {"Status": "SUCCESS", "PhysicalResourceId": physical_id}
 
 
@@ -129,7 +158,13 @@ def _delete_apps(region: str, domain_id: str) -> list[str]:
 
 
 def _delete_spaces(region: str, domain_id: str) -> list[str]:
-    """Delete all spaces in the domain. Spaces must be deleted before profiles."""
+    """Delete all spaces in the domain and wait for them to be gone.
+
+    Spaces must be fully removed before user profiles can be deleted, and
+    user profiles must be fully removed before the domain can be deleted.
+    ``delete_space`` is asynchronous, so after issuing the deletes we poll
+    ``list_spaces`` until it returns empty (or a timeout elapses).
+    """
     errors: list[str] = []
     sm = boto3.client("sagemaker", region_name=region)
 
@@ -138,6 +173,10 @@ def _delete_spaces(region: str, domain_id: str) -> list[str]:
         for page in paginator.paginate(DomainIdEquals=domain_id):
             for space in page.get("Spaces", []):
                 space_name = space["SpaceName"]
+                # Skip spaces already being deleted; the wait loop below
+                # will still account for them.
+                if space.get("Status") == "Deleting":
+                    continue
                 try:
                     sm.delete_space(DomainId=domain_id, SpaceName=space_name)
                     logger.info("Deleted space: %s", space_name)
@@ -147,6 +186,21 @@ def _delete_spaces(region: str, domain_id: str) -> list[str]:
                         msg = f"Failed to delete space {space_name}: {e}"
                         logger.error(msg)
                         errors.append(msg)
+
+        # Wait for spaces to finish deleting (up to 3 minutes).
+        for _ in range(36):
+            remaining: list[str] = []
+            for page in paginator.paginate(DomainIdEquals=domain_id):
+                for space in page.get("Spaces", []):
+                    remaining.append(space["SpaceName"])
+            if not remaining:
+                break
+            logger.info("Waiting for %d space(s) to delete: %s", len(remaining), remaining)
+            time.sleep(5)
+        else:
+            msg = f"Timed out waiting for spaces to delete in {domain_id}: {remaining}"
+            logger.error(msg)
+            errors.append(msg)
     except ClientError as e:
         msg = f"Failed to list spaces: {e}"
         logger.error(msg)
@@ -156,7 +210,15 @@ def _delete_spaces(region: str, domain_id: str) -> list[str]:
 
 
 def _delete_user_profiles(region: str, domain_id: str) -> list[str]:
-    """Delete all user profiles in the domain. Returns a list of error messages."""
+    """Delete all user profiles in the domain and wait for them to be gone.
+
+    ``delete_user_profile`` is asynchronous — it puts the profile into
+    ``Deleting`` state and returns immediately. If we don't wait for the
+    list to drain, CloudFormation will race ahead to delete the domain
+    and fail with ``Unable to delete Domain ... because UserProfile(s)
+    are associated with it``. This function polls ``list_user_profiles``
+    until it's empty (or a timeout elapses).
+    """
     errors: list[str] = []
     sm = boto3.client("sagemaker", region_name=region)
 
@@ -165,6 +227,10 @@ def _delete_user_profiles(region: str, domain_id: str) -> list[str]:
         for page in paginator.paginate(DomainIdEquals=domain_id):
             for profile in page.get("UserProfiles", []):
                 name = profile["UserProfileName"]
+                # Skip profiles already being deleted; the wait loop below
+                # will still account for them.
+                if profile.get("Status") == "Deleting":
+                    continue
                 try:
                     sm.delete_user_profile(DomainId=domain_id, UserProfileName=name)
                     logger.info("Deleted user profile: %s", name)
@@ -174,6 +240,31 @@ def _delete_user_profiles(region: str, domain_id: str) -> list[str]:
                     msg = f"Failed to delete profile {name}: {e}"
                     logger.error(msg)
                     errors.append(msg)
+
+        # Wait for profiles to finish deleting (up to 3 minutes). Without
+        # this, CloudFormation will race ahead to delete the domain while
+        # profiles are still in ``Deleting`` state and fail the stack.
+        remaining: list[str] = []
+        for _ in range(36):
+            remaining = []
+            for page in paginator.paginate(DomainIdEquals=domain_id):
+                for profile in page.get("UserProfiles", []):
+                    remaining.append(profile["UserProfileName"])
+            if not remaining:
+                break
+            logger.info(
+                "Waiting for %d user profile(s) to delete: %s",
+                len(remaining),
+                remaining,
+            )
+            time.sleep(5)
+        else:
+            msg = (
+                f"Timed out waiting for user profiles to delete in "
+                f"{domain_id}: {remaining}"
+            )
+            logger.error(msg)
+            errors.append(msg)
     except ClientError as e:
         msg = f"Failed to list user profiles: {e}"
         logger.error(msg)

--- a/lambda/analytics-cleanup/handler.py
+++ b/lambda/analytics-cleanup/handler.py
@@ -29,6 +29,60 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
+# ---------------------------------------------------------------------------
+# Tunables
+# ---------------------------------------------------------------------------
+#
+# These constants govern how aggressively we poll SageMaker/EFS while waiting
+# for asynchronous delete operations to drain. The defaults are sized for the
+# worst case we've observed in production (a domain with a handful of users,
+# one JupyterLab app each). If you see timeouts in CloudWatch, raise the
+# ``*_WAIT_SECONDS`` values — and correspondingly bump ``timeout=`` on the
+# ``CleanupFunction`` in ``gco/stacks/analytics_stack.py`` so the Lambda
+# doesn't exceed its own execution timeout.
+#
+# Lower the values if you want the custom resource to fail fast during
+# local testing, but remember that CloudFormation will then hit the domain
+# delete before the async drains finish and fail with
+# ``Unable to delete Domain ... because UserProfile(s) are associated``.
+
+# Interval between list-and-check iterations of every drain wait loop.
+# Small enough to keep typical stacks responsive, large enough to avoid
+# throttling SageMaker/EFS control-plane APIs.
+DRAIN_POLL_INTERVAL_SECONDS = 5
+
+# Brief pause after issuing ``delete_space`` / ``delete_user_profile`` to
+# avoid ThrottlingException when a domain has dozens of resources.
+DELETE_PACE_SECONDS = 1
+
+# Maximum time to wait for SageMaker apps to reach ``Deleted``/``Failed``.
+# Apps typically go terminal within 30-60 seconds; 2 minutes leaves plenty
+# of headroom without risking a Lambda timeout.
+APP_DELETE_WAIT_SECONDS = 120
+
+# Maximum time to wait for SageMaker spaces to disappear from ``list_spaces``.
+# Spaces drain faster than user profiles but may be gated by app deletion.
+SPACE_DELETE_WAIT_SECONDS = 180
+
+# Maximum time to wait for SageMaker user profiles to disappear from
+# ``list_user_profiles``. This is the critical wait — if CloudFormation
+# reaches ``DeleteDomain`` with any profiles still lingering, the whole
+# stack fails with a UserProfile-in-use error and has to be manually
+# unstuck.
+USER_PROFILE_DELETE_WAIT_SECONDS = 180
+
+# Maximum time to wait for SageMaker-managed EFS mount targets to drain.
+# Mount target deletion is usually sub-30s but can stall briefly while
+# the ENIs are detached.
+MOUNT_TARGET_DELETE_WAIT_SECONDS = 120
+
+
+def _poll_iterations(total_wait_seconds: int) -> int:
+    """Return the number of iterations for a drain loop with
+    ``DRAIN_POLL_INTERVAL_SECONDS`` between polls."""
+    return max(1, total_wait_seconds // DRAIN_POLL_INTERVAL_SECONDS)
+
+
 def handler(event: dict, context: object) -> dict:
     """CloudFormation custom resource handler."""
     request_type = event.get("RequestType", "")
@@ -137,9 +191,9 @@ def _delete_apps(region: str, domain_id: str) -> list[str]:
                         logger.error(msg)
                         errors.append(msg)
 
-        # Wait for apps to finish deleting (up to 2 minutes)
-        for _ in range(24):
-            time.sleep(5)
+        # Wait for apps to finish deleting.
+        for _ in range(_poll_iterations(APP_DELETE_WAIT_SECONDS)):
+            time.sleep(DRAIN_POLL_INTERVAL_SECONDS)
             active = []
             for page in paginator.paginate(DomainIdEquals=domain_id):
                 for app in page.get("Apps", []):
@@ -180,15 +234,15 @@ def _delete_spaces(region: str, domain_id: str) -> list[str]:
                 try:
                     sm.delete_space(DomainId=domain_id, SpaceName=space_name)
                     logger.info("Deleted space: %s", space_name)
-                    time.sleep(1)
+                    time.sleep(DELETE_PACE_SECONDS)
                 except ClientError as e:
                     if "does not exist" not in str(e):
                         msg = f"Failed to delete space {space_name}: {e}"
                         logger.error(msg)
                         errors.append(msg)
 
-        # Wait for spaces to finish deleting (up to 3 minutes).
-        for _ in range(36):
+        # Wait for spaces to finish deleting.
+        for _ in range(_poll_iterations(SPACE_DELETE_WAIT_SECONDS)):
             remaining: list[str] = []
             for page in paginator.paginate(DomainIdEquals=domain_id):
                 for space in page.get("Spaces", []):
@@ -196,7 +250,7 @@ def _delete_spaces(region: str, domain_id: str) -> list[str]:
             if not remaining:
                 break
             logger.info("Waiting for %d space(s) to delete: %s", len(remaining), remaining)
-            time.sleep(5)
+            time.sleep(DRAIN_POLL_INTERVAL_SECONDS)
         else:
             msg = f"Timed out waiting for spaces to delete in {domain_id}: {remaining}"
             logger.error(msg)
@@ -235,17 +289,17 @@ def _delete_user_profiles(region: str, domain_id: str) -> list[str]:
                     sm.delete_user_profile(DomainId=domain_id, UserProfileName=name)
                     logger.info("Deleted user profile: %s", name)
                     # Brief pause to avoid throttling
-                    time.sleep(1)
+                    time.sleep(DELETE_PACE_SECONDS)
                 except ClientError as e:
                     msg = f"Failed to delete profile {name}: {e}"
                     logger.error(msg)
                     errors.append(msg)
 
-        # Wait for profiles to finish deleting (up to 3 minutes). Without
-        # this, CloudFormation will race ahead to delete the domain while
-        # profiles are still in ``Deleting`` state and fail the stack.
+        # Wait for profiles to finish deleting. Without this, CloudFormation
+        # will race ahead to delete the domain while profiles are still in
+        # ``Deleting`` state and fail the stack.
         remaining: list[str] = []
-        for _ in range(36):
+        for _ in range(_poll_iterations(USER_PROFILE_DELETE_WAIT_SECONDS)):
             remaining = []
             for page in paginator.paginate(DomainIdEquals=domain_id):
                 for profile in page.get("UserProfiles", []):
@@ -257,7 +311,7 @@ def _delete_user_profiles(region: str, domain_id: str) -> list[str]:
                 len(remaining),
                 remaining,
             )
-            time.sleep(5)
+            time.sleep(DRAIN_POLL_INTERVAL_SECONDS)
         else:
             msg = (
                 f"Timed out waiting for user profiles to delete in "
@@ -420,9 +474,9 @@ def _delete_sagemaker_managed_efs(region: str, domain_id: str) -> list[str]:
                 logger.error(msg)
                 errors.append(msg)
 
-        # Wait for mount targets to be deleted (up to 2 minutes)
-        for _ in range(24):
-            time.sleep(5)
+        # Wait for mount targets to be deleted.
+        for _ in range(_poll_iterations(MOUNT_TARGET_DELETE_WAIT_SECONDS)):
+            time.sleep(DRAIN_POLL_INTERVAL_SECONDS)
             remaining = efs.describe_mount_targets(FileSystemId=target_fs)
             if not remaining.get("MountTargets"):
                 break

--- a/lambda/analytics-cleanup/handler.py
+++ b/lambda/analytics-cleanup/handler.py
@@ -76,6 +76,17 @@ USER_PROFILE_DELETE_WAIT_SECONDS = 180
 # the ENIs are detached.
 MOUNT_TARGET_DELETE_WAIT_SECONDS = 120
 
+# SageMaker-managed NFS security group retry behaviour. Right after
+# ``DeleteDomain``, SageMaker's control plane briefly holds an internal
+# reference on one of the two NFS SGs (typically the outbound one),
+# causing ``delete_security_group`` to fail with ``DependencyViolation``
+# for ~30-60 seconds before clearing. We retry that many times, pausing
+# between attempts; if the reference is still there on the final try we
+# promote the failure to a critical error so CloudFormation stops
+# before the VPC delete hits the same dependency and fails the stack.
+SG_DELETE_MAX_ATTEMPTS = 4
+SG_DELETE_RETRY_BACKOFF_SECONDS = 15
+
 
 def _poll_iterations(total_wait_seconds: int) -> int:
     """Return the number of iterations for a drain loop with
@@ -361,6 +372,14 @@ def _delete_sagemaker_security_groups(region: str, domain_id: str, vpc_id: str) 
     The two SGs cross-reference each other (outbound rules on one point
     to the other), creating a circular dependency. We must revoke all
     ingress/egress rules before deleting.
+
+    Right after ``DeleteDomain``, SageMaker's control plane briefly
+    retains an internal reference on one of the NFS SGs — typically the
+    outbound one — causing ``delete_security_group`` to fail with
+    ``DependencyViolation``. The reference reliably clears within 30-60s.
+    We retry the delete ``SG_DELETE_MAX_ATTEMPTS`` times with
+    ``SG_DELETE_RETRY_BACKOFF_SECONDS`` between attempts, and only
+    surface an error if the SG is still undeletable after the final try.
     """
     errors: list[str] = []
     ec2 = boto3.client("ec2", region_name=region)
@@ -389,15 +408,51 @@ def _delete_sagemaker_security_groups(region: str, domain_id: str, vpc_id: str) 
             except ClientError as e:
                 logger.warning("Failed to revoke rules on %s: %s", sg_id, e)
 
-        # Second pass: delete the security groups.
-        for sg in sgs:
-            sg_id = sg["GroupId"]
-            sg_name = sg.get("GroupName", "")
-            try:
-                ec2.delete_security_group(GroupId=sg_id)
-                logger.info("Deleted SageMaker security group: %s (%s)", sg_id, sg_name)
-            except ClientError as e:
-                msg = f"Failed to delete security group {sg_id}: {e}"
+        # Second pass: delete the security groups, retrying on
+        # ``DependencyViolation`` for ones where SageMaker still holds
+        # a transient reference post-DeleteDomain.
+        pending = [(sg["GroupId"], sg.get("GroupName", "")) for sg in sgs]
+        for attempt in range(1, SG_DELETE_MAX_ATTEMPTS + 1):
+            still_pending: list[tuple[str, str]] = []
+            for sg_id, sg_name in pending:
+                try:
+                    ec2.delete_security_group(GroupId=sg_id)
+                    logger.info("Deleted SageMaker security group: %s (%s)", sg_id, sg_name)
+                except ClientError as e:
+                    code = e.response.get("Error", {}).get("Code", "")
+                    # ``InvalidGroup.NotFound`` means some other actor
+                    # already deleted it — treat as success.
+                    if code == "InvalidGroup.NotFound":
+                        logger.info("SG %s (%s) already deleted", sg_id, sg_name)
+                        continue
+                    if code == "DependencyViolation":
+                        logger.warning(
+                            "SG %s (%s) has a dependent object (attempt %d/%d); will retry",
+                            sg_id,
+                            sg_name,
+                            attempt,
+                            SG_DELETE_MAX_ATTEMPTS,
+                        )
+                        still_pending.append((sg_id, sg_name))
+                        continue
+                    msg = f"Failed to delete security group {sg_id}: {e}"
+                    logger.error(msg)
+                    errors.append(msg)
+            if not still_pending:
+                break
+            pending = still_pending
+            if attempt < SG_DELETE_MAX_ATTEMPTS:
+                time.sleep(SG_DELETE_RETRY_BACKOFF_SECONDS)
+        else:
+            # Exhausted retries with SGs still undeletable.
+            for sg_id, sg_name in pending:
+                msg = (
+                    f"Failed to delete security group {sg_id} ({sg_name}) "
+                    f"after {SG_DELETE_MAX_ATTEMPTS} attempts: "
+                    "DependencyViolation did not clear. CloudFormation "
+                    "will fail to delete the VPC; manually delete the "
+                    "SG after its dependent object releases."
+                )
                 logger.error(msg)
                 errors.append(msg)
     except ClientError as e:

--- a/lambda/helm-installer/handler.py
+++ b/lambda/helm-installer/handler.py
@@ -40,6 +40,24 @@ logger.setLevel(logging.INFO)
 SUCCESS = "SUCCESS"
 FAILED = "FAILED"
 
+
+# ---------------------------------------------------------------------------
+# Tunables
+# ---------------------------------------------------------------------------
+
+# Maximum number of install/upgrade attempts for each chart. Some charts
+# (e.g. cert-manager, NVIDIA operators) depend on admission webhooks or
+# CRDs that briefly flap during cluster bring-up, and a single retry often
+# clears those transient failures. Raise this if you see persistent retry
+# exhaustion in the logs; lower it for faster feedback in local testing.
+HELM_INSTALL_MAX_RETRIES = 3
+
+# Seconds to wait between failed chart attempts. Sized to give the EKS
+# control plane time to stabilise (webhook endpoints coming up, API
+# server throttling clearing) without dragging CloudFormation custom
+# resource completion beyond its 15-minute timeout.
+HELM_INSTALL_RETRY_DELAY_SECONDS = 30
+
 # Load default chart configurations
 CHARTS_CONFIG_PATH = Path(__file__).parent / "charts.yaml"
 
@@ -582,9 +600,10 @@ def lambda_handler(event: dict[str, Any], context: Any) -> None:
 
         if request_type in ("Create", "Update"):
             # Install/upgrade enabled charts with retry for transient failures
-            # (e.g., webhook not ready yet, API server temporarily unavailable)
-            max_retries = 3
-            retry_delay = 30  # seconds
+            # (e.g., webhook not ready yet, API server temporarily unavailable).
+            # Tunables at the top of this module.
+            max_retries = HELM_INSTALL_MAX_RETRIES
+            retry_delay = HELM_INSTALL_RETRY_DELAY_SECONDS
 
             # First pass: uninstall disabled charts that were previously installed
             for chart_name, config in charts_config.items():

--- a/lambda/kubectl-applier-simple/handler.py
+++ b/lambda/kubectl-applier-simple/handler.py
@@ -57,6 +57,25 @@ SUCCESS = "SUCCESS"
 FAILED = "FAILED"
 
 
+# ---------------------------------------------------------------------------
+# Tunables
+# ---------------------------------------------------------------------------
+
+# Maximum time to wait for a PersistentVolume or PersistentVolumeClaim to
+# disappear after we issue a delete. Needed when we're recreating a PV
+# whose ``volumeHandle`` changed (FSx/EFS ID rotated) or reconciling a
+# Lost PVC whose backing PV was just recreated. If you see this wait
+# consistently timing out, check for stuck finalizers (the handler
+# already clears the standard ``pv-protection`` / ``pvc-protection``
+# finalizers) or for an AWS control-plane issue on the underlying
+# volume. Raising the value is safe — it only blocks the re-create path,
+# not steady-state applies.
+PV_PVC_DELETE_WAIT_SECONDS = 30
+
+# Interval between PV/PVC existence polls during the delete wait.
+PV_PVC_DELETE_POLL_INTERVAL_SECONDS = 1
+
+
 def get_eks_client() -> Any:
     """Get EKS client with lazy initialization."""
     global _eks_client
@@ -630,10 +649,15 @@ def apply_manifests(
                                     # Wait for the PV to actually disappear
                                     import time as _time
 
-                                    for _wait in range(30):
+                                    _pv_iterations = max(
+                                        1,
+                                        PV_PVC_DELETE_WAIT_SECONDS
+                                        // PV_PVC_DELETE_POLL_INTERVAL_SECONDS,
+                                    )
+                                    for _wait in range(_pv_iterations):
                                         try:
                                             v1.read_persistent_volume(name)
-                                            _time.sleep(1)
+                                            _time.sleep(PV_PVC_DELETE_POLL_INTERVAL_SECONDS)
                                         except ApiException as read_e:
                                             if read_e.status == 404:
                                                 break
@@ -661,12 +685,17 @@ def apply_manifests(
                                     v1.delete_namespaced_persistent_volume_claim(name, namespace)
                                     import time as _time
 
-                                    for _wait in range(30):
+                                    _pvc_iterations = max(
+                                        1,
+                                        PV_PVC_DELETE_WAIT_SECONDS
+                                        // PV_PVC_DELETE_POLL_INTERVAL_SECONDS,
+                                    )
+                                    for _wait in range(_pvc_iterations):
                                         try:
                                             v1.read_namespaced_persistent_volume_claim(
                                                 name, namespace
                                             )
-                                            _time.sleep(1)
+                                            _time.sleep(PV_PVC_DELETE_POLL_INTERVAL_SECONDS)
                                         except ApiException as read_e:
                                             if read_e.status == 404:
                                                 break

--- a/tests/test_analytics_cleanup_lambda.py
+++ b/tests/test_analytics_cleanup_lambda.py
@@ -53,6 +53,18 @@ def _set_env(monkeypatch):
         monkeypatch.setenv(key, value)
 
 
+@pytest.fixture(autouse=True)
+def _fast_sleep(monkeypatch):
+    """Skip real waiting inside the handler so tests stay fast.
+
+    ``_delete_user_profiles`` and ``_delete_spaces`` now poll and sleep
+    while the SageMaker delete calls drain asynchronously. Tests use
+    paginators that return empty on the first re-list, so the loop exits
+    on the first iteration — but only if ``time.sleep`` is a no-op.
+    """
+    monkeypatch.setattr(_module.time, "sleep", lambda _: None)
+
+
 # ---------------------------------------------------------------------------
 # handler() top-level tests
 # ---------------------------------------------------------------------------
@@ -98,7 +110,7 @@ class TestHandler:
     @patch("analytics_cleanup_handler._delete_user_profiles", return_value=["err2"])
     @patch("analytics_cleanup_handler._delete_spaces", return_value=[])
     @patch("analytics_cleanup_handler._delete_apps", return_value=[])
-    def test_delete_returns_success_even_on_errors(
+    def test_delete_raises_on_critical_errors(
         self,
         mock_apps,
         mock_spaces,
@@ -108,7 +120,33 @@ class TestHandler:
         mock_efs,
         mock_sgs,
     ):
-        """Cleanup errors must not block stack deletion."""
+        """Errors draining apps/spaces/user-profiles must fail the custom
+        resource so CloudFormation doesn't proceed to a guaranteed-fail
+        domain delete.
+        """
+        with pytest.raises(RuntimeError, match="Analytics cleanup failed"):
+            handler({"RequestType": "Delete"}, None)
+
+    @patch("analytics_cleanup_handler._delete_sagemaker_security_groups", return_value=["sg-err"])
+    @patch("analytics_cleanup_handler._delete_sagemaker_managed_efs", return_value=["efs-err"])
+    @patch("analytics_cleanup_handler._get_sagemaker_home_efs_id", return_value="")
+    @patch("analytics_cleanup_handler._delete_efs_resource_policy")
+    @patch("analytics_cleanup_handler._delete_user_profiles", return_value=[])
+    @patch("analytics_cleanup_handler._delete_spaces", return_value=[])
+    @patch("analytics_cleanup_handler._delete_apps", return_value=[])
+    def test_delete_tolerates_non_critical_errors(
+        self,
+        mock_apps,
+        mock_spaces,
+        mock_profiles,
+        mock_efs_policy,
+        mock_get_sm_efs,
+        mock_efs,
+        mock_sgs,
+    ):
+        """EFS and SG cleanup errors are best-effort and must not block the
+        domain delete — they're logged but the handler still returns SUCCESS.
+        """
         result = handler({"RequestType": "Delete"}, None)
         assert result["Status"] == "SUCCESS"
 
@@ -122,13 +160,18 @@ class TestDeleteUserProfiles:
     def test_deletes_all_profiles(self):
         mock_sm = MagicMock()
         mock_paginator = MagicMock()
-        mock_paginator.paginate.return_value = [
-            {
-                "UserProfiles": [
-                    {"UserProfileName": "alice"},
-                    {"UserProfileName": "bob"},
-                ]
-            }
+        # First paginate() call: enumerate profiles for deletion.
+        # Subsequent paginate() calls: poll loop — return empty to exit.
+        mock_paginator.paginate.side_effect = [
+            [
+                {
+                    "UserProfiles": [
+                        {"UserProfileName": "alice"},
+                        {"UserProfileName": "bob"},
+                    ]
+                }
+            ],
+            [{"UserProfiles": []}],
         ]
         mock_sm.get_paginator.return_value = mock_paginator
 
@@ -152,12 +195,57 @@ class TestDeleteUserProfiles:
         assert errors == []
         mock_sm.delete_user_profile.assert_not_called()
 
+    def test_waits_for_profiles_to_drain(self):
+        """Profiles in Deleting state are skipped for the delete call but
+        still gate the wait loop — we must not return until they're gone.
+        """
+        mock_sm = MagicMock()
+        mock_paginator = MagicMock()
+        # Initial list has 1 profile to delete.
+        # Wait loop sees it still Deleting, then gone.
+        mock_paginator.paginate.side_effect = [
+            [{"UserProfiles": [{"UserProfileName": "alice", "Status": "InService"}]}],
+            [{"UserProfiles": [{"UserProfileName": "alice", "Status": "Deleting"}]}],
+            [{"UserProfiles": []}],
+        ]
+        mock_sm.get_paginator.return_value = mock_paginator
+
+        with patch("boto3.client", return_value=mock_sm):
+            errors = _delete_user_profiles("us-east-2", "d-test123")
+
+        assert errors == []
+        mock_sm.delete_user_profile.assert_called_once_with(
+            DomainId="d-test123", UserProfileName="alice"
+        )
+
+    def test_timeout_reports_error(self, monkeypatch):
+        """If profiles never drain, the function must report an error so
+        the top-level handler can raise.
+        """
+        mock_sm = MagicMock()
+        mock_paginator = MagicMock()
+        # Always return a lingering profile — the wait loop will time out.
+        mock_paginator.paginate.return_value = [
+            {"UserProfiles": [{"UserProfileName": "alice", "Status": "Deleting"}]}
+        ]
+        mock_sm.get_paginator.return_value = mock_paginator
+
+        with patch("boto3.client", return_value=mock_sm):
+            errors = _delete_user_profiles("us-east-2", "d-test123")
+
+        assert len(errors) == 1
+        assert "Timed out" in errors[0]
+        assert "alice" in errors[0]
+
     def test_delete_failure_is_captured(self):
         from botocore.exceptions import ClientError
 
         mock_sm = MagicMock()
         mock_paginator = MagicMock()
-        mock_paginator.paginate.return_value = [{"UserProfiles": [{"UserProfileName": "alice"}]}]
+        mock_paginator.paginate.side_effect = [
+            [{"UserProfiles": [{"UserProfileName": "alice"}]}],
+            [{"UserProfiles": []}],
+        ]
         mock_sm.get_paginator.return_value = mock_paginator
         mock_sm.delete_user_profile.side_effect = ClientError(
             {"Error": {"Code": "ValidationException", "Message": "in use"}},
@@ -167,8 +255,8 @@ class TestDeleteUserProfiles:
         with patch("boto3.client", return_value=mock_sm):
             errors = _delete_user_profiles("us-east-2", "d-test123")
 
-        assert len(errors) == 1
-        assert "alice" in errors[0]
+        assert len(errors) >= 1
+        assert any("alice" in e for e in errors)
 
     def test_list_failure_is_captured(self):
         from botocore.exceptions import ClientError

--- a/tests/test_analytics_cleanup_lambda.py
+++ b/tests/test_analytics_cleanup_lambda.py
@@ -402,3 +402,143 @@ class TestDeleteSagemakerManagedEfs:
 
         assert len(errors) == 1
         assert "fsmt-001" in errors[0]
+
+
+# ---------------------------------------------------------------------------
+# _delete_sagemaker_security_groups tests
+# ---------------------------------------------------------------------------
+
+_delete_sagemaker_security_groups = _module._delete_sagemaker_security_groups
+
+
+class TestDeleteSagemakerSecurityGroups:
+    """Cover the DependencyViolation retry behaviour for the NFS SGs."""
+
+    def _sg(self, group_id, group_name, ingress=None, egress=None):
+        return {
+            "GroupId": group_id,
+            "GroupName": group_name,
+            "IpPermissions": ingress or [],
+            "IpPermissionsEgress": egress or [],
+        }
+
+    def test_deletes_both_sgs_on_first_attempt(self):
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_security_groups.return_value = {
+            "SecurityGroups": [
+                self._sg("sg-in", "security-group-for-inbound-nfs-d-test"),
+                self._sg("sg-out", "security-group-for-outbound-nfs-d-test"),
+            ]
+        }
+
+        with patch("boto3.client", return_value=mock_ec2):
+            errors = _delete_sagemaker_security_groups("us-east-2", "d-test", "vpc-xyz")
+
+        assert errors == []
+        assert mock_ec2.delete_security_group.call_count == 2
+
+    def test_retries_on_dependency_violation_then_succeeds(self, monkeypatch):
+        """The outbound SG typically fails once with DependencyViolation
+        and clears within one backoff interval."""
+        from botocore.exceptions import ClientError
+
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_security_groups.return_value = {
+            "SecurityGroups": [
+                self._sg("sg-out", "security-group-for-outbound-nfs-d-test"),
+            ]
+        }
+        # First call: DependencyViolation. Second call: succeeds.
+        dep_violation = ClientError(
+            {
+                "Error": {
+                    "Code": "DependencyViolation",
+                    "Message": "has a dependent object",
+                }
+            },
+            "DeleteSecurityGroup",
+        )
+        mock_ec2.delete_security_group.side_effect = [dep_violation, None]
+
+        with patch("boto3.client", return_value=mock_ec2):
+            errors = _delete_sagemaker_security_groups("us-east-2", "d-test", "vpc-xyz")
+
+        assert errors == []
+        assert mock_ec2.delete_security_group.call_count == 2
+
+    def test_reports_error_after_exhausting_retries(self):
+        """If DependencyViolation persists across every attempt, emit
+        an actionable error so the caller can decide how to handle it."""
+        from botocore.exceptions import ClientError
+
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_security_groups.return_value = {
+            "SecurityGroups": [
+                self._sg("sg-out", "security-group-for-outbound-nfs-d-test"),
+            ]
+        }
+        mock_ec2.delete_security_group.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "DependencyViolation",
+                    "Message": "has a dependent object",
+                }
+            },
+            "DeleteSecurityGroup",
+        )
+
+        with patch("boto3.client", return_value=mock_ec2):
+            errors = _delete_sagemaker_security_groups("us-east-2", "d-test", "vpc-xyz")
+
+        assert len(errors) == 1
+        assert "sg-out" in errors[0]
+        assert "DependencyViolation did not clear" in errors[0]
+        # Every attempt was used.
+        assert mock_ec2.delete_security_group.call_count == _module.SG_DELETE_MAX_ATTEMPTS
+
+    def test_treats_already_deleted_as_success(self):
+        """An ``InvalidGroup.NotFound`` response means some other actor
+        (e.g. an operator recovering a prior failed destroy) has already
+        deleted the SG. Treat it as success, not an error."""
+        from botocore.exceptions import ClientError
+
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_security_groups.return_value = {
+            "SecurityGroups": [
+                self._sg("sg-in", "security-group-for-inbound-nfs-d-test"),
+            ]
+        }
+        mock_ec2.delete_security_group.side_effect = ClientError(
+            {"Error": {"Code": "InvalidGroup.NotFound", "Message": "gone"}},
+            "DeleteSecurityGroup",
+        )
+
+        with patch("boto3.client", return_value=mock_ec2):
+            errors = _delete_sagemaker_security_groups("us-east-2", "d-test", "vpc-xyz")
+
+        assert errors == []
+
+    def test_other_client_errors_are_surfaced_immediately(self):
+        """Errors other than ``DependencyViolation`` / ``InvalidGroup.NotFound``
+        surface on the first attempt without retrying — these are not
+        transient and retries would waste Lambda time."""
+        from botocore.exceptions import ClientError
+
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_security_groups.return_value = {
+            "SecurityGroups": [
+                self._sg("sg-in", "security-group-for-inbound-nfs-d-test"),
+            ]
+        }
+        mock_ec2.delete_security_group.side_effect = ClientError(
+            {"Error": {"Code": "UnauthorizedOperation", "Message": "denied"}},
+            "DeleteSecurityGroup",
+        )
+
+        with patch("boto3.client", return_value=mock_ec2):
+            errors = _delete_sagemaker_security_groups("us-east-2", "d-test", "vpc-xyz")
+
+        assert len(errors) == 1
+        assert "sg-in" in errors[0]
+        # Only one attempt — no retry for non-DependencyViolation errors.
+        assert mock_ec2.delete_security_group.call_count == 1

--- a/tests/test_oidc_stack.py
+++ b/tests/test_oidc_stack.py
@@ -226,9 +226,7 @@ class TestOIDCIAMPolicy:
                         [
                             Match.object_like(
                                 {
-                                    "Action": Match.array_with(
-                                        ["eks:DescribeClusterVersions"]
-                                    ),
+                                    "Action": Match.array_with(["eks:DescribeClusterVersions"]),
                                     "Effect": "Allow",
                                 }
                             )

--- a/tests/test_oidc_stack.py
+++ b/tests/test_oidc_stack.py
@@ -214,6 +214,30 @@ class TestOIDCIAMPolicy:
             },
         )
 
+    def test_policy_has_eks_describe_cluster_versions(self):
+        """Policy should allow eks:DescribeClusterVersions so the
+        dependency scan can detect newer Kubernetes minor releases."""
+        template = _synth_stack()
+        template.has_resource_properties(
+            "AWS::IAM::Policy",
+            {
+                "PolicyDocument": {
+                    "Statement": Match.array_with(
+                        [
+                            Match.object_like(
+                                {
+                                    "Action": Match.array_with(
+                                        ["eks:DescribeClusterVersions"]
+                                    ),
+                                    "Effect": "Allow",
+                                }
+                            )
+                        ]
+                    )
+                }
+            },
+        )
+
     def test_policy_has_rds_describe(self):
         """Policy should allow rds:DescribeDBEngineVersions."""
         template = _synth_stack()

--- a/tests/test_stacks.py
+++ b/tests/test_stacks.py
@@ -2020,6 +2020,11 @@ class TestStackManagerDestroyAnalyticsFallback:
                 StackManager, "_ensure_analytics_enabled_for_destroy", return_value=True
             ) as mock_enable,
             patch.object(StackManager, "_restore_analytics_disabled") as mock_restore,
+            # Patch the dependency-removal helper so we only exercise
+            # the toggle / CDK / fallback logic here.
+            patch.object(
+                StackManager, "_remove_api_gateway_analytics_dependency", return_value=True
+            ),
         ):
             # CDK destroy succeeds (because we enabled the toggle)
             mock_run.return_value = MagicMock(returncode=0)
@@ -2092,7 +2097,9 @@ class TestStackManagerDestroyExclusively:
         with (
             patch.object(StackManager, "_run_cdk") as mock_run,
             patch.object(StackManager, "_stack_exists_in_cloudformation", return_value=False),
-            patch.object(StackManager, "_remove_api_gateway_analytics_dependency"),
+            patch.object(
+                StackManager, "_remove_api_gateway_analytics_dependency", return_value=True
+            ),
         ):
             mock_run.return_value = MagicMock(returncode=0)
 
@@ -2131,7 +2138,9 @@ class TestStackManagerDestroyExclusively:
         with (
             patch.object(StackManager, "_run_cdk") as mock_run,
             patch.object(StackManager, "_stack_exists_in_cloudformation", return_value=False),
-            patch.object(StackManager, "_remove_api_gateway_analytics_dependency") as mock_remove,
+            patch.object(
+                StackManager, "_remove_api_gateway_analytics_dependency", return_value=True
+            ) as mock_remove,
         ):
             mock_run.return_value = MagicMock(returncode=0)
 
@@ -2149,7 +2158,9 @@ class TestStackManagerDestroyExclusively:
         with (
             patch.object(StackManager, "_run_cdk") as mock_run,
             patch.object(StackManager, "_stack_exists_in_cloudformation", return_value=False),
-            patch.object(StackManager, "_remove_api_gateway_analytics_dependency") as mock_remove,
+            patch.object(
+                StackManager, "_remove_api_gateway_analytics_dependency", return_value=True
+            ) as mock_remove,
         ):
             mock_run.return_value = MagicMock(returncode=0)
 
@@ -2157,6 +2168,222 @@ class TestStackManagerDestroyExclusively:
             manager.destroy(stack_name="gco-us-east-1", force=True)
 
             mock_remove.assert_not_called()
+
+    def test_destroy_analytics_aborts_when_api_gateway_still_imports(self):
+        """If the api-gateway still imports analytics exports after the
+        redeploy attempt, the destroy must abort instead of cascading
+        into a guaranteed-fail CloudFormation delete."""
+        from cli.stacks import StackManager
+
+        config = MagicMock()
+        config.api_gateway_region = "us-east-2"
+
+        with (
+            patch.object(StackManager, "_run_cdk") as mock_run,
+            patch.object(StackManager, "_stack_exists_in_cloudformation", return_value=False),
+            patch.object(
+                StackManager, "_remove_api_gateway_analytics_dependency", return_value=False
+            ) as mock_remove,
+        ):
+            manager = StackManager(config)
+            result = manager.destroy(stack_name="gco-analytics", force=True)
+
+            # Short-circuits before invoking cdk destroy.
+            assert result is False
+            mock_remove.assert_called_once()
+            mock_run.assert_not_called()
+
+
+class TestRemoveApiGatewayAnalyticsDependency:
+    """Tests for the redeploy/skip logic in _remove_api_gateway_analytics_dependency."""
+
+    def test_skips_redeploy_when_api_gateway_does_not_exist(self):
+        """If gco-api-gateway isn't in CloudFormation, no consumer can
+        exist, so the expensive redeploy is skipped and the destroy is
+        marked safe."""
+        from cli.stacks import StackManager
+
+        config = MagicMock()
+        config.api_gateway_region = "us-east-2"
+
+        with (
+            patch.object(StackManager, "_stack_exists_in_cloudformation", return_value=False),
+            patch.object(StackManager, "deploy") as mock_deploy,
+        ):
+            manager = StackManager(config)
+            result = manager._remove_api_gateway_analytics_dependency()
+
+            assert result is True
+            mock_deploy.assert_not_called()
+
+    def test_skips_redeploy_when_no_analytics_imports(self):
+        """If gco-api-gateway exists but doesn't import from gco-analytics
+        (e.g. analytics was never fully wired up), skip the redeploy."""
+        from cli.stacks import StackManager
+
+        config = MagicMock()
+        config.api_gateway_region = "us-east-2"
+
+        with (
+            patch.object(StackManager, "_stack_exists_in_cloudformation", return_value=True),
+            patch.object(
+                StackManager, "_api_gateway_imports_from_analytics", return_value=False
+            ),
+            patch.object(StackManager, "deploy") as mock_deploy,
+        ):
+            manager = StackManager(config)
+            result = manager._remove_api_gateway_analytics_dependency()
+
+            assert result is True
+            mock_deploy.assert_not_called()
+
+    def test_redeploy_failure_is_fatal_when_imports_remain(self):
+        """If the redeploy fails and api-gateway still imports analytics
+        exports, the destroy must be blocked."""
+        from cli.stacks import StackManager
+
+        config = MagicMock()
+        config.api_gateway_region = "us-east-2"
+
+        # The second call (post-redeploy recheck) also reports imports.
+        with (
+            patch.object(StackManager, "_stack_exists_in_cloudformation", return_value=True),
+            patch.object(
+                StackManager, "_api_gateway_imports_from_analytics", return_value=True
+            ),
+            patch.object(StackManager, "deploy", return_value=False),
+            patch("cli.stacks.get_analytics_config", return_value={"enabled": True}),
+            patch("cli.stacks.update_analytics_config"),
+        ):
+            manager = StackManager(config)
+            result = manager._remove_api_gateway_analytics_dependency()
+
+            assert result is False
+
+    def test_redeploy_failure_is_tolerated_when_consumer_vanished(self):
+        """If the redeploy failed because api-gateway was auto-deleted
+        by the ROLLBACK_COMPLETE cleanup, the post-redeploy recheck
+        finds no imports and the destroy is allowed to proceed."""
+        from cli.stacks import StackManager
+
+        config = MagicMock()
+        config.api_gateway_region = "us-east-2"
+
+        import_results = iter([True, False])
+
+        with (
+            patch.object(StackManager, "_stack_exists_in_cloudformation", return_value=True),
+            patch.object(
+                StackManager,
+                "_api_gateway_imports_from_analytics",
+                side_effect=lambda: next(import_results),
+            ),
+            patch.object(StackManager, "deploy", return_value=False),
+            patch("cli.stacks.get_analytics_config", return_value={"enabled": True}),
+            patch("cli.stacks.update_analytics_config"),
+        ):
+            manager = StackManager(config)
+            result = manager._remove_api_gateway_analytics_dependency()
+
+            assert result is True
+
+
+class TestApiGatewayImportsFromAnalytics:
+    """Tests for the CloudFormation-based export/import detection helper."""
+
+    def test_returns_false_when_no_analytics_exports(self):
+        """If no exports are owned by gco-analytics, no imports can exist."""
+        from cli.stacks import StackManager
+
+        config = MagicMock()
+        config.api_gateway_region = "us-east-2"
+
+        mock_cfn = MagicMock()
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [
+            {
+                "Exports": [
+                    {
+                        "Name": "other-export",
+                        "ExportingStackId": (
+                            "arn:aws:cloudformation:us-east-2:111:stack/gco-global/abc"
+                        ),
+                    }
+                ]
+            }
+        ]
+        mock_cfn.get_paginator.return_value = mock_paginator
+
+        with patch("boto3.client", return_value=mock_cfn):
+            manager = StackManager(config)
+            assert manager._api_gateway_imports_from_analytics() is False
+
+    def test_returns_true_when_api_gateway_is_importer(self):
+        """If gco-api-gateway appears in the Imports list for any
+        gco-analytics export, return True."""
+        from cli.stacks import StackManager
+
+        config = MagicMock()
+        config.api_gateway_region = "us-east-2"
+
+        mock_cfn = MagicMock()
+        export_paginator = MagicMock()
+        export_paginator.paginate.return_value = [
+            {
+                "Exports": [
+                    {
+                        "Name": "gco-analytics:CognitoPoolArn",
+                        "ExportingStackId": (
+                            "arn:aws:cloudformation:us-east-2:111:stack/gco-analytics/abc"
+                        ),
+                    }
+                ]
+            }
+        ]
+        import_paginator = MagicMock()
+        import_paginator.paginate.return_value = [{"Imports": ["gco-api-gateway"]}]
+
+        def get_paginator(op_name):
+            return export_paginator if op_name == "list_exports" else import_paginator
+
+        mock_cfn.get_paginator.side_effect = get_paginator
+
+        with patch("boto3.client", return_value=mock_cfn):
+            manager = StackManager(config)
+            assert manager._api_gateway_imports_from_analytics() is True
+
+    def test_returns_false_when_no_importers(self):
+        """Export exists but has no consumers yet."""
+        from cli.stacks import StackManager
+
+        config = MagicMock()
+        config.api_gateway_region = "us-east-2"
+
+        mock_cfn = MagicMock()
+        export_paginator = MagicMock()
+        export_paginator.paginate.return_value = [
+            {
+                "Exports": [
+                    {
+                        "Name": "gco-analytics:CognitoPoolArn",
+                        "ExportingStackId": (
+                            "arn:aws:cloudformation:us-east-2:111:stack/gco-analytics/abc"
+                        ),
+                    }
+                ]
+            }
+        ]
+        import_paginator = MagicMock()
+        import_paginator.paginate.return_value = [{"Imports": []}]
+
+        def get_paginator(op_name):
+            return export_paginator if op_name == "list_exports" else import_paginator
+
+        mock_cfn.get_paginator.side_effect = get_paginator
+
+        with patch("boto3.client", return_value=mock_cfn):
+            manager = StackManager(config)
+            assert manager._api_gateway_imports_from_analytics() is False
 
 
 class TestStackManagerDeployAnalyticsAutoApiGateway:

--- a/tests/test_stacks.py
+++ b/tests/test_stacks.py
@@ -2226,9 +2226,7 @@ class TestRemoveApiGatewayAnalyticsDependency:
 
         with (
             patch.object(StackManager, "_stack_exists_in_cloudformation", return_value=True),
-            patch.object(
-                StackManager, "_api_gateway_imports_from_analytics", return_value=False
-            ),
+            patch.object(StackManager, "_api_gateway_imports_from_analytics", return_value=False),
             patch.object(StackManager, "deploy") as mock_deploy,
         ):
             manager = StackManager(config)
@@ -2248,9 +2246,7 @@ class TestRemoveApiGatewayAnalyticsDependency:
         # The second call (post-redeploy recheck) also reports imports.
         with (
             patch.object(StackManager, "_stack_exists_in_cloudformation", return_value=True),
-            patch.object(
-                StackManager, "_api_gateway_imports_from_analytics", return_value=True
-            ),
+            patch.object(StackManager, "_api_gateway_imports_from_analytics", return_value=True),
             patch.object(StackManager, "deploy", return_value=False),
             patch("cli.stacks.get_analytics_config", return_value={"enabled": True}),
             patch("cli.stacks.update_analytics_config"),


### PR DESCRIPTION
## Summary

Fixes the recurring `DELETE_FAILED` on `gco-analytics` that left the
`StudioDomain` wedged with `UserProfile(s) are associated with it`,
hardens the surrounding destroy orchestration, tidies up Lambda
tunables, and adds an EKS Kubernetes minor-version drift check to
the monthly dependency scan.

## What's in here

Five commits, each scoped to one concern so they can be reviewed
independently:

1. **`fix(analytics-cleanup): drain user profiles before domain delete`**
   The `DomainCleanup` custom resource was firing
   `delete_user_profile` for each profile and returning `SUCCESS`
   without waiting for the async delete to finish. CloudFormation
   raced ahead to `DeleteDomain` and failed. The handler now polls
   `list_user_profiles` (and `list_spaces`) until they drain, with a
   3-minute budget each, and raises `RuntimeError` on unresolved
   critical errors so the custom resource fails fast instead of
   cascading into a guaranteed-fail domain delete. Tests updated for
   the new contract.

2. **`fix(stacks): verify api-gateway no longer imports analytics exports before destroy`**
   The CLI redeploys `gco-api-gateway` with analytics disabled before
   tearing down `gco-analytics` so the `/studio/*` imports drop. If
   that redeploy failed (for example because `gco-api-gateway` was
   already in `ROLLBACK_COMPLETE` and its `CREATE` couldn't resolve a
   `gco-global` export), the old code logged a warning and charged
   into an `export in use` error. The new logic:
   - Skips the redeploy entirely when `gco-api-gateway` doesn't
     exist or doesn't actually import from `gco-analytics`.
   - Rechecks `list_exports` + `list_imports` after a failed redeploy
     and lets the destroy proceed if no consumer remains.
   - Otherwise returns `False` and the caller aborts with an
     actionable message.

3. **`fix(analytics-stack): bump cleanup Lambda timeout to 15 minutes`**
   The cleanup Lambda now runs multiple async drain loops in series
   (apps, spaces, user profiles, SageMaker-managed EFS mount
   targets, security groups). Worst-case arithmetic exceeds the old
   5-minute timeout. 15 minutes covers the worst case; the common
   case still finishes in well under a minute.

4. **`refactor(lambdas): hoist wait/retry magic numbers to named constants`**
   Pull inlined wait budgets and retry counts up to a "Tunables"
   block at the top of each handler, with comments explaining what
   each knob does and when you'd want to adjust it. Covers
   `analytics-cleanup`, `helm-installer`, and `kubectl-applier-simple`.
   No behaviour change.

5. **`feat(deps-scan): detect newer EKS Kubernetes minor releases`**
   The monthly dependency scan now compares
   `cdk.json::kubernetes_version` against the latest minor still in
   EKS standard support (`eks:DescribeClusterVersions` filtered by
   `STANDARD_SUPPORT`) and, when drift is detected, renders a table
   with the current pin, latest available minor, and the
   end-of-standard-support date for the pinned minor so upgrade
   urgency is visible in the generated issue. `.github/oidc_provider/policy.json`
   and the two inline policy snippets in `.github/CI.md` +
   `.github/oidc_provider/README.md` grow the new IAM action.
   `tests/test_oidc_stack.py` asserts the synthesised stack grants it.

## Testing

Not merging until I do more environment testing. So far I've confirmed:

- All 17 cleanup-handler tests pass, including the new drain-loop and
  timeout cases.
- All 30 `test_stacks.py::TestStackManagerDestroy*` /
  `TestRemoveApiGatewayAnalyticsDependency` /
  `TestApiGatewayImportsFromAnalytics` cases pass.
- All 42 analytics-stack synth tests pass against the 15-minute
  timeout.
- All 20 OIDC stack tests pass with the new
  `eks:DescribeClusterVersions` assertion.
- All 56 BATS cases in `tests/BATS/test_dependency_scan.bats` pass.
- `shellcheck -x .github/scripts/dependency-scan.sh` is clean.
- Local end-to-end run of `dependency-scan.sh` without AWS creds
  hits every preflight skip cleanly and writes a well-formed report.

## Operator notes

- **Stuck `gco-analytics` stacks existing before this PR** still need
  to be unwedged manually (delete remaining user profiles via the
  console or `aws sagemaker delete-user-profile`, then
  `aws cloudformation delete-stack`). This PR prevents the stuck state
  from recurring on future destroys but does not un-stick an already
  failed stack.
- **OIDC policy needs redeploy** in any account running the
  deps-scan workflow. From `.github/oidc_provider/`:
  `cdk deploy GCOGitHubOIDCStack`.
- Kubernetes minor check is a no-op until the next sc
