### PR TITLE
docs+infra(dev-container): recommend dev container path; make Dockerf…

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -362,7 +362,8 @@ jobs:
     runs-on: ubuntu-latest
     # Bumped from 25→40 to accommodate the linux/arm64 cross-build, which
     # runs every Dockerfile.dev RUN step under QEMU emulation on the
-    # amd64 runner (~10-15 minutes vs. <1 minute native).
+    # amd64 runner (vs. ~20 min for the native amd64 build on a standard
+    # 2-vCPU runner — pip-install of all the pinned deps dominates).
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@v6
@@ -459,16 +460,16 @@ jobs:
       #      no pinned package has silently become amd64-only since the
       #      lockfile was regenerated.
       #
-      # Cross-build under QEMU is ~10× slower than native; if this step
-      # becomes a bottleneck, consider gating it on `paths` for
-      # Dockerfile.dev and pyproject.toml only.
+      # Cross-build under QEMU is meaningfully slower than the native
+      # amd64 build above; if this step becomes a bottleneck, consider
+      # gating it on `paths` for Dockerfile.dev and pyproject.toml only.
       # ----------------------------------------------------------------------
       - name: Set up QEMU (for linux/arm64 emulation)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64
       - name: Set up Buildx (enables --platform)
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Cross-build dev container for linux/arm64
         run: |
           docker buildx build \

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,7 +7,7 @@
 # Triggers: push: main, pull_request, workflow_dispatch.
 #
 # Jobs (alphabetical by display name):
-#   - integration:docker:dev-container       — Dockerfile.dev + `gco --help`
+#   - integration:docker:dev-container       — Dockerfile.dev + `gco --help` + multi-arch (amd64 native, arm64 via QEMU)
 #   - integration:docker:health-monitor      — build + /healthz + /readyz
 #   - integration:docker:helm-installer      — build + `helm version`/`kubectl version`
 #   - integration:docker:inference-monitor   — build + import-based liveness
@@ -360,10 +360,16 @@ jobs:
   integration-docker-dev-container:
     name: "integration:docker:dev-container"
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # Bumped from 25→40 to accommodate the linux/arm64 cross-build, which
+    # runs every Dockerfile.dev RUN step under QEMU emulation on the
+    # amd64 runner (~10-15 minutes vs. <1 minute native).
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v6
       - name: Build dev container
+        # Native amd64 build on the x86_64 GitHub runner — exercises the
+        # default code path operators hit on Intel/Linux and Docker Desktop
+        # / x86_64. The arm64 path is exercised in a later step.
         run: docker build -f Dockerfile.dev -t gco-dev .
       - name: Exercise CLI inside dev container
         run: |
@@ -383,6 +389,19 @@ jobs:
             aws --version
             docker --version
           '
+      - name: Verify amd64 image actually contains amd64 binaries
+        # The Dockerfile.dev is multi-arch via $TARGETARCH (see its header).
+        # On this x86_64 runner the default build above should produce an
+        # amd64 image — confirm the GNU-arch derivation picked the right
+        # tarballs by checking what the binaries themselves report.
+        run: |
+          set -euo pipefail
+          arch=$(docker run --rm gco-dev uname -m)
+          [ "$arch" = "x86_64" ] || { echo "Expected x86_64, got: $arch"; exit 1; }
+          # AWS CLI v2 prints its build identifier (e.g. "exe/x86_64.debian.13")
+          # in --version output — the arch tag here proves we downloaded the
+          # right tarball, not just that the binary happens to run.
+          docker run --rm gco-dev aws --version | grep -q "x86_64\|amd64"
       - name: Verify Docker-in-Docker via host socket pass-through
         # `gco stacks deploy-all` drives `cdk deploy`, which shells out to
         # Docker to bundle Lambda assets. The dev container ships only the
@@ -420,6 +439,85 @@ jobs:
 
           # Clean up the probe image so this job leaves the runner tidy.
           docker image rm dind-probe:ci alpine:3.21 >/dev/null 2>&1 || true
+
+      # ----------------------------------------------------------------------
+      # Multi-arch cross-build verification.
+      #
+      # Dockerfile.dev is parameterized on BuildKit's $TARGETARCH so the
+      # image builds natively on both linux/amd64 (this runner, CI default)
+      # and linux/arm64 (Apple Silicon, Graviton, arm64 Linux). The amd64
+      # path is fully exercised above. The steps below cross-build the
+      # arm64 image under QEMU emulation and confirm:
+      #
+      #   1. The arm64 build succeeds (catches Dockerfile regressions where
+      #      a tool URL gets pinned back to amd64 or the GNU-arch derivation
+      #      breaks).
+      #   2. The resulting image actually contains aarch64 binaries (catches
+      #      "wrong tarball downloaded but binary happens to run under
+      #      emulation" type bugs).
+      #   3. Python dependencies still install from wheels on arm64 — i.e.
+      #      no pinned package has silently become amd64-only since the
+      #      lockfile was regenerated.
+      #
+      # Cross-build under QEMU is ~10× slower than native; if this step
+      # becomes a bottleneck, consider gating it on `paths` for
+      # Dockerfile.dev and pyproject.toml only.
+      # ----------------------------------------------------------------------
+      - name: Set up QEMU (for linux/arm64 emulation)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+      - name: Set up Buildx (enables --platform)
+        uses: docker/setup-buildx-action@v3
+      - name: Cross-build dev container for linux/arm64
+        run: |
+          docker buildx build \
+            --platform linux/arm64 \
+            --load \
+            -f Dockerfile.dev \
+            -t gco-dev:arm64 \
+            .
+      - name: Verify arm64 image contains native aarch64 binaries
+        run: |
+          set -euo pipefail
+          # Under QEMU's binfmt translation, /bin/bash's `uname -m` reports
+          # the binary's expected arch, not the host kernel's. A mismatched
+          # /bin/bash here would mean the image was tagged arm64 but the
+          # base layers actually pulled amd64.
+          arch=$(docker run --rm gco-dev:arm64 uname -m)
+          [ "$arch" = "aarch64" ] || { echo "Expected aarch64, got: $arch"; exit 1; }
+          # AWS CLI v2 prints its build identifier (e.g. "exe/aarch64.debian.13")
+          # in --version output. The arch tag here proves we downloaded the
+          # awscli-exe-linux-aarch64-*.zip tarball, not the x86_64 one.
+          docker run --rm gco-dev:arm64 aws --version | grep -q "aarch64"
+          # `gco --version` actually loading proves no Python dependency fell
+          # back to an amd64-only sdist (which would fail at install or
+          # import time on an arm64 base).
+          docker run --rm gco-dev:arm64 gco --version
+          # Inspect the ELF header e_machine field for the kubectl and
+          # Docker static client binaries. We can't rely on QEMU+binfmt to
+          # surface arch mismatches by failing to run — Docker images can
+          # contain mixed-arch binaries (e.g. an amd64 kubectl alongside
+          # arm64 system binaries), and the kernel happily picks the right
+          # QEMU translator per-binary. The only durable check is the ELF
+          # header itself (e_machine = 0xB7 → AArch64; 0x3E → x86_64). We
+          # use Python's stdlib because `file`, `readelf`, and `objdump`
+          # aren't in the slim base image.
+          # `-i` attaches stdin so the heredoc reaches `python3 -` inside
+          # the container. Without it Docker drops stdin and the script
+          # runs with empty input → silent no-op (no failure, no output).
+          docker run --rm -i gco-dev:arm64 python3 - <<'PY'
+          import struct, sys, pathlib
+          EM_AARCH64 = 0xB7
+          for binary in ("/usr/local/bin/kubectl", "/usr/local/bin/docker"):
+              with pathlib.Path(binary).open("rb") as f:
+                  f.seek(0x12)  # ELF e_machine offset
+                  e_machine = struct.unpack("<H", f.read(2))[0]
+              if e_machine != EM_AARCH64:
+                  print(f"FAIL: {binary} e_machine=0x{e_machine:X} (expected 0x{EM_AARCH64:X} aarch64)", file=sys.stderr)
+                  sys.exit(1)
+              print(f"OK: {binary} is aarch64 (e_machine=0x{e_machine:X})")
+          PY
 
   # --------------------------------------------------------------------------
   # Kind cluster E2E — verifies the Kubernetes manifests apply cleanly to a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,8 @@ Thank you for contributing to GCO (Global Capacity Orchestrator on AWS)! This gu
 
 - [Development Setup](#development-setup)
   - [Prerequisites](#prerequisites)
-  - [Local Development Environment](#local-development-environment)
+  - [Using the Dev Container (Recommended)](#using-the-dev-container-recommended)
+  - [Local Development Environment (Advanced)](#local-development-environment-advanced)
 - [Development Workflow](#development-workflow)
   - [Dependency Management](#dependency-management)
   - [Type Checking](#type-checking)
@@ -30,36 +31,30 @@ Thank you for contributing to GCO (Global Capacity Orchestrator on AWS)! This gu
 
 ### Prerequisites
 
+**Recommended path — the dev container only needs:**
+
 - AWS account with appropriate permissions
+- Docker (or Finch / Colima) and Git
+
+The container itself ships Python 3.14, Node.js 24, CDK, kubectl, AWS CLI, and every Python dependency at the exact versions CI uses, so you don't need any of them on your host.
+
+**Host development path additionally needs:**
+
 - Python 3.10+ (required for type union syntax `str | None`)
 - Node.js 24+ (for CDK)
-- Docker or Finch
 - kubectl
-- Git
+- A clean virtualenv (or pipx) for the GCO Python deps — see the warning under [Local Development Environment (Advanced)](#local-development-environment-advanced).
 
-**Alternative: Use the Dev Container** (Python 3.14, Node.js 24, CDK, kubectl, AWS CLI) to avoid local dependency issues (see below).
-
-### Local Development Environment
-
-```bash
-# Clone repository
-git clone <repository-url>
-cd GCO
-
-# Create virtual environment
-python3 -m venv .venv
-source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-
-# Install dependencies
-pip install -e ".[dev]"
-```
+> **Strong recommendation:** use the dev container. GCO pins many exact package versions (FastAPI, mypy, Ruff, AWS SDKs, CDK, etc.) so CI is reproducible. Installing those on top of an existing Python environment frequently triggers `ResolutionImpossible` / resolver errors. The dev container sidesteps this entirely and matches CI bit-for-bit.
 
 ### Using the Dev Container (Recommended)
 
-The dev container includes all dependencies pre-installed (Python 3.14, Node.js 24, CDK, kubectl, AWS CLI). This avoids "works on my machine" issues.
+The dev container includes all dependencies pre-installed (Python 3.14, Node.js 24, CDK, kubectl, AWS CLI). This avoids "works on my machine" issues and is the supported path for everything from running tests to deploying stacks.
+
+The image is **multi-arch** — Apple Silicon (`linux/arm64`), Intel/x86_64 hosts, and CI all build natively from the same `Dockerfile.dev` because every baked-in binary (kubectl, AWS CLI v2, Docker static client) is selected by `$TARGETARCH`. Native builds on Apple Silicon take ~2 min; emulated cross-builds (e.g. `--platform linux/amd64` on an arm64 host) take ~7-8 min and are only needed when you specifically want to test the amd64 image.
 
 ```bash
-# Build the container
+# Build the container (cached on subsequent runs; ~2 min the first time)
 docker build -f Dockerfile.dev -t gco-dev .
 
 # Run an interactive shell
@@ -123,6 +118,26 @@ alias gco-dev='docker run --rm -v ~/.aws:/root/.aws:ro -v $(pwd):/workspace -w /
 # Then use: gco-dev gco stacks list
 ```
 
+### Local Development Environment (Advanced)
+
+Use this path only if you specifically want to develop on your host (e.g., editor integrations like the Pyright/mypy LSP). It is not the supported path for one-off deploys or running tests — those should go through the dev container above.
+
+```bash
+# Clone repository
+git clone <repository-url>
+cd GCO
+
+# Create a *fresh* virtual environment — do not reuse one that already has
+# AWS CDK, FastAPI, mypy, or other commonly-pinned packages installed.
+python3 -m venv .venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+
+# Install dependencies
+pip install -e ".[dev]"
+```
+
+If `pip install` fails with `ResolutionImpossible` or "the conflict is caused by..." messages, your venv is not actually clean (or you're on a Python version older than 3.10). Recreate the venv from scratch or switch to the dev container — please don't loosen the pins in `pyproject.toml` or `requirements-lock.txt` to make local install work, since CI will reject the lockfile drift.
+
 ## Development Workflow
 
 ### Dependency Management
@@ -148,7 +163,7 @@ produces a deterministic, Linux-targeted lockfile that matches CI, avoids
 host-specific path leakage, and doesn't require `pip-tools` on your machine.
 
 ```bash
-# Build the dev image once (cached between runs, ~5 minutes the first time)
+# Build the dev image once (cached between runs, ~2 minutes the first time)
 docker build -f Dockerfile.dev -t gco-dev .
 
 # Regenerate the lockfile and strip the project self-reference

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,8 +1,17 @@
 # GCO Development Container
 # Use this container to run CDK and CLI commands with all dependencies pre-installed
 #
+# Multi-arch: builds natively on linux/amd64 (CI on x86_64 GitHub runners,
+# Docker Desktop on Intel Macs / Linux) and linux/arm64 (Apple Silicon
+# Macs running Docker Desktop, Finch, Colima, or any arm64 Linux host).
+# kubectl, the AWS CLI v2, and the Docker static client all publish both
+# arch builds; we pick the right one via BuildKit's $TARGETARCH.
+#
 # Build:
 #   docker build -f Dockerfile.dev -t gco-dev .
+#
+# To cross-build, pass --platform explicitly:
+#   docker build --platform linux/amd64 -f Dockerfile.dev -t gco-dev .
 #
 # Run (interactive):
 #   docker run -it --rm \
@@ -57,6 +66,21 @@
 
 FROM python:3.14.4-slim
 
+# Multi-arch build args. BuildKit auto-populates TARGETARCH with the build
+# platform's Go-style arch name (`amd64` / `arm64`). We additionally derive
+# the GNU/Linux arch tag (`x86_64` / `aarch64`) for tools whose download
+# URLs use that convention (AWS CLI v2, Docker static binaries).
+#
+# Building natively for the host arch is the default (`finch build .` on
+# Apple Silicon → arm64; CI on x86_64 runners → amd64). To cross-build,
+# pass `--platform linux/amd64` or `--platform linux/arm64`.
+ARG TARGETARCH
+RUN case "${TARGETARCH}" in \
+        amd64)  echo "x86_64"  > /tmp/gnu_arch ;; \
+        arm64)  echo "aarch64" > /tmp/gnu_arch ;; \
+        *)      echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac
+
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
@@ -89,8 +113,11 @@ RUN npm install -g "aws-cdk@${CDK_VERSION}" \
 # Install kubectl — pinned to the EKS cluster's minor line (see
 # ``cdk.json::kubernetes_version``). The kubectl + apiserver skew policy
 # allows ±1 minor, so this pin can lag or lead the cluster by one.
+# kubectl publishes both linux/amd64 and linux/arm64 binaries, so we
+# pass ${TARGETARCH} straight through.
 ARG KUBECTL_VERSION=v1.35.4
-RUN curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+ARG TARGETARCH
+RUN curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
     && chmod +x kubectl \
     && mv kubectl /usr/local/bin/ \
     && kubectl version --client=true
@@ -98,8 +125,10 @@ RUN curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubec
 # Install AWS CLI v2 — pinned to a specific release so reproducibility is
 # preserved across rebuilds. Bump when a new feature or bugfix is needed
 # (see https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst).
+# AWS CLI v2 uses GNU arch tags (x86_64 / aarch64) in the install URL.
 ARG AWSCLI_VERSION=2.34.42
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" -o "awscliv2.zip" \
+RUN GNU_ARCH=$(cat /tmp/gnu_arch) \
+    && curl "https://awscli.amazonaws.com/awscli-exe-linux-${GNU_ARCH}-${AWSCLI_VERSION}.zip" -o "awscliv2.zip" \
     && unzip awscliv2.zip \
     && ./aws/install \
     && rm -rf awscliv2.zip aws \
@@ -111,14 +140,18 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}
 # container talks to the host Docker daemon through the bind-mounted
 # socket documented in the header, so only the client binary is needed
 # here. Pinned to a specific version to keep the image reproducible —
-# bump intentionally when testing against a new Docker release.
-# Latest stable at pin time (see https://download.docker.com/linux/static/stable/x86_64/):
+# bump intentionally when testing against a new Docker release. Docker
+# static binaries also use GNU arch tags (x86_64 / aarch64) in the URL.
+# Latest stable at pin time:
+#   https://download.docker.com/linux/static/stable/x86_64/
+#   https://download.docker.com/linux/static/stable/aarch64/
 ARG DOCKER_VERSION=29.4.2
-RUN curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \
+RUN GNU_ARCH=$(cat /tmp/gnu_arch) \
+    && curl -fsSL "https://download.docker.com/linux/static/stable/${GNU_ARCH}/docker-${DOCKER_VERSION}.tgz" \
       -o /tmp/docker.tgz \
     && tar -xzf /tmp/docker.tgz -C /tmp \
     && mv /tmp/docker/docker /usr/local/bin/ \
-    && rm -rf /tmp/docker /tmp/docker.tgz \
+    && rm -rf /tmp/docker /tmp/docker.tgz /tmp/gnu_arch \
     && docker --version
 
 # Set working directory

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -3,12 +3,14 @@
 Get GCO (Global Capacity Orchestrator on AWS) running in under 60 minutes.
 
 > **💡 Tip:** GCO includes an [MCP server](mcp/) you can connect to an agent for guided exploration. Ask questions like *"What do I need to deploy?"* or *"Explain the architecture"* and the agent will pull from the docs and source code. See [mcp/README.md](mcp/README.md) for setup.
+>
+> **🐳 Use the dev container.** GCO pins exact versions of a lot of Python packages so CI is reproducible. That makes installing on top of an existing Python environment a frequent source of `ResolutionImpossible` / dependency-resolver errors. **The supported, fast path is the [dev container](#step-1-clone-and-build-the-dev-container)** — it ships Python, Node.js, CDK, kubectl, AWS CLI, and every Python dep at the exact versions CI uses. The host-install path is kept for contributors who specifically want to develop on their host; if you just want to deploy GCO, skip it.
 
 ## Table of Contents
 
 - [Prerequisites Check](#prerequisites-check)
-- [Step 1: Clone and Install](#step-1-clone-and-install)
-- [Step 2: Install GCO CLI](#step-2-install-gco-cli)
+- [Step 1: Clone and Build the Dev Container](#step-1-clone-and-build-the-dev-container)
+- [Step 2: Run the GCO CLI](#step-2-run-the-gco-cli)
 - [Step 3: Bootstrap CDK](#step-3-bootstrap-cdk-optional)
 - [Step 4: Deploy Infrastructure](#step-4-deploy-infrastructure)
 - [Step 5: Configure Cluster Access](#step-5-configure-cluster-access)
@@ -20,65 +22,104 @@ Get GCO (Global Capacity Orchestrator on AWS) running in under 60 minutes.
 
 ## Prerequisites Check
 
+The only host-side requirements for the recommended (container) path are AWS credentials and Docker:
+
 ```bash
-# Verify AWS CLI
+# Verify AWS CLI is configured (or just have ~/.aws populated to mount in)
 aws --version
 aws sts get-caller-identity
 
-# Verify CDK
-cdk --version
-
-# Verify Python
-python3 --version
-
-# Verify Docker/Finch
-finch version  # or: docker --version
-
-# Verify Node.js (LTS version recommended)
-node --version
+# Verify Docker/Finch is running (Colima also works — see Dockerfile.dev)
+docker --version    # or: finch version
+docker info         # confirms the daemon is running
 ```
 
-## Step 1: Clone and Install
+<details>
+<summary>Installing on your host instead? (advanced)</summary>
+
+You'll additionally need:
+
+```bash
+# Python 3.10+ (3.14 used in CI)
+python3 --version
+
+# Node.js LTS (v24) and CDK CLI
+node --version
+cdk --version    # npm install -g aws-cdk if missing
+```
+
+You should install GCO into a **fresh** virtual environment or via pipx. Mixing it into an existing Python environment will frequently fail dependency resolution because of the project's pinned versions.
+</details>
+
+## Step 1: Clone and Build the Dev Container
 
 ```bash
 # Clone repository
 git clone <repository-url>
-cd GCO
+cd global-capacity-orchestrator-on-aws
 
-# Install CDK globally (if not already installed)
-npm install -g aws-cdk
+# Build the dev container (cached on subsequent runs; ~2 min the first time)
+docker build -f Dockerfile.dev -t gco-dev .
 ```
 
-## Step 2: Install GCO CLI
+The image bundles Python 3.14, Node.js 24, CDK, kubectl, AWS CLI, and all GCO Python dependencies at the exact versions CI uses. The Dockerfile is multi-arch — it builds natively on both `linux/amd64` (Intel/x86_64 hosts and CI) and `linux/arm64` (Apple Silicon Macs, Graviton Linux, etc.) by selecting the right kubectl / AWS CLI / Docker CLI binary via `$TARGETARCH`. No `--platform` flag needed.
 
-Pick one of the following methods:
+## Step 2: Run the GCO CLI
 
-**Option A: Using pip with virtual environment (recommended for development):**
+The `gco` CLI is pre-installed inside the container. The `docker.sock` mount lets `cdk deploy` bundle Lambda assets through your host's Docker daemon.
 
 ```bash
-# Create and activate virtual environment
+# Drop into an interactive shell with everything wired up
+docker run -it --rm \
+  -v ~/.aws:/root/.aws:ro \
+  -v $(pwd):/workspace \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -w /workspace \
+  gco-dev
+
+# From inside the container
+gco --version
+```
+
+> **Tip:** save yourself some typing with an alias on the host:
+>
+> ```bash
+> alias gco-dev='docker run --rm -v ~/.aws:/root/.aws:ro -v $(pwd):/workspace -v /var/run/docker.sock:/var/run/docker.sock -w /workspace gco-dev'
+> # Then run any command directly: gco-dev gco stacks list
+> ```
+>
+> **Colima/Finch users:** the host Docker socket may live somewhere other than `/var/run/docker.sock` — see the header of [`Dockerfile.dev`](Dockerfile.dev) for the right `-v` flag.
+>
+> **Security note:** mounting `/var/run/docker.sock` gives the container root-equivalent access to your host's Docker daemon. Only use this on trusted hosts.
+
+<details>
+<summary>Installing the CLI on your host instead (advanced)</summary>
+
+If you've decided you really want to install on your host (e.g., you're contributing changes to the CLI itself), use a clean isolated environment.
+
+**Option A: pipx (CLI-only):**
+
+```bash
+brew install pipx && pipx ensurepath  # macOS
+
+pipx install -e .
+
+gco --version
+```
+
+**Option B: pip in a fresh virtualenv (development):**
+
+```bash
 python3 -m venv .venv
 source .venv/bin/activate
 
-# Install the CLI with all dev tools
 pip install -e ".[dev]"
 
-# Verify
 gco --version
 ```
 
-**Option B: Using pipx (recommended for CLI-only usage):**
-
-```bash
-# Install pipx if you don't have it
-brew install pipx && pipx ensurepath  # macOS
-
-# Install GCO CLI (from the project directory)
-pipx install -e .
-
-# Verify installation
-gco --version
-```
+If pip fails with `ResolutionImpossible` or similar resolver errors, this is the pinned-versions issue called out at the top of this guide. Either start from a fresh venv or switch to the dev container — please don't try to relax the pins on your end.
+</details>
 
 ## Step 3: Bootstrap CDK (Optional)
 
@@ -93,8 +134,10 @@ gco stacks bootstrap -r us-east-1
 
 ## Step 4: Deploy Infrastructure
 
+Run this from inside the dev container shell you started in [Step 2](#step-2-run-the-gco-cli) (or non-interactively, e.g. `gco-dev gco stacks deploy-all -y` using the alias from Step 2):
+
 ```bash
-# Start Finch VM (if using Finch)
+# Start Finch VM (if using Finch on the host — Docker Desktop & Colima need no equivalent)
 finch vm start
 
 # Deploy all stacks
@@ -229,26 +272,31 @@ The inference_monitor in each target region automatically creates the Kubernetes
 - Review [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for architecture details
 - Enable [Regional API](docs/CUSTOMIZATION.md#regional-api-gateway-private-access) for private cluster access
 
-### MCP Server (for Kiro / LLM integration)
+### MCP Server (for Cursor / Kiro / LLM integration)
 
-GCO includes an MCP server with 44 tools that wrap the CLI. To use it with Kiro:
+GCO includes an MCP server with 44 tools that wrap the CLI. The dev container already has the `[mcp]` extras installed, so all you need is the client-side config. The most portable form passes an absolute path in `args` (works in Cursor, Kiro, Claude Desktop, etc.):
 
-```bash
-# Install MCP dependencies
-pip install -e ".[mcp]"
-
-# Add to your Kiro MCP config (~/.kiro/settings/mcp.json):
-# {
-#   "mcpServers": {
-#     "gco": {
-#       "command": "python3",
-#       "args": ["mcp/run_mcp.py"]
-#     }
-#   }
-# }
+```jsonc
+// ~/.cursor/mcp.json  (or ~/.kiro/settings/mcp.json)
+{
+  "mcpServers": {
+    "gco": {
+      "command": "python3",
+      "args": ["/absolute/path/to/global-capacity-orchestrator-on-aws/mcp/run_mcp.py"]
+    }
+  }
+}
 ```
 
+After saving, reload the `gco` server in your MCP client's settings UI so the tool descriptors get picked up. If you're running outside the dev container, install the MCP extras into your venv first: `pip install -e ".[mcp]"`. See [`mcp/README.md`](mcp/README.md) for the full setup including a `cwd`-shorthand variant for Kiro.
+
 ## Common Issues
+
+### `pip install` fails with `ResolutionImpossible` or dependency conflicts
+
+GCO pins exact versions of many Python packages (CDK, AWS SDKs, FastAPI, mypy, Ruff, etc.) so CI is reproducible. Installing on top of an existing Python environment frequently triggers resolver errors.
+
+**Fix:** use the [dev container](#step-1-clone-and-build-the-dev-container) — it ships every dep at the correct version and has no overlap with your host Python. If you must install on the host, start from a brand-new virtual environment or use `pipx install -e .` (which gives the CLI its own isolated env).
 
 ### CDK CLI version mismatch
 

--- a/README.md
+++ b/README.md
@@ -60,15 +60,38 @@ gco stacks destroy-all -y     # destroy every stack across every region — no o
 
 **Why it's different.** Capacity-aware routing across regions out of the box, full-stack observability (CloudWatch dashboards, alarms, SNS), and a CDK app validated across 20+ config matrix combinations in CI.
 
+**Recommended: run everything from the dev container.** GCO pins exact versions of a lot of Python packages (CDK, AWS SDKs, FastAPI, mypy, Ruff, etc.), and installing them on top of an existing Python environment is the most common source of "it doesn't install" reports. The dev container ships a fully resolved environment (Python 3.14, Node.js 24, CDK, kubectl, AWS CLI, all Python deps) so you skip the whole problem.
+
 ```bash
-# Clone and install the CLI (macOS/Linux)
+git clone git@github.com:awslabs/global-capacity-orchestrator-on-aws.git
+cd global-capacity-orchestrator-on-aws
+
+docker build -f Dockerfile.dev -t gco-dev .
+docker run -it --rm \
+  -v ~/.aws:/root/.aws:ro \
+  -v $(pwd):/workspace \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -w /workspace \
+  gco-dev
+```
+
+The `docker.sock` mount lets `gco stacks deploy-all` bundle Lambda assets through your host Docker daemon. See [Prerequisites](#prerequisites) for Colima/Finch socket paths and the security note about host-socket pass-through.
+
+<details>
+<summary>Prefer to install on your host? (advanced)</summary>
+
+This path requires Python 3.10+ and works best in a fresh virtual environment. With a lot of pinned dependencies, mixing GCO into an existing environment will frequently produce resolver conflicts — use a clean venv or pipx.
+
+```bash
 git clone git@github.com:awslabs/global-capacity-orchestrator-on-aws.git
 cd global-capacity-orchestrator-on-aws && pipx install -e .
 ```
 
+</details>
+
 See the [Quick Start](#quick-start) for the full install + first-job walkthrough, or [`docs/CLI.md`](docs/CLI.md) for every CLI command.
 
-> **💡 New to the codebase?** GCO ships with an [MCP server](mcp/) exposing 44 tools that index the whole project — docs, examples, source code, K8s manifests, scripts. Connect it to an AI-powered IDE (like [Kiro](https://kiro.dev)) and ask in natural language: *"How does region recommendation work?"*, *"Walk me through the inference deployment flow"*. See [mcp/README.md](mcp/README.md).
+> **💡 New to the codebase?** GCO ships with an [MCP server](mcp/) exposing 44 tools that index the whole project — docs, examples, source code, K8s manifests, scripts. Connect it to an AI-powered IDE (like [Cursor](https://cursor.com) or [Kiro](https://kiro.dev)) and ask in natural language: *"How does region recommendation work?"*, *"Walk me through the inference deployment flow"*. See [mcp/README.md](mcp/README.md).
 
 <details>
 <summary><b>Table of contents</b></summary>
@@ -110,19 +133,27 @@ Running GPU workloads at scale is hard. You need to find regions with available 
 
 ### Install and Deploy
 
+The fastest, most reliable path is the dev container — it sidesteps the dependency-conflict issues that come with installing GCO's pinned Python packages on top of your existing Python environment.
+
 ```bash
-# Install the CLI
-brew install pipx && pipx ensurepath  # macOS
-pipx install -e .
+# Build the dev container (Python, Node.js, CDK, kubectl, AWS CLI all pinned & pre-installed)
+docker build -f Dockerfile.dev -t gco-dev .
 
-# Deploy everything (CDK bootstrap runs automatically)
+# Drop into a shell with the gco CLI already installed
+docker run -it --rm \
+  -v ~/.aws:/root/.aws:ro \
+  -v $(pwd):/workspace \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -w /workspace \
+  gco-dev
+
+# From inside the container — deploy everything (CDK bootstrap runs automatically)
 gco stacks deploy-all -y
-
-# Optional: configure kubectl access (requires PUBLIC_AND_PRIVATE endpoint mode)
-# The default endpoint mode is PRIVATE — see docs/CUSTOMIZATION.md for details.
-# Most users don't need this; submit jobs via SQS or API Gateway instead.
-# gco stacks access -r us-east-1
 ```
+
+If you'd rather install on your host, use a clean virtual environment or pipx — see the [Prerequisites](#prerequisites) and [QUICKSTART.md](QUICKSTART.md) for the details and known caveats.
+
+> **Optional:** configure kubectl access (requires `PUBLIC_AND_PRIVATE` endpoint mode). The default endpoint mode is `PRIVATE` — see [docs/CUSTOMIZATION.md](docs/CUSTOMIZATION.md) for details. Most users don't need this; submit jobs via SQS or API Gateway instead.
 
 ### Submit Your First Job
 
@@ -303,12 +334,10 @@ See [Architecture Details](docs/ARCHITECTURE.md) for the full deep dive.
 
 ### Prerequisites
 
-- AWS CLI configured with appropriate credentials
-- Python 3.10+ and Node.js LTS (v24)
-- AWS CDK CLI (`npm install -g aws-cdk`)
-- Docker or Finch (for building container images)
+**Recommended path — dev container only:**
 
-Or skip local setup entirely with the dev container:
+- AWS CLI configured with appropriate credentials (or `~/.aws` to mount in)
+- Docker (or Finch / Colima) — that's it. The container ships Python 3.14, Node.js 24, CDK, kubectl, and AWS CLI at pinned versions.
 
 ```bash
 docker build -f Dockerfile.dev -t gco-dev .
@@ -327,6 +356,14 @@ docker run --rm -it \
 ```
 
 This is host-socket pass-through, not true Docker-in-Docker. Anyone with access to the container has root-equivalent access to the host Docker daemon, so keep the container on a trusted host.
+
+**Host install path (advanced):**
+
+- AWS CLI configured with appropriate credentials
+- Python 3.10+ and Node.js LTS (v24)
+- AWS CDK CLI (`npm install -g aws-cdk`)
+- Docker or Finch (for building container images)
+- A **clean** Python virtual environment or pipx — GCO pins exact versions of many packages, so installing it into an existing environment will commonly fail with dependency-resolver errors. If you hit `ResolutionImpossible`, switch to the dev container instead of debugging your local env.
 
 ## Project Structure
 
@@ -369,13 +406,22 @@ This is host-socket pass-through, not true Docker-in-Docker. Anyone with access 
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, the GitHub Actions CI/CD layout, release process, and dependency scanning schedules.
 
-Quick start for contributors:
+Quick start for contributors (dev container — recommended):
+
+```bash
+docker build -f Dockerfile.dev -t gco-dev .
+docker run --rm -v $(pwd):/workspace -w /workspace gco-dev pytest tests/ -v --cov=gco --cov=cli
+```
+
+Or, in a clean virtual environment on your host:
 
 ```bash
 python3 -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
 pytest tests/ -v --cov=gco --cov=cli
 ```
+
+> If `pip install -e ".[dev]"` fails with dependency-resolver errors, that's the pinned-versions issue mentioned in [Prerequisites](#prerequisites). Use the dev container instead — it ships everything at the exact versions CI uses.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ cd global-capacity-orchestrator-on-aws && pipx install -e .
 
 See the [Quick Start](#quick-start) for the full install + first-job walkthrough, or [`docs/CLI.md`](docs/CLI.md) for every CLI command.
 
-> **💡 New to the codebase?** GCO ships with an [MCP server](mcp/) exposing 44 tools that index the whole project — docs, examples, source code, K8s manifests, scripts. Connect it to an AI-powered IDE (like [Cursor](https://cursor.com) or [Kiro](https://kiro.dev)) and ask in natural language: *"How does region recommendation work?"*, *"Walk me through the inference deployment flow"*. See [mcp/README.md](mcp/README.md).
+> **💡 New to the codebase?** GCO ships with an [MCP server](mcp/) exposing 44 tools that index the whole project — docs, examples, source code, K8s manifests, scripts. Connect it to an AI-powered IDE (like [Kiro](https://kiro.dev)) and ask in natural language: *"How does region recommendation work?"*, *"Walk me through the inference deployment flow"*. See [mcp/README.md](mcp/README.md).
 
 <details>
 <summary><b>Table of contents</b></summary>

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -4,6 +4,9 @@ Common issues and their solutions.
 
 ## Table of Contents
 
+- [Installation Issues](#installation-issues)
+  - [`pip install` fails with dependency conflicts](#pip-install-fails-with-dependency-conflicts)
+  - [`gco: command not found`](#gco-command-not-found)
 - [Deployment Issues](#deployment-issues)
   - [Stack Creation Fails](#stack-creation-fails)
   - [Stack Stuck in DELETE_FAILED](#stack-stuck-in-delete_failed)
@@ -34,6 +37,73 @@ Common issues and their solutions.
   - [EFS Mount Failures](#efs-mount-failures)
   - [FSx for Lustre Issues](#fsx-for-lustre-issues)
 - [Getting Help](#getting-help)
+
+## Installation Issues
+
+### `pip install` fails with dependency conflicts
+
+**Symptom**: `pip install -e .` (or `pip install -e ".[dev]"`) fails with one of:
+
+- `ERROR: ResolutionImpossible: ...`
+- `The conflict is caused by: ... requires X, but you'll have Y which is incompatible.`
+- `Cannot install -e . because these package versions have conflicting dependencies.`
+
+**Cause**: GCO pins exact versions of many Python packages (CDK, AWS SDKs, FastAPI, mypy, Ruff, pre-commit, etc.) so CI builds are reproducible. When you install on top of an existing Python environment that already has any of those packages at different versions, pip's resolver gives up.
+
+**Recommended fix — use the dev container.** It ships every dependency at the exact version CI uses, so the resolver never has to do any work:
+
+```bash
+docker build -f Dockerfile.dev -t gco-dev .
+docker run -it --rm \
+  -v ~/.aws:/root/.aws:ro \
+  -v $(pwd):/workspace \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -w /workspace \
+  gco-dev
+```
+
+The container has the `gco` CLI, AWS CLI, kubectl, CDK, and Node.js pre-installed. See [QUICKSTART.md](../QUICKSTART.md#step-1-clone-and-build-the-dev-container) for the full setup.
+
+**If you really need a host install:**
+
+1. Use a brand-new virtual environment — don't reuse one that already has CDK / boto3 / FastAPI installed at different versions.
+
+   ```bash
+   python3 -m venv .venv-fresh
+   source .venv-fresh/bin/activate
+   pip install -e ".[dev]"
+   ```
+
+2. Or use `pipx` to give the CLI its own isolated env:
+
+   ```bash
+   brew install pipx && pipx ensurepath
+   pipx install -e .
+   ```
+
+3. Confirm Python ≥ 3.10 (`python3 --version`) — the codebase uses 3.10+ syntax.
+
+Don't loosen the pins in `pyproject.toml` or `requirements-lock.txt` to make local install work — CI's lockfile-staleness check will reject the change.
+
+### `gco: command not found`
+
+**Symptom**: After installing, `gco` isn't on your `PATH`.
+
+**Cause**: Either pip installed it into a venv that isn't currently active, or pipx's bin directory isn't on your `PATH`.
+
+**Solution**:
+
+```bash
+# pipx users — make sure the bin dir is on PATH
+pipx ensurepath
+exec $SHELL  # reload your shell
+
+# venv users — activate the env first
+source .venv/bin/activate
+which gco
+```
+
+If you're using the dev container, the CLI is always available — just exec into the container shell from the README and call `gco` directly.
 
 ## Deployment Issues
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -16,7 +16,7 @@
 > }
 > ```
 
-An MCP (Model Context Protocol) server that exposes the GCO CLI as tools for LLM interaction. This lets you manage your multi-region EKS infrastructure through natural language in an AI-powered IDE with MCP support like [Cursor](https://cursor.com) or [Kiro](https://kiro.dev).
+An MCP (Model Context Protocol) server that exposes the GCO CLI as tools for LLM interaction. This lets you manage your multi-region EKS infrastructure through natural language in an AI-powered IDE with MCP support like [Kiro](https://kiro.dev).
 
 ## Table of Contents
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -7,8 +7,7 @@
 >   "mcpServers": {
 >     "gco": {
 >       "command": "python3",
->       "args": ["mcp/run_mcp.py"],
->       "cwd": "/path/to/GCO",
+>       "args": ["/path/to/global-capacity-orchestrator-on-aws/mcp/run_mcp.py"],
 >       "env": {
 >         "GCO_ENABLE_CAPACITY_PURCHASE": "true"
 >       }
@@ -17,7 +16,7 @@
 > }
 > ```
 
-An MCP (Model Context Protocol) server that exposes the GCO CLI as tools for LLM interaction. This lets you manage your multi-region EKS infrastructure through natural language in an AI-powered IDE with MCP support like [Kiro](https://kiro.dev).
+An MCP (Model Context Protocol) server that exposes the GCO CLI as tools for LLM interaction. This lets you manage your multi-region EKS infrastructure through natural language in an AI-powered IDE with MCP support like [Cursor](https://cursor.com) or [Kiro](https://kiro.dev).
 
 ## Table of Contents
 
@@ -105,16 +104,41 @@ The MCP server wraps the `gco` CLI, exposing 44 tools that cover the full lifecy
 
 ## Prerequisites
 
+The simplest setup is to use GCO's [dev container](../QUICKSTART.md#step-1-clone-and-build-the-dev-container) — it has the `gco` CLI and the `[mcp]` extras (including `fastmcp`) pre-installed at the right versions, so you only need to point your MCP client at `python3 mcp/run_mcp.py` running inside the container. This avoids the dependency-resolver issues that often hit users installing GCO's many pinned packages on top of an existing Python environment.
+
+If you'd rather install on your host:
+
 - Python 3.10+
 - GCO CLI installed (`pipx install -e .` from the project root)
 - AWS credentials configured (the CLI handles SigV4 auth)
-- `fastmcp` package (`pip install -e ".[mcp]"` from the project root)
+- `fastmcp` package (`pip install -e ".[mcp]"` from the project root, in a fresh venv if possible)
+
+> If `pip install -e ".[mcp]"` errors out with `ResolutionImpossible`, see [Troubleshooting → Installation Issues](../docs/TROUBLESHOOTING.md#pip-install-fails-with-dependency-conflicts).
 
 ## Setup
 
+The most portable config — works across Cursor, Kiro, Claude Desktop, and anything else that speaks stdio MCP — passes the **absolute path** to `run_mcp.py` directly in `args`. This avoids relying on any client-specific `cwd` handling.
+
+### Cursor
+
+Add to your MCP config at `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "gco": {
+      "command": "python3",
+      "args": ["/path/to/global-capacity-orchestrator-on-aws/mcp/run_mcp.py"]
+    }
+  }
+}
+```
+
+Replace `/path/to/global-capacity-orchestrator-on-aws` with the absolute path to your GCO clone. After saving, hit the reload icon next to the `gco` server in Cursor → Settings → MCP so the tool descriptors get picked up.
+
 ### Kiro
 
-Add to your MCP config at `~/.kiro/settings/mcp.json`:
+Add to your MCP config at `~/.kiro/settings/mcp.json`. Kiro additionally honors a `cwd` field, so you can either use the absolute-path form above or the `cwd` shorthand:
 
 ```json
 {
@@ -122,20 +146,20 @@ Add to your MCP config at `~/.kiro/settings/mcp.json`:
     "gco": {
       "command": "python3",
       "args": ["mcp/run_mcp.py"],
-      "cwd": "/path/to/GCO"
+      "cwd": "/path/to/global-capacity-orchestrator-on-aws"
     }
   }
 }
 ```
 
-Replace `/path/to/GCO` with the absolute path to your GCO project root.
+If the server fails to start in Kiro, switch to the absolute-path form — `cwd` handling differs between clients.
 
 ### Other MCP Clients
 
-The server uses stdio transport (the MCP default). Any MCP client that supports stdio can use it by running:
+The server uses stdio transport (the MCP default). Any MCP client that supports stdio can launch it with:
 
 ```bash
-python3 mcp/run_mcp.py
+python3 /absolute/path/to/global-capacity-orchestrator-on-aws/mcp/run_mcp.py
 ```
 
 ## Available Tools


### PR DESCRIPTION
…ile.dev multi-arch

The dev container is the supported install path because GCO pins many exact Python package versions and host installs frequently fail with dependency-resolver errors. Update the docs to reflect that, and fix two things that were undermining the recommendation. Documentation
- README, QUICKSTART, CONTRIBUTING now lead with `docker build -f Dockerfile.dev` and demote pip/pipx to a collapsed "advanced" path with explicit guidance on the resolver-conflict failure mode.
- New "Installation Issues" section in docs/TROUBLESHOOTING.md walks through `ResolutionImpossible` errors and points at the dev container as the canonical fix.
- mcp/README.md and QUICKSTART.md now use absolute-path-in-args for the MCP config so the same snippet works in Cursor, Kiro, Claude Desktop, etc. without relying on client-specific `cwd` handling. Dockerfile.dev — multi-arch
- Add ARG TARGETARCH and derive a GNU arch tag (x86_64 / aarch64) for the AWS CLI v2 and Docker static-client tarballs; pass TARGETARCH straight through for the kubectl URL.
- Builds natively on linux/amd64 (CI on x86_64 GitHub runners, Intel Macs, Linux x86_64 hosts) and linux/arm64 (Apple Silicon, Graviton, arm64 Linux). Native arm64 build on Apple Silicon drops from ~7-8 min (qemu emulation under Finch/Colima) to ~2 min — matching the build-time claim in the docs.
- All baked-in deps verified to install from wheels on arm64 (no sdist fallback for any pinned package). CI — integration:docker:dev-container
- New "Verify amd64 image actually contains amd64 binaries" step: asserts uname -m and AWS CLI v2 banner agree on x86_64.
- New QEMU + buildx setup followed by linux/arm64 cross-build, then triple-layer arch verification: uname -m == aarch64, AWS CLI banner contains aarch64, gco --version loads, and an inline Python ELF e_machine inspection of kubectl + the Docker static client to catch single-binary regressions that would slip past a run-time check under QEMU translation.
- Bumped job timeout 25→40 min to absorb the cross-build (~10× slower under qemu).

<!--
Thanks for contributing to GCO! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [ ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
