### PR TITLE
docs: added tables of contents to four readmes

### DIFF
--- a/lambda/README.md
+++ b/lambda/README.md
@@ -2,6 +2,13 @@
 
 AWS Lambda functions that power GCO's infrastructure layer. These are deployed as part of the CDK stacks and handle cluster operations, API routing, security, and cross-region coordination.
 
+## Table of Contents
+
+- [Contents](#contents)
+- [Build](#build)
+- [Architecture](#architecture)
+- [Control-Flow Diagrams](#control-flow-diagrams)
+
 ## Contents
 
 | Directory | Description |

--- a/lambda/analytics-cleanup/README.md
+++ b/lambda/analytics-cleanup/README.md
@@ -2,6 +2,16 @@
 
 CloudFormation custom resource handler that runs during `gco-analytics` stack deletion. Removes resources that CloudFormation can't delete on its own because they were created at runtime (not in the template).
 
+## Table of Contents
+
+- [What it does](#what-it-does)
+- [Why it's needed](#why-its-needed)
+- [Environment variables](#environment-variables)
+- [IAM permissions required](#iam-permissions-required)
+- [Error handling](#error-handling)
+- [Dependencies](#dependencies)
+- [Tests](#tests)
+
 ## What it does
 
 On stack **Delete**:

--- a/lambda/proxy-shared/README.md
+++ b/lambda/proxy-shared/README.md
@@ -2,6 +2,12 @@
 
 Shared utility library used by the `api-gateway-proxy` and `regional-api-proxy` Lambda functions. Not deployed as a standalone Lambda.
 
+## Table of Contents
+
+- [Contents](#contents)
+- [Provided Utilities](#provided-utilities)
+- [Usage](#usage)
+
 ## Contents
 
 - `proxy_utils.py` — Thread-safe secret caching and HTTP forwarding with retry logic

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,16 @@
 
 Utility scripts for development, testing, and operations.
 
+## Table of Contents
+
+- [Contents](#contents)
+- [Usage](#usage)
+  - [Setup Cluster Access](#setup-cluster-access)
+  - [Bump Version](#bump-version)
+  - [Test CDK Synthesis](#test-cdk-synthesis)
+  - [Dump cdk-nag Findings](#dump-cdk-nag-findings)
+  - [Test Webhook Delivery](#test-webhook-delivery)
+
 ## Contents
 
 | Script | Description |


### PR DESCRIPTION
<!--
Thanks for contributing to GCO! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

Adds four tables of contents to READMEs.

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [x] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [x] `pytest tests/` passes locally
- [x] `cdk synth` succeeds (if CDK code changed)
- [x] New tests added for new behavior
- [x] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [x] Documentation updated (README, `docs/`, inline docstrings) as needed
- [x] No secrets, credentials, or customer data committed
- [x] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [x] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
