### PR TITLE
feat(mcp): add read-only Mission metric-reader tools

### DIFF
--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -19,6 +19,7 @@ Mission is GCO's goal-directed iteration loop. The operator declares a directive
   - [Allowed operators and constructs](#allowed-operators-and-constructs)
   - [Rejected outright](#rejected-outright)
   - [Why the eval is safe](#why-the-eval-is-safe)
+- [Reading Metrics with Reader Tools](#reading-metrics-with-reader-tools)
 - [Quickstart](#quickstart)
 - [One-Command Run](#one-command-run)
 - [The No-AWS Smoke Test](#the-no-aws-smoke-test)
@@ -362,6 +363,119 @@ The validated AST is compiled and evaluated with `eval(code, globals_, locals_)`
 The double defence (AST allowlist plus empty `__builtins__`) is the same pattern used by the wider script sandbox (`mcp/mission/sandbox.py`). The validator is exercised by a Hypothesis property test (`tests/test_mission_predicate_security.py`) that synthesises forbidden constructs and asserts the evaluator is never reached.
 
 If you need an expression that the allowlist rejects, the right path is to do the work inside an allowlisted tool and surface the result on the Observation under a key the predicate can read. The predicate is intentionally a thin "is the goal hit" check, not a place to put real logic.
+
+## Reading Metrics with Reader Tools
+
+A `metric_threshold` criterion reads a number off the Observation by dot-path — but something has to *put* that number there. The metric-reader tools (registered under `mcp/tools/metrics.py`, all carrying the `safe` tag) are read-only tools that surface a single training-style scalar in the exact shape the Observe phase merges, so a criterion can watch training loss, eval accuracy, throughput, or GPU utilisation with zero scripting.
+
+### The canonical metrics shape
+
+Every reader tool returns a JSON object with a top-level `metrics` key whose value maps metric names to numbers:
+
+```json
+{
+  "metrics": {"loss": 0.42},
+  "source": "file:s3://cluster-shared/run-7/trainer_state.json",
+  "region": "us-east-1",
+  "format": "hf_trainer_state",
+  "aggregation": "min"
+}
+```
+
+This is the **canonical metrics shape**: a dict with a top-level `metrics` key mapping string names to numeric (`int`/`float`) values. When a tool call returns this shape during the Execute phase, the Observe phase merges it into the iteration's Observation via `metrics.update(...)`, so the value lands at `observation["metrics"]["loss"]`. Everything else in the result — `source`, `region`, `format`, `aggregation`, timestamps, raw datapoints — is provenance that lives strictly *outside* the `metrics` object, so the merged `observation["metrics"]` dict only ever contains numbers.
+
+Two consequences follow directly:
+
+- A reader's success result merges cleanly, and a criterion reads the value by dot-path.
+- A reader's *failure* result is a structured error envelope (`{"code": "...", "details": {...}}`) with **no** top-level `metrics` key, so the Observe phase skips it and the criterion is left `inconclusive` rather than failing the loop. A failed read never crashes the session.
+
+### The `metrics.<name>` dot-path convention
+
+A reader emits its value under a single metric name — either the caller-supplied output name or a deterministic default derived from the source (the CloudWatch metric name, the extracted field, the file field). The name is constrained to a single dot-path segment: 1–128 characters, no `.` separator, no whitespace. The resulting dot-path a criterion reads is therefore always exactly `metrics.<name>`.
+
+So a reader that emits `{"metrics": {"loss": 0.42}}` is observed by a criterion whose `metric` field is `"metrics.loss"`:
+
+```json
+{
+  "criterion_id": "loss_target",
+  "kind": "metric_threshold",
+  "required": true,
+  "metric": "metrics.loss",
+  "op": "<",
+  "target": 0.1
+}
+```
+
+Pick the output name on the tool call and the `metrics.<name>` dot-path on the criterion so the two line up.
+
+### Aggregation modes for history-bearing readers
+
+Mission keeps metrics **point-in-time** — the engine accumulates `tool_results` across iterations but deliberately leaves `metrics` per-iteration. Training artifacts and logs, though, frequently carry *history*: a Hugging Face `log_history` array, JSONL step lines, a column of values. A **history-bearing reader** (the job-log reader, and the file readers for sequence-bearing formats) reduces that history to one number itself via an `aggregation` parameter, so a criterion can express goals like "best loss so far" without the engine ever accumulating metrics.
+
+| `aggregation` | Reduces the observed sequence to |
+|---------------|----------------------------------|
+| `last` (default) | The most recent numeric value. |
+| `first` | The earliest numeric value. |
+| `min` | The smallest numeric value. |
+| `max` | The largest numeric value. |
+| `mean` | The arithmetic mean of the numeric values. |
+
+Non-numeric entries in the sequence are ignored before reducing. The applied mode is reported as a diagnostic field outside `metrics`. When the caller supplies no mode, the reader defaults to `last`, so the most recent value is returned. An out-of-set mode, an empty sequence, and a sequence with no numeric values each surface as a distinct error envelope code.
+
+### The four reader tools
+
+| Tool | Source | History-bearing? | Availability |
+|------|--------|------------------|--------------|
+| `metrics_cloudwatch_get` | A single CloudWatch `GetMetricStatistics` datapoint for a named metric/namespace/dimensions/region (most-recent datapoint selected deterministically). | No | default-on |
+| `metrics_from_job_logs` | The tail of a job's logs, extracted by JSON key (dot-path) or regex (first capture group), reduced via the aggregation mode. | Yes | default-on |
+| `metrics_from_shared_storage_file` | A metrics file a job wrote to EFS or the cluster shared bucket, dispatched on a `format` parameter (`json`, `csv`, `hf_trainer_state`, `jsonl`, `yaml`, `parquet`, and optional/stretch `tfevents`). | Yes for sequence-bearing formats | default-on |
+| `metrics_from_local_file` | A metrics file on the **local filesystem**, confined to an allowlisted root. Reuses every piece of the shared-storage reader (same `format` set, aggregation handling, size cap, output shape, error model) and adds only local-path confinement. | Yes for sequence-bearing formats | **gated** by `GCO_ENABLE_LOCAL_METRICS`, default-off |
+
+The three default-on readers are read-only against remote AWS resources, incur only normal API-call-rate charges, and are always present in `mcp.list_tools()` — referenceable from a Mission session's tool allowlist with no flag juggling.
+
+`metrics_from_local_file` is the deliberate exception. Reading the MCP host's local filesystem is a real security concern even for a read-only tool, so it is gated default-off behind `GCO_ENABLE_LOCAL_METRICS` (or the umbrella `GCO_ENABLE_ALL_TOOLS=true`) and confined to the single root configured via `GCO_METRICS_LOCAL_ROOT`. Every read path is fully resolved — collapsing `..` segments and following symlinks — and rejected unless it stays inside that root: a `..` escape returns a `path_traversal_escape` envelope, a symlink whose target jumps out returns `symlink_escape`, and an enabled gate with no configured root returns `local_root_not_configured`. Its docstring begins with the literal prefix `[gated by GCO_ENABLE_LOCAL_METRICS]`.
+
+### Example: observe training loss from an HF Trainer state file
+
+A common case is driving validation/training loss down while a Hugging Face `Trainer` writes `trainer_state.json` (its `log_history` is a list of per-step dicts carrying `loss`, `eval_loss`, and friends). Point the file reader at the artifact, ask for the `loss` field with `format: hf_trainer_state`, and reduce with `aggregation: min` to track the best loss seen so far:
+
+```jsonc
+// tool call the strategy issues during the Execute phase
+{
+  "tool": "metrics_from_shared_storage_file",
+  "args": {
+    "path": "s3://cluster-shared/run-7/trainer_state.json",
+    "region": "us-east-1",
+    "field": "loss",
+    "format": "hf_trainer_state",
+    "aggregation": "min",
+    "output_name": "loss"
+  }
+}
+```
+
+```json
+// the matching metric_threshold criterion
+{
+  "criterion_id": "best_loss",
+  "kind": "metric_threshold",
+  "required": true,
+  "metric": "metrics.loss",
+  "op": "<=",
+  "target": 0.1
+}
+```
+
+The reader collects every `loss` entry from `log_history`, reduces to the minimum, and emits `{"metrics": {"loss": <best>}, "format": "hf_trainer_state", "aggregation": "min", ...}`. The Observe phase merges it, and the criterion compares `metrics.loss <= 0.1`. If the file is missing, malformed, or carries no numeric `loss`, the reader returns an error envelope instead and the criterion reads `inconclusive` — the loop keeps running.
+
+### Future work: cumulative metrics and trend criteria
+
+These readers deliberately do **not** change Mission engine semantics. The engine keeps metrics strictly point-in-time, and history is reduced *inside* the reader via an aggregation mode rather than accumulated across iterations by the engine. Two engine capabilities are explicitly **out of scope** here and called out as future work:
+
+- A **cumulative-metrics view** that would let the engine accumulate `metrics` across iterations the way it already accumulates `tool_results`.
+- A **`metric_trend` criterion** kind that would evaluate the direction or slope of a metric over several iterations (history-aware observation), rather than comparing a single point-in-time value to a fixed target.
+
+Until those land as a separate, deliberate effort, express "best so far" and similar history-shaped goals through a reader `aggregation` mode against a source that already carries the history.
 
 ## Quickstart
 

--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -8,6 +8,7 @@ Mission is GCO's goal-directed iteration loop. The operator declares a directive
 - [Generating a Criteria File](#generating-a-criteria-file)
 - [Criteria File Schema](#criteria-file-schema)
   - [`metric_threshold` criterion](#metric_threshold-criterion)
+  - [`metric_trend` criterion](#metric_trend-criterion)
   - [`event` criterion](#event-criterion)
   - [`tool_call_succeeded` criterion](#tool_call_succeeded-criterion)
   - [`predicate` criterion](#predicate-criterion)
@@ -127,12 +128,12 @@ The `--allowlist` flag (repeatable) is informational for the deterministic path;
 
 The criteria file is a JSON **array** — one or more criterion objects. Every criterion declares what "done" looks like for that dimension of the goal. The Evaluate phase walks the array on every checkpoint and stamps each criterion as `met`, `unmet`, or `inconclusive`. The session reaches a `complete` verdict only when **every required criterion is `met`** and **none are `inconclusive`** — see [Required vs optional criteria](#required-vs-optional-criteria).
 
-Four criterion kinds are supported. Every criterion regardless of kind carries these three required keys:
+Five criterion kinds are supported. Every criterion regardless of kind carries these three required keys:
 
 | Key | Type | Description |
 |-----|------|-------------|
 | `criterion_id` | non-empty string | Stable identifier, unique across the file. Used by the audit log, the Final_Report, and the verdict cascade. |
-| `kind` | string | One of `metric_threshold`, `event`, `predicate`, `tool_call_succeeded`. |
+| `kind` | string | One of `metric_threshold`, `metric_trend`, `event`, `predicate`, `tool_call_succeeded`. |
 | `required` | bool | When `true`, this criterion must be `met` for the session to complete. When `false`, it's tracked but not blocking. |
 
 The kind-specific keys are documented per section below.
@@ -159,6 +160,37 @@ Example:
   "target": 0.1
 }
 ```
+
+### `metric_trend` criterion
+
+Evaluates the *direction* of a metric across iterations rather than comparing a single point-in-time value to a fixed target. Use this for goals like "loss is falling" or "throughput is not regressing" where the shape of the curve matters more than any one reading.
+
+Unlike `metric_threshold`, which reads the latest value off the per-iteration Observation, `metric_trend` reads the metric's **history** — the ordered series of numeric readings the engine accumulates across iterations under `metric_history` (oldest→newest). The engine builds that series in the Evaluate phase; you don't have to make tools emit it. Non-numeric readings are skipped so a stray string can't poison the series.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `metric` | non-empty string | The metric to track. Accepts the same dot-path form as `metric_threshold` (`metrics.loss`) or the bare metric name (`loss`); a leading `metrics.` is stripped before the history lookup. |
+| `direction` | string | One of `decreasing` (last < first), `increasing` (last > first), `non_increasing` (last <= first), `non_decreasing` (last >= first). The strict forms require an actual net change; the `non_` forms allow a flat series. |
+| `window` | positive int | Optional. Consider only the most-recent `window` readings. Default: the entire history. |
+| `min_points` | positive int | Optional. The minimum number of numeric readings required before the criterion decides `met`/`unmet`. With fewer points the criterion is `inconclusive` (a trend is undefined on a single reading, and the loop is never failed for lack of history). Default and floor: `2`. |
+
+The verdict compares the last reading of the windowed series to its first reading per `direction`. Evidence is a structured dict (`direction`, the windowed `points`, `first`, `last`, and net `delta`) so the audit log shows exactly what the verdict was computed from.
+
+Example — "drive validation loss down across the run, looking at the last 5 readings":
+
+```json
+{
+  "criterion_id": "loss_falling",
+  "kind": "metric_trend",
+  "required": true,
+  "metric": "metrics.val_loss",
+  "direction": "decreasing",
+  "window": 5,
+  "min_points": 3
+}
+```
+
+Pair `metric_trend` with `metric_threshold` to express "loss is both below 0.1 **and** still falling" — two criteria over the same metric, one point-in-time and one history-aware.
 
 ### `event` criterion
 
@@ -248,11 +280,14 @@ The `validate_criteria` validator emits structured rejections through `MissionVa
 | `not_a_dict` | One of the entries was not a JSON object. |
 | `criterion_id_missing_or_invalid` | A criterion lacks a non-empty string `criterion_id`. |
 | `duplicate_criterion_id` | Two criteria share the same `criterion_id`. |
-| `kind_invalid` | `kind` was not one of the three supported values. |
+| `kind_invalid` | `kind` was not one of the supported values. |
 | `required_missing_or_not_a_bool` | `required` was missing or not a JSON boolean. |
-| `metric_missing_or_invalid` | `metric_threshold` lacks a non-empty string `metric`. |
+| `metric_missing_or_invalid` | `metric_threshold` or `metric_trend` lacks a non-empty string `metric`. |
 | `op_invalid` | `metric_threshold` `op` was not one of the six comparison operators. |
 | `target_not_a_number` | `metric_threshold` `target` was not a JSON number. |
+| `direction_invalid` | `metric_trend` `direction` was not one of `decreasing`, `increasing`, `non_increasing`, `non_decreasing`. |
+| `window_must_be_positive_int` | `metric_trend` `window` was present but not a positive int. |
+| `min_points_must_be_positive_int` | `metric_trend` `min_points` was present but not a positive int. |
 | `event_name_missing_or_invalid` | `event` criterion lacks a non-empty `event_name`. |
 | `expression_missing_or_invalid` | `predicate` criterion lacks a non-empty `expression`. |
 | `tool_name_missing_or_invalid` | `tool_call_succeeded` lacks a non-empty `tool_name`. |
@@ -410,7 +445,7 @@ Pick the output name on the tool call and the `metrics.<name>` dot-path on the c
 
 ### Aggregation modes for history-bearing readers
 
-Mission keeps metrics **point-in-time** — the engine accumulates `tool_results` across iterations but deliberately leaves `metrics` per-iteration. Training artifacts and logs, though, frequently carry *history*: a Hugging Face `log_history` array, JSONL step lines, a column of values. A **history-bearing reader** (the job-log reader, and the file readers for sequence-bearing formats) reduces that history to one number itself via an `aggregation` parameter, so a criterion can express goals like "best loss so far" without the engine ever accumulating metrics.
+Mission keeps the per-iteration `metrics` dict **point-in-time** — each iteration's Observation carries the latest reading, and a `metric_threshold` criterion compares that single value to a target. Training artifacts and logs, though, frequently carry *history*: a Hugging Face `log_history` array, JSONL step lines, a column of values. A **history-bearing reader** (the job-log reader, and the file readers for sequence-bearing formats) reduces that history to one number itself via an `aggregation` parameter, so a criterion can express goals like "best loss so far" at the source level — independent of, and complementary to, the cross-iteration history the engine accumulates for [`metric_trend`](#metric_trend-criterion).
 
 | `aggregation` | Reduces the observed sequence to |
 |---------------|----------------------------------|
@@ -468,14 +503,14 @@ A common case is driving validation/training loss down while a Hugging Face `Tra
 
 The reader collects every `loss` entry from `log_history`, reduces to the minimum, and emits `{"metrics": {"loss": <best>}, "format": "hf_trainer_state", "aggregation": "min", ...}`. The Observe phase merges it, and the criterion compares `metrics.loss <= 0.1`. If the file is missing, malformed, or carries no numeric `loss`, the reader returns an error envelope instead and the criterion reads `inconclusive` — the loop keeps running.
 
-### Future work: cumulative metrics and trend criteria
+### Cumulative metrics and the `metric_trend` criterion
 
-These readers deliberately do **not** change Mission engine semantics. The engine keeps metrics strictly point-in-time, and history is reduced *inside* the reader via an aggregation mode rather than accumulated across iterations by the engine. Two engine capabilities are explicitly **out of scope** here and called out as future work:
+There are two complementary ways to observe a metric's history, and they operate at different layers:
 
-- A **cumulative-metrics view** that would let the engine accumulate `metrics` across iterations the way it already accumulates `tool_results`.
-- A **`metric_trend` criterion** kind that would evaluate the direction or slope of a metric over several iterations (history-aware observation), rather than comparing a single point-in-time value to a fixed target.
+- **Reader-level reduction (`aggregation`)** collapses history that already exists *inside a single artifact* — a `log_history` array, a JSONL stream, a column — down to one number before it ever reaches the engine. Use it for "best/earliest/mean value within this file or log tail".
+- **Engine-level history (`metric_trend`)** observes how a metric moves *across iterations* of the Mission loop. The engine accumulates a `metric_history` series for every numeric metric it sees (oldest→newest) in the Evaluate phase's cumulative observation — the same place it already accumulates `tool_results`. A [`metric_trend`](#metric_trend-criterion) criterion reads that series and evaluates its direction (`decreasing`, `increasing`, `non_increasing`, `non_decreasing`) over an optional `window`, with a `min_points` floor below which it stays `inconclusive`.
 
-Until those land as a separate, deliberate effort, express "best so far" and similar history-shaped goals through a reader `aggregation` mode against a source that already carries the history.
+So "drive loss down and keep it falling" is expressible as two criteria over the same metric: a `metric_threshold` (`metrics.loss <= 0.1`) for the point-in-time floor, and a `metric_trend` (`direction: decreasing`) for the cross-iteration shape. The per-iteration `metrics` dict stays point-in-time exactly as before — `metric_history` lives alongside it on the cumulative view, so existing `metric_threshold`, `event`, and `predicate` criteria are unaffected, and predicates can read `obs['metric_history']` directly when they need the raw series.
 
 ## Quickstart
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,6 +21,7 @@ This directory contains example Kubernetes manifests you can use with GCO (Globa
   - [KEDA Autoscaled Job](#keda-autoscaled-job)
   - [Kueue Job Queueing](#kueue-job-queueing)
   - [MegaTrain SFT Job](#megatrain-sft-job)
+  - [Mission Training-Loss Observation](#mission-training-loss-observation)
   - [Model Download Job](#model-download-job)
   - [Multi-GPU Distributed Training](#multi-gpu-distributed-training)
   - [Ray Cluster](#ray-cluster)
@@ -62,6 +63,7 @@ This directory contains example Kubernetes manifests you can use with GCO (Globa
 | [KEDA Scaled](#keda-autoscaled-job) | `keda-scaled-job.yaml` | Scheduler | — | — |
 | [Kueue](#kueue-job-queueing) | `kueue-job.yaml` | Scheduler | Optional | — |
 | [MegaTrain SFT](#megatrain-sft-job) | `megatrain-sft-job.yaml` | Jobs | ✅ | — |
+| [Mission Training-Loss](#mission-training-loss-observation) | `mission-training-loss-criteria.json`, `megatrain-trainer-state.json` | Mission | — | Mission |
 | [Model Download](#model-download-job) | `model-download-job.yaml` | Jobs | — | — |
 | [Multi-GPU Training](#multi-gpu-distributed-training) | `multi-gpu-training.yaml` | Jobs | ✅ | — |
 | [Pipeline DAG](#dag-pipeline) | `pipeline-dag.yaml` | Pipeline | — | — |
@@ -399,6 +401,51 @@ gco jobs logs megatrain-sft -r us-east-1
 **Requirements:** GPU node with large CPU RAM, shared EFS storage.
 
 **When to use:** SFT fine-tuning of large HuggingFace models, full-precision training on a single GPU.
+
+---
+
+### Mission Training-Loss Observation
+
+**Files:** `mission-training-loss-criteria.json`, `megatrain-trainer-state.json`
+
+Ties the [MegaTrain SFT Job](#megatrain-sft-job) to a [Mission](../docs/MISSION.md) `metric_threshold` criterion so the goal-directed loop can watch training loss fall without any scripting. The MegaTrain trainer writes a Hugging Face `trainer_state.json` to shared EFS under its `OUTPUT_DIR` (`/mnt/gco/megatrain-sft/checkpoints`); its `log_history` is a list of per-step records carrying `loss`, `eval_loss`, `step`, and `epoch`. The read-only `metrics_from_shared_storage_file` tool reads that file with `format=hf_trainer_state`, collects the `loss` field across every `log_history` entry, and reduces the sequence to a single number via an aggregation mode — `min` for "best loss so far", or `last` for "current loss". The result lands in the canonical `{"metrics": {"loss": <number>}}` shape that Mission's Observe phase merges, so the `metrics.loss` dot-path in the criterion resolves directly.
+
+- `megatrain-trainer-state.json` is a small representative sample of the artifact MegaTrain produces (five training steps plus one eval record) so you can try the reader against a concrete file.
+- `mission-training-loss-criteria.json` is a one-criterion [Criteria File](../docs/MISSION.md#criteria-file-schema) asserting `metrics.loss <= 1.5`.
+
+**Prerequisites:** `GCO_ENABLE_MISSION=true` (or the umbrella `GCO_ENABLE_ALL_TOOLS=true`). The MegaTrain job must have run and written its `trainer_state.json` to shared storage.
+
+**Usage:**
+
+```bash
+export GCO_ENABLE_MISSION=true
+
+# Run the training job that produces trainer_state.json on shared EFS.
+gco jobs submit-direct examples/megatrain-sft-job.yaml -r us-east-1
+
+# Drive a Mission that observes the best training loss so far.
+gco mission start --run \
+  --directive "Drive MegaTrain SFT training loss to 1.5 or below." \
+  --criteria-file examples/mission-training-loss-criteria.json \
+  --max-iterations 10 --max-wall-clock 3600 \
+  --tool-allowlist metrics_from_shared_storage_file
+```
+
+The Mission loop calls `metrics_from_shared_storage_file` each iteration with these arguments:
+
+```json
+{
+  "path": "/mnt/gco/megatrain-sft/checkpoints/trainer_state.json",
+  "region": "us-east-1",
+  "field": "loss",
+  "format": "hf_trainer_state",
+  "aggregation": "min"
+}
+```
+
+Switch `aggregation` to `last` to track the current step's loss instead of the best-so-far. To observe the held-out metric instead, set `field` to `eval_loss`.
+
+**When to use:** Goal-directed training runs where a `metric_threshold` criterion should observe a metric a HF Trainer persisted (loss, eval loss, perplexity) without writing a custom log-scraping tool.
 
 ---
 

--- a/examples/megatrain-trainer-state.json
+++ b/examples/megatrain-trainer-state.json
@@ -1,0 +1,22 @@
+{
+  "best_metric": 1.612,
+  "best_model_checkpoint": "/mnt/gco/megatrain-sft/checkpoints/checkpoint-5",
+  "epoch": 1.0,
+  "global_step": 5,
+  "is_hyper_param_search": false,
+  "is_local_process_zero": true,
+  "is_world_process_zero": true,
+  "max_steps": 5,
+  "num_train_epochs": 1,
+  "total_flos": 0.0,
+  "trial_name": null,
+  "trial_params": null,
+  "log_history": [
+    {"epoch": 0.2, "step": 1, "loss": 2.9013, "learning_rate": 1e-05, "grad_norm": 4.21},
+    {"epoch": 0.4, "step": 2, "loss": 2.4307, "learning_rate": 8e-06, "grad_norm": 3.88},
+    {"epoch": 0.6, "step": 3, "loss": 2.0951, "learning_rate": 6e-06, "grad_norm": 3.12},
+    {"epoch": 0.8, "step": 4, "loss": 1.8042, "learning_rate": 4e-06, "grad_norm": 2.76},
+    {"epoch": 1.0, "step": 5, "loss": 1.6120, "learning_rate": 2e-06, "grad_norm": 2.41},
+    {"epoch": 1.0, "step": 5, "eval_loss": 1.7558, "eval_runtime": 12.83, "eval_samples_per_second": 7.79, "eval_steps_per_second": 0.97}
+  ]
+}

--- a/examples/mission-training-loss-criteria.json
+++ b/examples/mission-training-loss-criteria.json
@@ -1,0 +1,10 @@
+[
+  {
+    "criterion_id": "best_training_loss",
+    "kind": "metric_threshold",
+    "required": true,
+    "metric": "metrics.loss",
+    "op": "<=",
+    "target": 1.5
+  }
+]

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -23,6 +23,7 @@ An MCP (Model Context Protocol) server that exposes the Global Capacity Orchestr
   - [Cost Tracking](#cost-tracking)
   - [Infrastructure](#infrastructure)
   - [Storage](#storage)
+  - [Metrics](#metrics)
   - [Model Weights](#model-weights)
   - [Templates](#templates)
   - [Webhooks](#webhooks)
@@ -57,7 +58,7 @@ An MCP (Model Context Protocol) server that exposes the Global Capacity Orchestr
 
 ## Overview
 
-The MCP server wraps the `gco` CLI, exposing 92 tools by default (up to 113 with all flags enabled) that cover the full lifecycle of GPU workload management:
+The MCP server wraps the `gco` CLI, exposing 95 tools by default (up to 117 with all flags enabled) that cover the full lifecycle of GPU workload management:
 
 - Submit and monitor jobs across regions
 - Deploy and manage inference endpoints with canary deployments
@@ -453,6 +454,17 @@ Each table lists the `Risk Tier` and `Gated By` columns alongside the descriptio
 | `list_file_systems` | List EFS and FSx file systems | safe | — |
 | `files_get` | Fetch a single file from shared storage | safe | — |
 | `files_access_points` | List EFS access points | safe | — |
+
+### Metrics
+
+Read-only metric-reader tools that surface a single training-style scalar (loss, accuracy, throughput, GPU utilization) in the canonical `{"metrics": {...}}` shape a Mission `metric_threshold` criterion can observe with zero scripting. The three remote-source readers are registered by default; `metrics_from_local_file` reads the MCP host's local filesystem and is therefore gated default-off behind `GCO_ENABLE_LOCAL_METRICS`.
+
+| Tool | Description | Risk Tier | Gated By |
+|------|-------------|-----------|----------|
+| `metrics_cloudwatch_get` | Read one CloudWatch datapoint as a canonical metric | safe | — |
+| `metrics_from_job_logs` | Extract a scalar from the tail of a job's logs by JSON key or regex | safe | — |
+| `metrics_from_shared_storage_file` | Read a named field from a shared-storage metrics file (JSON, CSV, HF Trainer state, JSONL, YAML, Parquet, tfevents) | safe | — |
+| `metrics_from_local_file` | Read a named field from a local metrics file confined to `GCO_METRICS_LOCAL_ROOT` | safe | `GCO_ENABLE_LOCAL_METRICS` |
 
 ### Model Weights
 

--- a/mcp/metric_readers/__init__.py
+++ b/mcp/metric_readers/__init__.py
@@ -1,0 +1,1 @@
+"""Pure, dependency-light helpers for the read-only metric-reader tools."""

--- a/mcp/metric_readers/aggregate.py
+++ b/mcp/metric_readers/aggregate.py
@@ -1,0 +1,98 @@
+"""Reduce a sequence of observed values down to one number.
+
+Several metric sources carry history rather than a single point: a training
+run logs a loss every step, a CSV column holds one value per row, a log tail
+matches a pattern many times. A threshold check, though, wants exactly one
+number. This module bridges that gap with a single pure function,
+:func:`reduce_sequence`, that collapses a sequence into one finite number
+according to a caller-chosen mode.
+
+The supported modes are:
+
+* ``last`` — the most recent number (the last one in the original order).
+* ``first`` — the earliest number (the first one in the original order).
+* ``min`` — the smallest number.
+* ``max`` — the largest number.
+* ``mean`` — the arithmetic mean of every number.
+
+Non-numeric entries (booleans, NaN, the infinities, strings, ``None``,
+containers) are never counted: every mode reduces only the values that pass
+the numeric guard, so ``last`` and ``first`` mean "the most recent / earliest
+*number*", skipping anything in between that is not one.
+
+The reducer distinguishes two empty-ish failures on purpose. A sequence that
+carried no entries at all fails with :attr:`~.shape.ErrorCode.EMPTY_SEQUENCE`;
+a sequence that had entries but none that were numbers fails with
+:attr:`~.shape.ErrorCode.NO_NUMERIC_VALUE`. Keeping them apart lets a caller
+tell "the source was empty" from "the source had data but none of it was a
+number".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal, cast
+
+from . import shape
+
+# The aggregation modes a caller may ask for. Kept as both a typing Literal
+# (for signatures) and a runtime frozenset (for membership checks).
+AggregationMode = Literal["last", "first", "min", "max", "mean"]
+VALID_MODES: frozenset[str] = frozenset({"last", "first", "min", "max", "mean"})
+
+
+def reduce_sequence(values: Sequence[object], mode: str) -> float:
+    """Collapse ``values`` to a single finite number using ``mode``.
+
+    The reduction proceeds in fixed order so the failure reported is always
+    the most specific one that applies:
+
+    1. An unrecognized ``mode`` raises
+       :class:`~.shape.MetricReaderError` with code
+       :attr:`~.shape.ErrorCode.INVALID_AGGREGATION_MODE`.
+    2. A sequence with no entries at all raises
+       :attr:`~.shape.ErrorCode.EMPTY_SEQUENCE`.
+    3. Entries that are not real, finite numbers are dropped (booleans, NaN,
+       the infinities, strings, ``None``, containers — anything
+       :func:`~.shape.is_numeric_value` rejects).
+    4. If nothing survives the filter, raise
+       :attr:`~.shape.ErrorCode.NO_NUMERIC_VALUE`.
+    5. Otherwise reduce the surviving numbers: ``last`` and ``first`` pick the
+       most recent / earliest survivor in the original order; ``min``,
+       ``max``, and ``mean`` reduce across all of them.
+
+    The returned value is always a real, finite number.
+    """
+    if mode not in VALID_MODES:
+        raise shape.MetricReaderError(
+            shape.ErrorCode.INVALID_AGGREGATION_MODE,
+            {"mode": mode, "valid_modes": sorted(VALID_MODES)},
+        )
+
+    if len(values) == 0:
+        raise shape.MetricReaderError(
+            shape.ErrorCode.EMPTY_SEQUENCE,
+            {"mode": mode},
+        )
+
+    # Keep only real, finite numbers, preserving their original order so
+    # ``last`` and ``first`` stay meaningful.
+    numeric: list[float] = [cast(float, v) for v in values if shape.is_numeric_value(v)]
+
+    if not numeric:
+        raise shape.MetricReaderError(
+            shape.ErrorCode.NO_NUMERIC_VALUE,
+            {"mode": mode, "entry_count": len(values)},
+        )
+
+    if mode == "last":
+        return numeric[-1]
+    if mode == "first":
+        return numeric[0]
+    if mode == "min":
+        return min(numeric)
+    if mode == "max":
+        return max(numeric)
+    # mode == "mean": membership in VALID_MODES guarantees this is the only
+    # remaining possibility.
+    return sum(numeric) / len(numeric)

--- a/mcp/metric_readers/cloudwatch.py
+++ b/mcp/metric_readers/cloudwatch.py
@@ -1,0 +1,175 @@
+"""Read-only CloudWatch datapoint reader.
+
+This module turns a single CloudWatch ``GetMetricStatistics`` request into one
+numeric scalar a metric-threshold check can read. It has two pieces:
+
+* :func:`select_most_recent` — a pure helper that, given a non-empty list of
+  CloudWatch datapoints, picks the one with the latest timestamp and returns
+  its statistic value alongside that timestamp in ISO-8601 form. No I/O, so it
+  is trivial to test in isolation.
+* :func:`get_datapoint` — the thin boto3 wrapper. It constructs a
+  region-scoped CloudWatch client, issues one read-only
+  ``GetMetricStatistics`` call bounded to the requested window, and hands the
+  returned datapoints to :func:`select_most_recent`. Every failure mode —
+  an empty result, an unreachable endpoint, a credentials problem, or any
+  other client error — is translated into a :class:`MetricReaderError` with a
+  stable code so the calling tool can render a structured error envelope
+  instead of crashing.
+
+``boto3`` is imported lazily inside :func:`get_datapoint` (mirroring the
+lazy-import convention used by the SSM helpers and the stacks CLI) so this
+module's import surface stays free of the SDK and tests can monkeypatch
+``boto3.client`` without dragging the SDK into unrelated test runs.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from .shape import ErrorCode, MetricReaderError
+
+# CloudWatch ``Error.Code`` values that mean "the request was rejected because
+# of credentials or permissions" rather than a transient transport failure.
+# These map to the ``unauthorized`` discriminator so an operator can tell an
+# access problem apart from an unreachable endpoint without reading the message.
+_UNAUTHORIZED_ERROR_CODES = frozenset(
+    {
+        "AccessDenied",
+        "AccessDeniedException",
+        "AuthFailure",
+        "ExpiredToken",
+        "ExpiredTokenException",
+        "InvalidAccessKeyId",
+        "InvalidClientTokenId",
+        "SignatureDoesNotMatch",
+        "UnauthorizedOperation",
+        "UnrecognizedClientException",
+    }
+)
+
+
+def select_most_recent(datapoints: list[dict[str, Any]], statistic: str) -> tuple[float, str]:
+    """Pick the latest datapoint and return its value and ISO timestamp.
+
+    Given a non-empty list of CloudWatch datapoints (each a dict carrying a
+    ``Timestamp`` and the requested statistic key), return a
+    ``(value, iso_timestamp)`` tuple where ``value`` is the chosen
+    datapoint's ``statistic`` reading coerced to a float and ``iso_timestamp``
+    is its timestamp in ISO-8601 form. Selection is deterministic: the
+    datapoint with the maximum ``Timestamp`` wins, and ``GetMetricStatistics``
+    never emits two datapoints sharing a timestamp within one period.
+
+    Args:
+        datapoints: A non-empty list of CloudWatch datapoint dicts.
+        statistic: The statistic key to read from the chosen datapoint
+            (for example ``"Average"`` or ``"Sum"``).
+
+    Returns:
+        A ``(value, iso_timestamp)`` tuple for the latest datapoint.
+    """
+    most_recent = max(datapoints, key=lambda dp: dp["Timestamp"])
+    value = float(most_recent[statistic])
+    timestamp = most_recent["Timestamp"]
+    iso_timestamp = timestamp.isoformat() if hasattr(timestamp, "isoformat") else str(timestamp)
+    return value, iso_timestamp
+
+
+def get_datapoint(
+    *,
+    metric_name: str,
+    namespace: str,
+    dimensions: dict[str, str] | None,
+    region: str,
+    period: int,
+    statistic: str,
+    start_time: datetime,
+    end_time: datetime,
+) -> tuple[float, str]:
+    """Read one CloudWatch datapoint for a metric in a named region.
+
+    Constructs a region-scoped CloudWatch client and issues a single
+    read-only ``GetMetricStatistics`` request bounded to
+    ``[start_time, end_time]`` for the supplied metric, namespace,
+    dimensions, period, and statistic. The dimensions mapping is passed to
+    CloudWatch unchanged, as a list of ``{"Name": ..., "Value": ...}`` pairs.
+
+    Args:
+        metric_name: The CloudWatch metric name.
+        namespace: The CloudWatch namespace the metric lives in.
+        dimensions: Name/value dimension pairs, or ``None`` for no dimensions.
+        region: The AWS region to scope the CloudWatch client to.
+        period: The aggregation period, in seconds.
+        statistic: The statistic to request (for example ``"Average"``).
+        start_time: The inclusive start of the lookback window.
+        end_time: The end of the lookback window.
+
+    Returns:
+        A ``(value, iso_timestamp)`` tuple for the latest datapoint in the
+        window, as produced by :func:`select_most_recent`.
+
+    Raises:
+        MetricReaderError: With :attr:`ErrorCode.NO_DATAPOINTS` when the
+            window holds no datapoints, or :attr:`ErrorCode.AWS_UNREACHABLE`
+            (carrying a ``kind`` discriminator of ``unreachable``,
+            ``unauthorized``, or ``client_error``) when the request cannot be
+            completed.
+    """
+    import boto3
+    from botocore.exceptions import (
+        BotoCoreError,
+        ClientError,
+        EndpointConnectionError,
+    )
+
+    dimension_pairs = [{"Name": key, "Value": value} for key, value in (dimensions or {}).items()]
+
+    try:
+        client = boto3.client("cloudwatch", region_name=region)
+        response = client.get_metric_statistics(
+            Namespace=namespace,
+            MetricName=metric_name,
+            Dimensions=dimension_pairs,
+            StartTime=start_time,
+            EndTime=end_time,
+            Period=period,
+            Statistics=[statistic],
+        )
+    except EndpointConnectionError as exc:
+        # A subclass of BotoCoreError; caught first so it keeps its own,
+        # more specific "unreachable" classification.
+        raise MetricReaderError(
+            ErrorCode.AWS_UNREACHABLE,
+            {"kind": "unreachable", "region": region, "message": str(exc)},
+        ) from exc
+    except ClientError as exc:
+        aws_error_code = exc.response.get("Error", {}).get("Code", "")
+        kind = "unauthorized" if aws_error_code in _UNAUTHORIZED_ERROR_CODES else "client_error"
+        raise MetricReaderError(
+            ErrorCode.AWS_UNREACHABLE,
+            {
+                "kind": kind,
+                "region": region,
+                "aws_error_code": aws_error_code,
+                "message": str(exc),
+            },
+        ) from exc
+    except BotoCoreError as exc:
+        raise MetricReaderError(
+            ErrorCode.AWS_UNREACHABLE,
+            {"kind": "unreachable", "region": region, "message": str(exc)},
+        ) from exc
+
+    datapoints = response.get("Datapoints", [])
+    if not datapoints:
+        raise MetricReaderError(
+            ErrorCode.NO_DATAPOINTS,
+            {
+                "metric_name": metric_name,
+                "namespace": namespace,
+                "region": region,
+                "statistic": statistic,
+            },
+        )
+
+    return select_most_recent(datapoints, statistic)

--- a/mcp/metric_readers/files.py
+++ b/mcp/metric_readers/files.py
@@ -1,0 +1,395 @@
+"""Read a named field out of a metrics file and reduce it to one number.
+
+A job can persist its metrics in many shapes: a hand-written JSON or YAML
+document, a CSV table, a Hugging Face ``Trainer`` state file, a stream of
+JSON-per-line step records, or a columnar Parquet file. This module turns any
+of those into a single finite number a threshold check can read.
+
+The work is split into two layers:
+
+* A small set of pure, per-format **handlers**. Each handler takes the raw file
+  bytes, the caller's field name, and an aggregation mode, and returns one
+  finite number — or raises :class:`~.shape.MetricReaderError` with a stable
+  code describing why it could not. Handlers do no I/O of their own: the bytes
+  are handed in already, so the same handler serves both the shared-storage
+  reader and the local-filesystem reader.
+* A :data:`_HANDLERS` dispatch map from a format name to its handler. The tool
+  wrapper looks a format up here; a format with no entry is reported as
+  unsupported rather than crashing.
+
+Field resolution differs by format. The document formats (``json``, ``yaml``)
+resolve the field as a dot-path walked segment-by-segment through nested
+objects. The tabular and record formats (``csv``, ``jsonl``, the Hugging Face
+``log_history``) treat the field as a flat column or key name and gather one
+value per row, line, or entry. A single resolved number is returned as-is; a
+gathered sequence is collapsed with the chosen aggregation mode, which ignores
+any non-numeric entries along the way.
+
+Every parsing or decoding failure becomes a malformed-file error; a field that
+cannot be located becomes a field-not-found error; a value that is present but
+is not a real number becomes a non-numeric error. Nothing escapes as an
+unhandled exception.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+import tempfile
+from collections.abc import Callable
+from typing import Literal, cast
+
+import yaml
+
+from . import shape
+from .aggregate import reduce_sequence
+
+# The full set of file formats the reader understands. The document and record
+# formats are handled here; the columnar and TensorBoard formats are dispatched
+# through the same map and carry their own lazy-import handlers.
+ReaderFormat = Literal[
+    "json",
+    "csv",
+    "hf_trainer_state",
+    "jsonl",
+    "yaml",
+    "parquet",
+    "tfevents",
+]
+
+
+def _decode(content: bytes, fmt: str) -> str:
+    """Decode raw file bytes as UTF-8 text, or report a malformed file.
+
+    The text-oriented formats (``csv``, ``jsonl``) need to work over decoded
+    lines. Bytes that are not valid UTF-8 are surfaced as a malformed-file
+    error tagged with the format, rather than letting the decode error escape.
+    """
+    try:
+        return content.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise shape.MetricReaderError(
+            shape.ErrorCode.MALFORMED_FILE,
+            {"format": fmt, "reason": "decode_error"},
+        ) from exc
+
+
+def _maybe_number(raw: object) -> object:
+    """Best-effort coerce a raw cell to a number, leaving non-numbers untouched.
+
+    Cells read from a CSV arrive as strings. A string that parses cleanly as an
+    integer or a float is returned as that number; anything else (an empty
+    cell, a label, ``None`` from a short row) is returned unchanged so the
+    downstream numeric filter can drop it. Non-string inputs pass straight
+    through.
+    """
+    if not isinstance(raw, str):
+        return raw
+    text = raw.strip()
+    try:
+        return int(text)
+    except ValueError:
+        pass
+    try:
+        return float(text)
+    except ValueError:
+        return raw
+
+
+def _describe_value(value: object) -> dict[str, object]:
+    """Render a non-numeric value into JSON-safe error-detail fields.
+
+    Returns the offending value (kept verbatim when it is a simple scalar,
+    otherwise its ``repr``) alongside its type name, so an operator can see
+    both what was found and what kind of thing it was.
+    """
+    if value is None or isinstance(value, str | int | float | bool):
+        shown: object = value
+    else:
+        shown = repr(value)
+    return {"value": shown, "value_type": type(value).__name__}
+
+
+def _resolve_dot_path(obj: object, field: str) -> object:
+    """Walk a dot-separated path through nested objects and return the leaf.
+
+    Each segment of ``field`` indexes one level deeper into a mapping. A
+    segment that is missing, or a level that is not a mapping, means the field
+    is absent and raises a field-not-found error.
+    """
+    current: object = obj
+    for segment in field.split("."):
+        if isinstance(current, dict) and segment in current:
+            current = current[segment]
+        else:
+            raise shape.MetricReaderError(
+                shape.ErrorCode.FIELD_NOT_FOUND,
+                {"field": field},
+            )
+    return current
+
+
+def _reduce_resolved(value: object, field: str, mode: str) -> float:
+    """Turn a resolved field value into one number.
+
+    A value that is already a real, finite number is returned directly. A list
+    is collapsed with the aggregation mode. Anything else is present but not a
+    number, which is a non-numeric error carrying the offending value.
+    """
+    if shape.is_numeric_value(value):
+        return cast(float, value)
+    if isinstance(value, list):
+        return reduce_sequence(value, mode)
+    raise shape.MetricReaderError(
+        shape.ErrorCode.NON_NUMERIC_VALUE,
+        {"field": field, **_describe_value(value)},
+    )
+
+
+def _handle_json(content: bytes, field: str, mode: str) -> float:
+    """Read a field from a plain JSON document.
+
+    The document is parsed, the field resolved by dot-path, and the leaf either
+    returned directly (a single number) or reduced (a list). Bytes that do not
+    parse as JSON are a malformed-file error.
+    """
+    try:
+        parsed: object = json.loads(content)
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise shape.MetricReaderError(
+            shape.ErrorCode.MALFORMED_FILE,
+            {"format": "json"},
+        ) from exc
+    return _reduce_resolved(_resolve_dot_path(parsed, field), field, mode)
+
+
+def _handle_yaml(content: bytes, field: str, mode: str) -> float:
+    """Read a field from a YAML document using the safe loader.
+
+    Mirrors the JSON handler: dot-path resolution, then a single number
+    returned directly or a list reduced. A document the safe loader rejects is
+    a malformed-file error.
+    """
+    try:
+        parsed: object = yaml.safe_load(content)
+    except yaml.YAMLError as exc:
+        raise shape.MetricReaderError(
+            shape.ErrorCode.MALFORMED_FILE,
+            {"format": "yaml"},
+        ) from exc
+    return _reduce_resolved(_resolve_dot_path(parsed, field), field, mode)
+
+
+def _handle_csv(content: bytes, field: str, mode: str) -> float:
+    """Read one column from a CSV table and reduce it.
+
+    The first row is the header; ``field`` names one of its columns. Every data
+    row's cell in that column is coerced toward a number and the resulting
+    sequence is reduced with the aggregation mode (non-numeric cells are
+    ignored). A column name absent from the header is a field-not-found error.
+    """
+    text = _decode(content, "csv")
+    reader = csv.DictReader(io.StringIO(text))
+    fieldnames = reader.fieldnames
+    if not fieldnames or field not in fieldnames:
+        raise shape.MetricReaderError(
+            shape.ErrorCode.FIELD_NOT_FOUND,
+            {"field": field},
+        )
+    candidates: list[object] = [_maybe_number(row.get(field)) for row in reader]
+    return reduce_sequence(candidates, mode)
+
+
+def _handle_jsonl(content: bytes, field: str, mode: str) -> float:
+    """Read a field across a stream of one-JSON-object-per-line records.
+
+    Each non-blank line is parsed on its own; a line that is not valid JSON is
+    skipped rather than failing the whole read. The named key is gathered from
+    every object that carries it, and the gathered sequence is reduced. When no
+    line yields a usable number — whether the key was never present or never
+    numeric — the result is a no-numeric-value error.
+    """
+    text = _decode(content, "jsonl")
+    candidates: list[object] = []
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        try:
+            obj: object = json.loads(stripped)
+        except ValueError:
+            continue
+        if isinstance(obj, dict) and field in obj:
+            candidates.append(obj[field])
+    try:
+        return reduce_sequence(candidates, mode)
+    except shape.MetricReaderError as exc:
+        # A stream that carried the field nowhere collapses to the same
+        # "no usable number" outcome as one where every value was non-numeric.
+        if exc.code == shape.ErrorCode.EMPTY_SEQUENCE:
+            raise shape.MetricReaderError(
+                shape.ErrorCode.NO_NUMERIC_VALUE,
+                {"field": field},
+            ) from exc
+        raise
+
+
+def _handle_hf(content: bytes, field: str, mode: str) -> float:
+    """Read a scalar from a Hugging Face ``Trainer`` state file.
+
+    When the document carries a ``log_history`` list, the named field is
+    gathered from every per-step entry that includes it and the sequence is
+    reduced — this is the path for per-step scalars such as ``loss`` or
+    ``eval_loss``. When ``log_history`` is absent (or the field never appears
+    in it), the field is looked up as a top-level key and returned directly, as
+    in an ``all_results.json``. A field found in neither place is a
+    field-not-found error.
+    """
+    try:
+        parsed: object = json.loads(content)
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise shape.MetricReaderError(
+            shape.ErrorCode.MALFORMED_FILE,
+            {"format": "hf_trainer_state"},
+        ) from exc
+
+    log_history: object = parsed.get("log_history") if isinstance(parsed, dict) else None
+    if isinstance(log_history, list):
+        candidates: list[object] = [
+            entry[field] for entry in log_history if isinstance(entry, dict) and field in entry
+        ]
+        if candidates:
+            return reduce_sequence(candidates, mode)
+
+    if isinstance(parsed, dict) and field in parsed:
+        value = parsed[field]
+        if shape.is_numeric_value(value):
+            return cast(float, value)
+        raise shape.MetricReaderError(
+            shape.ErrorCode.NON_NUMERIC_VALUE,
+            {"field": field, **_describe_value(value)},
+        )
+
+    raise shape.MetricReaderError(
+        shape.ErrorCode.FIELD_NOT_FOUND,
+        {"field": field},
+    )
+
+
+def _handle_parquet(content: bytes, field: str, mode: str) -> float:
+    """Reduce one column of a columnar (Parquet) file to a single number.
+
+    The columnar libraries (``pandas`` + ``pyarrow``) ship only in the
+    analytics extra, so they are imported lazily inside the handler. When
+    either is missing the failure is reported as a
+    :attr:`~.shape.ErrorCode.FORMAT_DEPENDENCY_UNAVAILABLE` envelope rather
+    than letting the ``ImportError`` escape (R12.4).
+
+    Once loaded, the file is parsed into a frame; bytes that do not parse as
+    Parquet are a malformed-file error. The named column is gathered as native
+    Python values — ``Series.tolist()`` converts NumPy scalars to ``int`` /
+    ``float`` so the numeric guard recognises them — and reduced with the
+    aggregation mode. A column absent from the schema is a field-not-found
+    error. An aggregated result of exactly ``0`` is a valid number and is
+    returned as-is; the reducer never treats it as "missing" (R12.2).
+    """
+    try:
+        import pandas as pd
+        import pyarrow  # noqa: F401  # read_parquet's engine; imported so a missing wheel surfaces here
+    except ImportError as exc:
+        raise shape.MetricReaderError(
+            shape.ErrorCode.FORMAT_DEPENDENCY_UNAVAILABLE,
+            {"format": "parquet", "dependency": "pandas+pyarrow"},
+        ) from exc
+
+    try:
+        frame = pd.read_parquet(io.BytesIO(content))
+    except Exception as exc:  # noqa: BLE001 - any pandas/pyarrow read failure is a malformed file
+        raise shape.MetricReaderError(
+            shape.ErrorCode.MALFORMED_FILE,
+            {"format": "parquet"},
+        ) from exc
+
+    if field not in frame.columns:
+        raise shape.MetricReaderError(
+            shape.ErrorCode.FIELD_NOT_FOUND,
+            {"field": field},
+        )
+
+    column_values: list[object] = frame[field].tolist()
+    return reduce_sequence(column_values, mode)
+
+
+def _handle_tfevents(content: bytes, field: str, mode: str) -> float:
+    """Reduce the scalar sequence for a TensorBoard tag to a single number.
+
+    TensorBoard ``tfevents`` reading is the optional/stretch format: its parser
+    (``tbparse``, which pulls in ``tensorboard``) is not a baseline dependency,
+    so it is imported lazily inside the handler. When the parser is not
+    installed the failure is reported as a
+    :attr:`~.shape.ErrorCode.FORMAT_DEPENDENCY_UNAVAILABLE` envelope rather than
+    an import crash (R13.3), so the baseline reader keeps working without the
+    heavyweight dependency (R13.4).
+
+    When the parser is present, the handed-in bytes are staged into a
+    short-lived temporary event file (``tbparse`` reads from a path, not a
+    buffer), the scalar rows for the requested ``field`` tag are gathered, and
+    the sequence is reduced with the aggregation mode — the caller defaults this
+    to ``last``, i.e. the latest scalar for the tag (R13.2). A tag that carries
+    no scalar rows is a field-not-found error, and bytes that do not parse as an
+    event file are a malformed-file error.
+    """
+    try:
+        from tbparse import SummaryReader
+    except ImportError as exc:
+        raise shape.MetricReaderError(
+            shape.ErrorCode.FORMAT_DEPENDENCY_UNAVAILABLE,
+            {"format": "tfevents", "dependency": "tbparse/tensorboard"},
+        ) from exc
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        event_path = os.path.join(tmp_dir, "events.out.tfevents")
+        with open(event_path, "wb") as handle:
+            handle.write(content)
+        try:
+            frame = SummaryReader(event_path, pivot=False).scalars
+        except Exception as exc:  # noqa: BLE001 - any tbparse read failure is a malformed file
+            raise shape.MetricReaderError(
+                shape.ErrorCode.MALFORMED_FILE,
+                {"format": "tfevents"},
+            ) from exc
+
+    if frame is None or getattr(frame, "empty", True) or "tag" not in frame.columns:
+        raise shape.MetricReaderError(
+            shape.ErrorCode.FIELD_NOT_FOUND,
+            {"field": field},
+        )
+    matched = frame[frame["tag"] == field]
+    if matched.empty:
+        raise shape.MetricReaderError(
+            shape.ErrorCode.FIELD_NOT_FOUND,
+            {"field": field},
+        )
+    tag_values: list[object] = matched["value"].tolist()
+    return reduce_sequence(tag_values, mode)
+
+
+# Format name -> handler. Each handler shares the
+# ``(content_bytes, field, mode) -> float`` contract and either returns one
+# finite number or raises a MetricReaderError with a stable code. A format that
+# is not a key here is treated as unsupported by the calling tool.
+#
+# The columnar (``parquet``) and TensorBoard (``tfevents``) handlers are
+# registered into this same map; their handlers carry lazy third-party imports
+# and are added alongside these baseline entries.
+_HANDLERS: dict[str, Callable[..., float]] = {
+    "json": _handle_json,
+    "csv": _handle_csv,
+    "hf_trainer_state": _handle_hf,
+    "jsonl": _handle_jsonl,
+    "yaml": _handle_yaml,
+    "parquet": _handle_parquet,
+    "tfevents": _handle_tfevents,
+}

--- a/mcp/metric_readers/files.py
+++ b/mcp/metric_readers/files.py
@@ -285,7 +285,7 @@ def _handle_parquet(content: bytes, field: str, mode: str) -> float:
     analytics extra, so they are imported lazily inside the handler. When
     either is missing the failure is reported as a
     :attr:`~.shape.ErrorCode.FORMAT_DEPENDENCY_UNAVAILABLE` envelope rather
-    than letting the ``ImportError`` escape (R12.4).
+    than letting the ``ImportError`` escape.
 
     Once loaded, the file is parsed into a frame; bytes that do not parse as
     Parquet are a malformed-file error. The named column is gathered as native
@@ -293,7 +293,7 @@ def _handle_parquet(content: bytes, field: str, mode: str) -> float:
     ``float`` so the numeric guard recognises them — and reduced with the
     aggregation mode. A column absent from the schema is a field-not-found
     error. An aggregated result of exactly ``0`` is a valid number and is
-    returned as-is; the reducer never treats it as "missing" (R12.2).
+    returned as-is; the reducer never treats it as "missing".
     """
     try:
         import pandas as pd
@@ -330,14 +330,14 @@ def _handle_tfevents(content: bytes, field: str, mode: str) -> float:
     so it is imported lazily inside the handler. When the parser is not
     installed the failure is reported as a
     :attr:`~.shape.ErrorCode.FORMAT_DEPENDENCY_UNAVAILABLE` envelope rather than
-    an import crash (R13.3), so the baseline reader keeps working without the
-    heavyweight dependency (R13.4).
+    an import crash, so the baseline reader keeps working without the
+    heavyweight dependency.
 
     When the parser is present, the handed-in bytes are staged into a
     short-lived temporary event file (``tbparse`` reads from a path, not a
     buffer), the scalar rows for the requested ``field`` tag are gathered, and
     the sequence is reduced with the aggregation mode — the caller defaults this
-    to ``last``, i.e. the latest scalar for the tag (R13.2). A tag that carries
+    to ``last``, i.e. the latest scalar for the tag. A tag that carries
     no scalar rows is a field-not-found error, and bytes that do not parse as an
     event file are a malformed-file error.
     """

--- a/mcp/metric_readers/localfs.py
+++ b/mcp/metric_readers/localfs.py
@@ -1,0 +1,91 @@
+"""Confine a caller-supplied path to an allowlisted root directory.
+
+The local-file metric reader is the only reader that accepts a path into the
+host filesystem, so it needs to prove — before opening anything — that the
+path stays inside a single allowlisted root. This module owns that proof and
+nothing else.
+
+:func:`resolve_within_root` is a pure function of ``(supplied_path, root)``:
+it resolves the path with realpath semantics (collapsing ``..`` segments and
+following every symlink), then checks the result against the resolved root.
+A single containment test catches both attack classes — a path that walks out
+with ``..`` segments and a path that stays lexically inside but points at a
+symlink whose target lives elsewhere. The helper never opens or reads any
+file, and never consults the environment; the caller reads the configured
+root once and passes it in as ``root``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from .shape import ErrorCode, MetricReaderError
+
+
+def resolve_within_root(supplied_path: str, root: str) -> Path:
+    """Resolve ``supplied_path`` and prove it stays within ``root``.
+
+    The returned path is the fully resolved location to read from, guaranteed
+    to live inside the resolved ``root``. Resolution uses realpath semantics:
+    ``..`` segments are collapsed and every symlink in the path is followed,
+    so a path escapes by either route is caught by the same containment check.
+
+    ``root`` must be a non-empty directory path; the caller is responsible for
+    reading it (for example from an environment variable) before calling here.
+    An unset or empty ``root`` raises a not-configured error so the reader can
+    refuse rather than fall back to some implicit location.
+
+    Raises:
+        MetricReaderError: with code ``LOCAL_ROOT_NOT_CONFIGURED`` when
+            ``root`` is empty; ``PATH_TRAVERSAL_ESCAPE`` when the supplied
+            path's ``..`` segments alone walk outside the root; or
+            ``SYMLINK_ESCAPE`` when the path stays lexically inside the root
+            but a symlink target points outside it. The supplied path is
+            included in the error details for the two escape cases.
+    """
+    if not root:
+        raise MetricReaderError(ErrorCode.LOCAL_ROOT_NOT_CONFIGURED)
+
+    # Absolute, real root: collapses ``..`` and follows any symlinks so the
+    # containment comparison below is between two fully-resolved paths.
+    real_root = Path(root).resolve()
+
+    supplied = Path(supplied_path)
+    # An absolute supplied path is used as-is; a relative one is joined under
+    # the root before resolution.
+    candidate = supplied if supplied.is_absolute() else (real_root / supplied)
+    resolved = candidate.resolve()
+
+    if not resolved.is_relative_to(real_root):
+        # The path escaped. Decide which distinct code to surface by asking
+        # whether ``..`` segments alone — collapsed lexically, without
+        # following any symlink — would already leave the root. If they would,
+        # this is a traversal escape; otherwise the lexical path stayed inside
+        # and only a symlink target jumped out.
+        if _lexically_escapes(supplied, real_root):
+            raise MetricReaderError(
+                ErrorCode.PATH_TRAVERSAL_ESCAPE,
+                {"supplied_path": supplied_path},
+            )
+        raise MetricReaderError(
+            ErrorCode.SYMLINK_ESCAPE,
+            {"supplied_path": supplied_path},
+        )
+
+    return resolved
+
+
+def _lexically_escapes(supplied: Path, real_root: Path) -> bool:
+    """Return True when collapsing ``..`` alone walks ``supplied`` out of root.
+
+    This mirrors the realpath collapse but stops short of touching the
+    filesystem: ``os.path.normpath`` folds ``..`` segments purely lexically
+    (it never follows symlinks). The result tells the caller whether an escape
+    was caused by the path text itself rather than by a symlink target.
+    """
+    if supplied.is_absolute():
+        lexical = Path(os.path.normpath(supplied))
+    else:
+        lexical = Path(os.path.normpath(real_root / supplied))
+    return not lexical.is_relative_to(real_root)

--- a/mcp/metric_readers/logs.py
+++ b/mcp/metric_readers/logs.py
@@ -1,0 +1,138 @@
+"""Pull a scalar out of a job's log lines.
+
+A job often prints its progress to stdout — sometimes as a structured JSON
+object per line, sometimes as free text a regular expression can pick apart.
+This module turns either of those into a list of candidate values that a
+later reduction step collapses into one number.
+
+It offers three pure helpers:
+
+* :func:`extract_by_json_key` — parse each line as a JSON object and pull the
+  value at a dotted key path.
+* :func:`extract_by_regex` — match each line against a compiled pattern and
+  pull its first capture group.
+* :func:`coerce_scalar` — turn one extracted value (a parsed JSON value or a
+  captured string) into a real, finite number, or fail with a structured
+  error.
+
+Everything here is pure: no log fetching, no I/O, no environment lookups. The
+caller supplies the already-retrieved lines and (for the regex path) an
+already-compiled pattern, which keeps these functions trivial to test in
+isolation.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from typing import Any, cast
+
+from . import shape
+
+
+def extract_by_json_key(lines: list[str], key: str) -> list[object]:
+    """Collect the value at ``key`` from every line that is a JSON object.
+
+    Each line is parsed independently. A line that is not valid JSON, or
+    that parses to something other than a JSON object (a bare number, string,
+    list, ``true``/``false``/``null``), is skipped — it contributes nothing
+    and never raises.
+
+    ``key`` is treated as a dotted path and resolved segment by segment
+    against the parsed object: ``"metrics.loss"`` walks ``obj["metrics"]
+    ["loss"]``. A line whose object does not contain the full path resolves
+    to nothing and is skipped too. The resolved values are returned in the
+    order the lines appeared; coercion to a number happens later.
+    """
+    segments = key.split(".")
+    collected: list[object] = []
+    for line in lines:
+        try:
+            parsed = json.loads(line)
+        except ValueError:
+            # Not parseable as JSON at all (covers JSONDecodeError, which is
+            # a ValueError subclass, and empty/whitespace-only lines).
+            continue
+        if not isinstance(parsed, dict):
+            # Parsed fine, but it is not a JSON object — skip it.
+            continue
+        value: Any = parsed
+        resolved = True
+        for segment in segments:
+            if isinstance(value, dict) and segment in value:
+                value = value[segment]
+            else:
+                resolved = False
+                break
+        if resolved:
+            collected.append(value)
+    return collected
+
+
+def extract_by_regex(lines: list[str], pattern: re.Pattern[str]) -> list[str]:
+    """Collect the first capture group from every line the pattern matches.
+
+    Each line is searched (not anchored) with ``pattern``; on a match the
+    substring captured by the pattern's first group is collected. Lines that
+    do not match contribute nothing. The pattern is expected to define at
+    least one capture group — the caller validates that before compiling —
+    and the captures are returned in line order for later coercion.
+    """
+    collected: list[str] = []
+    for line in lines:
+        match = pattern.search(line)
+        if match is not None:
+            collected.append(match.group(1))
+    return collected
+
+
+def _parse_numeric_string(raw: str) -> float:
+    """Parse a string into a real, finite number or raise.
+
+    Integers are recognized first so a whole number keeps its integer form;
+    anything else falls back to a float parse. A value that does not parse,
+    or that parses to NaN or an infinity, raises
+    :class:`~.shape.MetricReaderError` with code
+    :attr:`~.shape.ErrorCode.NON_NUMERIC_VALUE` and the offending raw string
+    in the details.
+    """
+    text = raw.strip()
+    try:
+        return int(text)
+    except ValueError:
+        pass
+    try:
+        parsed = float(text)
+    except ValueError, OverflowError:
+        raise shape.MetricReaderError(
+            shape.ErrorCode.NON_NUMERIC_VALUE,
+            {"raw": raw, "type": "str"},
+        ) from None
+    if not math.isfinite(parsed):
+        raise shape.MetricReaderError(
+            shape.ErrorCode.NON_NUMERIC_VALUE,
+            {"raw": raw, "type": "str"},
+        )
+    return parsed
+
+
+def coerce_scalar(raw: object) -> float:
+    """Turn one extracted value into a real, finite number, or fail.
+
+    A value that is already a real, finite number (and not a boolean) is
+    returned unchanged. A string is parsed — an integer form when possible,
+    otherwise a float — and rejected if it does not represent a finite
+    number. Every other input (a boolean, ``None``, NaN, an infinity, a list,
+    an object) raises :class:`~.shape.MetricReaderError` with code
+    :attr:`~.shape.ErrorCode.NON_NUMERIC_VALUE` and the offending raw value
+    recorded in the details.
+    """
+    if shape.is_numeric_value(raw):
+        return cast(float, raw)
+    if isinstance(raw, str):
+        return _parse_numeric_string(raw)
+    raise shape.MetricReaderError(
+        shape.ErrorCode.NON_NUMERIC_VALUE,
+        {"raw": raw, "type": type(raw).__name__},
+    )

--- a/mcp/metric_readers/shape.py
+++ b/mcp/metric_readers/shape.py
@@ -1,0 +1,214 @@
+"""Building blocks shared by every metric-reader tool.
+
+A metric reader either produces one numeric scalar wrapped in a canonical
+result shape, or it fails and produces a structured error envelope. This
+module owns the small, pure pieces both outcomes are built from:
+
+* :class:`ErrorCode` — the frozen set of stable, machine-readable failure
+  codes a reader can surface.
+* :class:`MetricReaderError` — the exception readers raise internally;
+  tool wrappers translate it into an error envelope.
+* :func:`validate_metric_name` — guards the caller-supplied metric name so
+  the resulting key is a single, well-formed path segment.
+* :func:`default_metric_key` — derives a deterministic, well-formed key from
+  a source identifier when the caller supplies no explicit name.
+* :func:`is_numeric_value` — the single source of truth for "is this a real,
+  finite number?".
+* :func:`metrics_result` — assembles the canonical
+  ``{"metrics": {key: value}, ...}`` success shape.
+* :func:`error_envelope` — assembles the ``{"code", "details"}`` failure
+  shape.
+
+Everything here is pure: no I/O, no clocks, no environment lookups. That
+keeps the pieces trivial to test in isolation and safe to call from both
+async tool handlers and synchronous code.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+# The longest a metric name may be, in characters.
+_MAX_METRIC_NAME_LEN = 128
+
+# The fallback key used when a source identifier sanitizes down to nothing.
+_DEFAULT_KEY_FALLBACK = "metric"
+
+
+class ErrorCode:
+    """Stable, machine-readable failure codes a metric reader can surface.
+
+    Each value is a short string an operator (or an automated caller) can
+    branch on without parsing a human message. The values are deliberately
+    frozen: callers and tests may depend on the exact strings.
+    """
+
+    METRIC_NAME_INVALID = "metric_name_invalid"
+    INVALID_AGGREGATION_MODE = "invalid_aggregation_mode"
+    EMPTY_SEQUENCE = "empty_sequence"
+    # A sequence had entries, but none survived the numeric filter.
+    NO_NUMERIC_VALUE = "no_numeric_value"
+    # A single resolved value was not a real, finite number.
+    NON_NUMERIC_VALUE = "non_numeric_value"
+    NO_DATAPOINTS = "no_datapoints"
+    # details.kind discriminates unreachable / unauthorized / client_error.
+    AWS_UNREACHABLE = "aws_unreachable"
+    INVALID_EXTRACTION_MODE = "invalid_extraction_mode"
+    INVALID_REGEX = "invalid_regex"
+    NO_MATCH = "no_match"
+    # details.kind discriminates unknown_job / unreachable.
+    LOG_RETRIEVAL_FAILED = "log_retrieval_failed"
+    FILE_NOT_FOUND = "file_not_found"
+    MALFORMED_FILE = "malformed_file"
+    # Covers both a missing object field and a missing table column.
+    FIELD_NOT_FOUND = "field_not_found"
+    # The same failure class as NON_NUMERIC_VALUE, named for file readers.
+    NON_NUMERIC_VALUE_FILE = NON_NUMERIC_VALUE
+    FILE_TOO_LARGE = "file_too_large"
+    UNSUPPORTED_FORMAT = "unsupported_format"
+    FORMAT_DEPENDENCY_UNAVAILABLE = "format_dependency_unavailable"
+    # Local-filesystem reader confinement codes. Kept distinct so an
+    # operator can tell a traversal attempt, a symlink escape, and an
+    # unconfigured root apart without inspecting the details payload.
+    #
+    # A supplied path's ".." segments escaped the allowlisted root.
+    PATH_TRAVERSAL_ESCAPE = "path_traversal_escape"
+    # A symlink within the path resolved to a target outside the root.
+    SYMLINK_ESCAPE = "symlink_escape"
+    # The reader is enabled but no allowlisted root is configured.
+    LOCAL_ROOT_NOT_CONFIGURED = "local_root_not_configured"
+
+
+class MetricReaderError(Exception):
+    """Raised internally when a reader cannot produce a metric.
+
+    Carries a stable short ``code`` (one of :class:`ErrorCode`) and an
+    optional structured ``details`` dict the tool wrapper renders into an
+    error envelope. The constructor accepts ``(code, details=None, *,
+    message=None)``; when ``message`` is omitted the exception's string
+    form falls back to ``code`` so logs always show something meaningful.
+    """
+
+    def __init__(
+        self,
+        code: str,
+        details: dict[str, Any] | None = None,
+        *,
+        message: str | None = None,
+    ) -> None:
+        self.code: str = code
+        self.details: dict[str, Any] | None = details
+        rendered = message if message is not None else code
+        super().__init__(rendered)
+
+
+def validate_metric_name(name: str) -> str:
+    """Return ``name`` unchanged when it is a single well-formed path segment.
+
+    A valid name is a non-empty string of at most 128 characters that
+    contains neither a ``.`` separator nor any whitespace character, so the
+    resulting metric path is exactly ``metrics.<name>``. Any other input —
+    empty, too long, containing a ``.``, or containing whitespace — raises
+    :class:`MetricReaderError` with code
+    :attr:`ErrorCode.METRIC_NAME_INVALID` and a ``details`` payload that
+    names the specific reason.
+    """
+    if not isinstance(name, str):
+        raise MetricReaderError(
+            ErrorCode.METRIC_NAME_INVALID,
+            {"reason": "not_a_string"},
+        )
+    if not name:
+        raise MetricReaderError(
+            ErrorCode.METRIC_NAME_INVALID,
+            {"reason": "empty", "name": name},
+        )
+    if len(name) > _MAX_METRIC_NAME_LEN:
+        raise MetricReaderError(
+            ErrorCode.METRIC_NAME_INVALID,
+            {
+                "reason": "too_long",
+                "name": name,
+                "max_length": _MAX_METRIC_NAME_LEN,
+                "actual_length": len(name),
+            },
+        )
+    if "." in name:
+        raise MetricReaderError(
+            ErrorCode.METRIC_NAME_INVALID,
+            {"reason": "contains_separator", "name": name},
+        )
+    if any(ch.isspace() for ch in name):
+        raise MetricReaderError(
+            ErrorCode.METRIC_NAME_INVALID,
+            {"reason": "contains_whitespace", "name": name},
+        )
+    return name
+
+
+def default_metric_key(source_hint: str) -> str:
+    """Derive a deterministic, well-formed key from a source identifier.
+
+    Used when the caller supplies no explicit metric name. Every character
+    that a metric name may not contain — a ``.`` separator or any whitespace
+    character — is replaced with an underscore, the result is capped at 128
+    characters, and an identifier that sanitizes down to nothing falls back
+    to a fixed placeholder. The same input always yields the same key, and
+    the key always satisfies :func:`validate_metric_name`.
+    """
+    text = str(source_hint)
+    sanitized = "".join("_" if (ch == "." or ch.isspace()) else ch for ch in text)
+    sanitized = sanitized[:_MAX_METRIC_NAME_LEN]
+    if not sanitized:
+        return _DEFAULT_KEY_FALLBACK
+    return sanitized
+
+
+def is_numeric_value(x: object) -> bool:
+    """Return True only for a real, finite number.
+
+    An integer qualifies; a float qualifies when it is finite. A boolean is
+    rejected even though ``bool`` is a subclass of ``int``, and NaN and the
+    infinities are rejected. Everything else — strings, ``None``, containers
+    — is rejected too. This is the single gate a value must pass before it
+    can stand in for a metric a threshold comparison will read.
+    """
+    if isinstance(x, bool):
+        return False
+    if isinstance(x, int):
+        return True
+    if isinstance(x, float):
+        # math.isfinite is False for NaN and +/-inf.
+        return math.isfinite(x)
+    return False
+
+
+def metrics_result(key: str, value: float, **provenance: object) -> dict[str, Any]:
+    """Assemble the canonical success shape: ``{"metrics": {key: value}, ...}``.
+
+    The single metric lives under the top-level ``metrics`` object; every
+    provenance field (source identifier, region, timestamp, aggregation mode
+    applied, and so on) is placed beside ``metrics`` at the top level, never
+    inside it, so the merged view contains only the numeric value. ``value``
+    must already be a real, finite number — callers coerce and check before
+    reaching this builder.
+    """
+    assert is_numeric_value(value), "metrics_result requires a finite numeric value"
+    # Lay down provenance first, then the metrics object, so the top-level
+    # ``metrics`` key is always the canonical numeric map even if a
+    # provenance field happens to share that name.
+    result: dict[str, Any] = dict(provenance)
+    result["metrics"] = {key: value}
+    return result
+
+
+def error_envelope(code: str, **details: object) -> dict[str, Any]:
+    """Assemble the structured failure shape: ``{"code": code, "details": {...}}``.
+
+    The returned object never carries a top-level ``metrics`` key, so a
+    consumer that merges only ``metrics``-shaped results skips it and leaves
+    the corresponding check undecided rather than acting on bad data. Any
+    diagnostic context is nested under ``details``.
+    """
+    return {"code": code, "details": dict(details)}

--- a/mcp/mission/README.md
+++ b/mcp/mission/README.md
@@ -1,0 +1,139 @@
+# Mission — Goal-Directed Iteration Loop
+
+`mcp/mission/` is the internal package behind GCO's **Mission** feature: a
+goal-directed iteration loop that drives an orchestrated workflow toward a set
+of machine-checkable success criteria. An operator declares a natural-language
+directive, a tool allowlist, and a budget; the engine runs repeated five-phase
+iterations (propose → execute → observe → evaluate → decide) until it reaches a
+terminal verdict.
+
+Mission is off by default. Enable it by setting `GCO_ENABLE_MISSION=true` for
+the MCP server (see [Feature Flags](../README.md#feature-flags)). For the
+user-facing guide — concepts, CLI walkthrough, and worked examples — read
+[`docs/MISSION.md`](../../docs/MISSION.md).
+
+## Table of Contents
+
+- [Overview](#overview)
+- [The Five-Phase Loop](#the-five-phase-loop)
+- [Module Map](#module-map)
+  - [Engine and Lifecycle](#engine-and-lifecycle)
+  - [Domain Types and State](#domain-types-and-state)
+  - [Verdict and Cadence](#verdict-and-cadence)
+  - [Input Validation and Sandboxes](#input-validation-and-sandboxes)
+  - [Advisory Sampling](#advisory-sampling)
+  - [Criteria Scaffolding](#criteria-scaffolding)
+  - [Reporting and Audit](#reporting-and-audit)
+  - [Wiring Helpers](#wiring-helpers)
+- [Design Principles](#design-principles)
+- [Related Documentation](#related-documentation)
+
+## Overview
+
+Mission turns a high-level goal into a controlled, auditable loop. The operator
+supplies four things:
+
+- A **directive** — the natural-language goal.
+- **Success criteria** — machine-checkable predicates the loop evaluates each
+  iteration to decide whether the goal is met.
+- A **tool allowlist** — the subset of MCP tools the loop may call.
+- A **budget** — caps on iterations and wall-clock time that bound the run.
+
+The engine then iterates until it reaches one of four verdicts: `continue`
+(keep going), `adjust` (revise the strategy), `complete` (criteria satisfied),
+or `terminate` (budget exhausted or no progress). The verdict cascade is fully
+deterministic; an optional advisory LLM can shape the *next strategy* on an
+`adjust`, but it never moves the verdict itself.
+
+## The Five-Phase Loop
+
+Each iteration walks through the same five phases. Every phase emits exactly one
+structured audit event, so a run is fully reconstructable from its audit trail.
+
+| Phase | Responsibility |
+|-------|----------------|
+| **Propose** | Select the strategy (tool sequence or scripted strategy) for this iteration. |
+| **Execute** | Run the proposed strategy against the tool allowlist. |
+| **Observe** | Collect the results into a structured observation. |
+| **Evaluate** | Check the observation against each success criterion. |
+| **Decide** | Run the deterministic verdict cascade to pick the next action. |
+
+## Module Map
+
+### Engine and Lifecycle
+
+| Module | Description |
+|--------|-------------|
+| [`engine.py`](engine.py) | The `MissionEngine` — drives one `run_iteration` lifecycle through all five phases, persists the iteration record, and writes a final report on a terminal verdict. Dependencies are injected at construction so phases stay pure and testable. |
+
+### Domain Types and State
+
+| Module | Description |
+|--------|-------------|
+| [`types.py`](types.py) | Shared `TypedDict` domain types (session state, iteration and phase records, verdict labels) so the engine, validators, and tool wrappers agree on one shape that round-trips through JSON. |
+| [`state.py`](state.py) | The `MissionStateBackend` persistence protocol plus concrete backends (filesystem, DynamoDB) for loading, saving, listing, and deleting session records. |
+
+### Verdict and Cadence
+
+| Module | Description |
+|--------|-------------|
+| [`decide.py`](decide.py) | The pure, deterministic verdict cascade — given the session, the in-progress iteration, and a passed-in wall-clock value, returns the `(verdict, reason)` tuple. No I/O, no clock reads, no randomness. |
+| [`checkpoints.py`](checkpoints.py) | Pure cadence resolver that decides whether a given iteration produces a real verdict or a synthetic `cadence_skip`, and records when the last real verdict happened. |
+
+### Input Validation and Sandboxes
+
+| Module | Description |
+|--------|-------------|
+| [`validation.py`](validation.py) | Pure shared validators that normalize operator-supplied JSON (criteria, strategies, budget) before it touches state, raising a structured error with a stable code on rejection. |
+| [`predicate.py`](predicate.py) | Restricted AST evaluator for `predicate` criteria — parses an untrusted Python expression once, validates it against a tight allowlist, and evaluates it against an observation with builtins cleared. |
+| [`sandbox.py`](sandbox.py) | Restricted AST validator for scripted strategies — the multi-statement counterpart to `predicate.py`, parsing untrusted script source in `exec` mode against an explicit node allowlist. |
+
+### Advisory Sampling
+
+| Module | Description |
+|--------|-------------|
+| [`sampling.py`](sampling.py) | Prompt builders for the optional advisory LLM path — assembles deterministic strategy-revision and final-report prompts from session data. Transport-agnostic and side-effect-free. |
+| [`_environment.py`](_environment.py) | Gathers slow-moving live environment signals (deployed regions, per-region cluster metrics, reservation counts) that fill the optional environment-context block of the sampling prompt. |
+
+### Criteria Scaffolding
+
+| Module | Description |
+|--------|-------------|
+| [`criteria_scaffold.py`](criteria_scaffold.py) | Helpers behind `gco mission scaffold-criteria` — turns a natural-language directive into a validated criteria array, via a pure keyword-matching path or an async sampling-backed path with retry-on-rejection. |
+
+### Reporting and Audit
+
+| Module | Description |
+|--------|-------------|
+| [`final_report.py`](final_report.py) | Builds and atomically persists the durable JSON final report that ends a session, capturing the directive, criteria, budget, full iteration history, and terminal verdict. |
+| [`audit.py`](audit.py) | Thin Mission-specific audit emitters for phase, verdict, and sampling events, each writing one structured entry through the shared audit logger. |
+
+### Wiring Helpers
+
+| Module | Description |
+|--------|-------------|
+| [`_engine_factory.py`](_engine_factory.py) | Shared factory that builds a production-wired `MissionEngine` (live tool dispatcher, sampling callable, sandbox runner) for both the MCP tool surface and the CLI, plus a stub dispatcher for `--dry-run` smoke tests. |
+
+## Design Principles
+
+- **Deterministic core, advisory edge.** The verdict cascade is pure and
+  reproducible. LLM sampling is strictly advisory — it can shape the next
+  strategy on an `adjust`, but it never changes the verdict.
+- **Untrusted input is sandboxed at parse time.** Predicate expressions and
+  scripted strategies are validated against tight AST allowlists before any
+  execution, so a malformed or hostile input is rejected immediately rather
+  than on iteration N.
+- **Pure functions take their context as arguments.** Validators, the verdict
+  cascade, and the cadence resolver perform no I/O and read no clocks — the
+  caller passes in the wall-clock value and any external context, which keeps
+  them trivial to unit-test.
+- **Bounded by budget.** Every run terminates cleanly when an iteration or
+  wall-clock cap fires.
+
+## Related Documentation
+
+- [`docs/MISSION.md`](../../docs/MISSION.md) — the user-facing Mission guide
+  (concepts, CLI usage, examples).
+- [`mcp/README.md`](../README.md) — the GCO MCP server, including the
+  [`GCO_ENABLE_MISSION`](../README.md#feature-flags) feature flag and the
+  `mission_*` tools.

--- a/mcp/mission/engine.py
+++ b/mcp/mission/engine.py
@@ -52,7 +52,7 @@ modules make for tools that take an injected context.
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, cast
@@ -1155,33 +1155,62 @@ class MissionEngine:
     def _build_cumulative_observation(
         current_obs: dict[str, Any], session: SessionState
     ) -> dict[str, Any]:
-        """Merge prior iterations' tool_results into a cumulative view.
+        """Merge prior iterations' tool_results and metric history into a view.
 
-        The cumulative observation is used by predicate criteria so
-        they can see tool results from all iterations, not just the
-        current one. This enables multi-tool goals where each tool
-        runs in a different iteration to converge on predicates that
-        check for content across tools.
+        Two things are cumulative on the returned view:
 
-        Only ``tool_results`` is cumulative; ``metrics``, ``events``,
-        and ``errors`` stay per-iteration because they represent the
-        current state (metrics can change between iterations; events
-        are per-iteration signals; errors are per-call).
+        * ``tool_results`` — every prior iteration's results concatenated with
+          the current iteration's, so predicate criteria can see results from
+          all iterations. This enables multi-tool goals where each tool runs in
+          a different iteration to converge.
+        * ``metric_history`` — a history-aware map from metric name to the
+          ordered list of its numeric values across the session
+          (oldest→newest, current iteration last). This is what lets the
+          ``metric_trend`` criterion ask "is loss falling across iterations?"
+          even though the engine keeps the per-iteration ``metrics`` dict
+          strictly point-in-time. Non-numeric and boolean metric values are
+          skipped so a stray string reading cannot poison a trend.
+
+        ``metrics``, ``events``, and ``errors`` stay per-iteration on the view
+        because they represent current state: ``metrics`` is the latest
+        point-in-time reading (a ``metric_threshold`` criterion still compares
+        the single current value), events are per-iteration signals, and errors
+        are per-call. The history lives *alongside* them under
+        ``metric_history`` rather than replacing them, so existing criteria are
+        unaffected.
         """
         all_tool_results: list[Any] = []
+        metric_history: dict[str, list[float]] = {}
+
+        def _accumulate_metrics(obs: Mapping[str, Any]) -> None:
+            metrics = obs.get("metrics")
+            if not isinstance(metrics, dict):
+                return
+            for key, value in metrics.items():
+                # Mirror the Numeric_Value guard the readers use: int or float,
+                # never bool. A non-numeric reading contributes no history
+                # point rather than breaking the series.
+                if isinstance(value, bool) or not isinstance(value, (int, float)):
+                    continue
+                metric_history.setdefault(key, []).append(float(value))
+
         for prior in session.get("iterations") or []:
             prior_obs = prior.get("observation") or {}
             prior_results = prior_obs.get("tool_results")
             if isinstance(prior_results, list):
                 all_tool_results.extend(prior_results)
-        # Append current iteration's results.
+            _accumulate_metrics(prior_obs)
+        # Append current iteration's results and metrics last so the history is
+        # ordered oldest→newest with the current reading at the end.
         current_results = current_obs.get("tool_results")
         if isinstance(current_results, list):
             all_tool_results.extend(current_results)
-        # Build the cumulative view: tool_results is cumulative,
-        # everything else comes from the current observation.
+        _accumulate_metrics(current_obs)
+        # Build the cumulative view: tool_results + metric_history are
+        # cumulative, everything else comes from the current observation.
         cumulative: dict[str, Any] = dict(current_obs)
         cumulative["tool_results"] = all_tool_results
+        cumulative["metric_history"] = metric_history
         return cumulative
 
     def _evaluate_one_criterion(
@@ -1198,6 +1227,10 @@ class MissionEngine:
 
         if kind == "metric_threshold":
             status, evidence = self._evaluate_metric_threshold(criterion, observation)
+        elif kind == "metric_trend":
+            # Trend evaluates against the cumulative observation, where the
+            # engine accumulates ``metric_history`` across iterations.
+            status, evidence = self._evaluate_metric_trend(criterion, cumulative_obs)
         elif kind == "event":
             status, evidence = self._evaluate_event(criterion, observation)
         elif kind == "predicate":
@@ -1242,6 +1275,95 @@ class MissionEngine:
         except ValueError:
             return "inconclusive", value
         return ("met" if met else "unmet"), value
+
+    @staticmethod
+    def _evaluate_metric_trend(
+        criterion: Criterion, cumulative_obs: dict[str, Any]
+    ) -> tuple[str, Any]:
+        """Evaluate a metric's direction across the accumulated history.
+
+        Reads the metric's value series from
+        ``cumulative_obs["metric_history"]`` — the oldest→newest list of
+        numeric readings the engine accumulates in
+        :meth:`_build_cumulative_observation`. The ``metric`` dot-path is
+        resolved against that map: a leading ``metrics.`` segment is stripped
+        so a criterion can reuse the same ``"metrics.loss"`` path it would use
+        for ``metric_threshold`` and still address the ``loss`` history series.
+
+        The series is trimmed to the most-recent ``window`` points (default:
+        all available). With fewer than ``min_points`` numeric points (default
+        2) the criterion is ``inconclusive`` — a trend is undefined on a single
+        reading, and the loop must never be failed for lack of history. The
+        verdict compares the last point to the first point of the windowed
+        series per ``direction``:
+
+        * ``decreasing``     → last <  first
+        * ``increasing``     → last >  first
+        * ``non_increasing`` → last <= first
+        * ``non_decreasing`` → last >= first
+
+        Evidence is a structured dict (direction, the windowed points, first /
+        last, and net delta) so the audit log shows exactly what the verdict
+        was computed from.
+        """
+        path = criterion.get("metric") or ""
+        direction = criterion.get("direction")
+        # Resolve the metric key against the history map. Accept both the bare
+        # key (``"loss"``) and the dot-path form (``"metrics.loss"``) so a
+        # trend criterion lines up with the metric_threshold convention.
+        history = cumulative_obs.get("metric_history")
+        if not isinstance(history, dict):
+            return "inconclusive", "metric_history_missing"
+        key = path.split(".", 1)[1] if path.startswith("metrics.") else path
+        series = history.get(key)
+        if not isinstance(series, list) or not series:
+            return "inconclusive", f"metric_history_empty:{key!r}"
+
+        # Keep only the numeric points (the accumulator already filters, but be
+        # defensive against a hand-built cumulative_obs in tests).
+        points: list[float] = [
+            float(v) for v in series if not isinstance(v, bool) and isinstance(v, (int, float))
+        ]
+
+        window = criterion.get("window")
+        if isinstance(window, int) and not isinstance(window, bool) and window > 0:
+            points = points[-window:]
+
+        min_points = criterion.get("min_points")
+        required_points = (
+            min_points if isinstance(min_points, int) and not isinstance(min_points, bool) else 2
+        )
+        required_points = max(2, required_points)
+        if len(points) < required_points:
+            return "inconclusive", {
+                "reason": "insufficient_history",
+                "points": points,
+                "required_points": required_points,
+            }
+
+        first = points[0]
+        last = points[-1]
+        delta = last - first
+        if direction == "decreasing":
+            met = last < first
+        elif direction == "increasing":
+            met = last > first
+        elif direction == "non_increasing":
+            met = last <= first
+        elif direction == "non_decreasing":
+            met = last >= first
+        else:
+            # Unreachable when the validator has run; surface defensively.
+            return "inconclusive", f"unknown_direction:{direction!r}"
+
+        evidence = {
+            "direction": direction,
+            "points": points,
+            "first": first,
+            "last": last,
+            "delta": delta,
+        }
+        return ("met" if met else "unmet"), evidence
 
     @staticmethod
     def _evaluate_event(criterion: Criterion, observation: dict[str, Any]) -> tuple[str, Any]:

--- a/mcp/mission/types.py
+++ b/mcp/mission/types.py
@@ -48,8 +48,24 @@ VerdictReason = Literal[
 StatusLabel = Literal["pending", "running", "paused", "completed", "terminated", "failed"]
 """The lifecycle states of a :class:`SessionState`."""
 
-CriterionKind = Literal["metric_threshold", "event", "predicate", "tool_call_succeeded"]
-"""The four Criterion evaluator kinds."""
+CriterionKind = Literal[
+    "metric_threshold", "event", "predicate", "tool_call_succeeded", "metric_trend"
+]
+"""The five Criterion evaluator kinds.
+
+``metric_trend`` is the history-aware kind: rather than comparing a single
+point-in-time value to a fixed target (``metric_threshold``), it evaluates the
+direction of a metric across iterations using the cumulative metric history the
+engine accumulates in :meth:`MissionEngine._build_cumulative_observation`.
+"""
+
+MetricTrendDirection = Literal["decreasing", "increasing", "non_increasing", "non_decreasing"]
+"""The four trend directions a ``metric_trend`` criterion can require.
+
+``decreasing`` / ``increasing`` require a strict net change across the window
+(last < first / last > first); ``non_increasing`` / ``non_decreasing`` allow a
+flat series (last <= first / last >= first).
+"""
 
 SamplingStatus = Literal["used", "rejected", "fallback", "unavailable", "disabled"]
 """The terminal status of a single sampling attempt on an iteration."""
@@ -89,7 +105,8 @@ class Criterion(TypedDict):
 
     The kind-specific keys (``metric``/``op``/``target`` for
     ``metric_threshold``, ``event_name`` for ``event``, ``expression`` for
-    ``predicate``, ``tool_name``/``min_count`` for ``tool_call_succeeded``)
+    ``predicate``, ``tool_name``/``min_count`` for ``tool_call_succeeded``,
+    ``metric``/``direction``/``window``/``min_points`` for ``metric_trend``)
     are not declared on the base ``TypedDict`` because they are mutually
     exclusive per ``kind``. Validators in ``mcp.mission.validation`` verify
     the right keys are present for each ``kind`` and may attach a private
@@ -107,6 +124,13 @@ class Criterion(TypedDict):
     expression: NotRequired[str]
     tool_name: NotRequired[str]
     min_count: NotRequired[int]
+    # metric_trend keys: ``direction`` is required for the kind; ``window``
+    # bounds how many of the most-recent points are considered (default: all
+    # available); ``min_points`` is the minimum number of numeric points
+    # required before the criterion decides met/unmet rather than inconclusive.
+    direction: NotRequired[MetricTrendDirection]
+    window: NotRequired[int]
+    min_points: NotRequired[int]
     # Cached parsed AST attached by ``validate_criteria`` for predicate entries.
     _parsed_ast: NotRequired[Any]
 
@@ -209,6 +233,14 @@ class Observation(TypedDict):
     metrics: dict[str, Any]
     events: list[dict[str, Any]]
     errors: NotRequired[list[dict[str, Any]]]
+    # Cumulative, history-aware view of every numeric metric seen across the
+    # session, keyed by metric name and ordered oldest→newest. Present only on
+    # the *cumulative* observation the Evaluate_Phase builds (see
+    # :meth:`MissionEngine._build_cumulative_observation`); the per-iteration
+    # Observation written to ``record["observation"]`` keeps ``metrics``
+    # strictly point-in-time and does not carry this key. Consumed by the
+    # ``metric_trend`` criterion and available to predicates.
+    metric_history: NotRequired[dict[str, list[float]]]
     phase_started_at: str
     phase_ended_at: str
 

--- a/mcp/mission/validation.py
+++ b/mcp/mission/validation.py
@@ -82,12 +82,17 @@ _DIRECTIVE_MAX_LEN: Final[int] = 8192
 """The hard cap on directive_text length, in characters."""
 
 _CRITERION_KINDS: Final[frozenset[str]] = frozenset(
-    {"metric_threshold", "event", "predicate", "tool_call_succeeded"}
+    {"metric_threshold", "event", "predicate", "tool_call_succeeded", "metric_trend"}
 )
-"""The four valid Criterion ``kind`` values."""
+"""The five valid Criterion ``kind`` values."""
 
 _METRIC_OPS: Final[frozenset[str]] = frozenset({"<", "<=", ">", ">=", "==", "!="})
 """The six valid comparison operators on a ``metric_threshold`` criterion."""
+
+_METRIC_TREND_DIRECTIONS: Final[frozenset[str]] = frozenset(
+    {"decreasing", "increasing", "non_increasing", "non_decreasing"}
+)
+"""The four valid trend directions on a ``metric_trend`` criterion."""
 
 _CADENCE_KINDS: Final[frozenset[str]] = frozenset(
     {"every_iteration", "every_n_iterations", "every_t_seconds", "on_event"}
@@ -207,6 +212,64 @@ def _validate_metric_threshold(entry: dict[str, Any], criterion_id: str) -> None
         )
 
 
+def _validate_metric_trend(entry: dict[str, Any], criterion_id: str) -> None:
+    """Check the kind-specific keys for a ``metric_trend`` criterion.
+
+    Required: ``metric`` (non-empty dot-path string) and ``direction`` (one of
+    the four :data:`_METRIC_TREND_DIRECTIONS`). Optional: ``window`` (positive
+    int — how many of the most-recent points to consider) and ``min_points``
+    (positive int — the minimum number of numeric points required before the
+    criterion decides met/unmet rather than inconclusive).
+
+    Unlike ``metric_threshold`` this kind has no ``op``/``target``: the
+    comparison is "where did the metric go over the window?", evaluated by
+    :meth:`MissionEngine._evaluate_metric_trend` against the cumulative metric
+    history the engine accumulates across iterations.
+    """
+    metric = entry.get("metric")
+    if not isinstance(metric, str) or not metric:
+        raise MissionValidationError(
+            "validation_error",
+            details={
+                "field": "criteria",
+                "criterion_id": criterion_id,
+                "reason": "metric_missing_or_invalid",
+            },
+        )
+    direction = entry.get("direction")
+    if direction not in _METRIC_TREND_DIRECTIONS:
+        raise MissionValidationError(
+            "validation_error",
+            details={
+                "field": "criteria",
+                "criterion_id": criterion_id,
+                "reason": "direction_invalid",
+                "allowed": sorted(_METRIC_TREND_DIRECTIONS),
+            },
+        )
+    # ``window`` and ``min_points`` are optional, but when present each must be
+    # a strictly-positive int (bool rejected). A missing value lets the engine
+    # apply its defaults (window = all points; min_points = 2).
+    if "window" in entry and not _is_positive_int(entry.get("window")):
+        raise MissionValidationError(
+            "validation_error",
+            details={
+                "field": "criteria",
+                "criterion_id": criterion_id,
+                "reason": "window_must_be_positive_int",
+            },
+        )
+    if "min_points" in entry and not _is_positive_int(entry.get("min_points")):
+        raise MissionValidationError(
+            "validation_error",
+            details={
+                "field": "criteria",
+                "criterion_id": criterion_id,
+                "reason": "min_points_must_be_positive_int",
+            },
+        )
+
+
 def _validate_event_criterion(entry: dict[str, Any], criterion_id: str) -> None:
     """Check the kind-specific keys for an ``event`` criterion."""
     event_name = entry.get("event_name")
@@ -299,10 +362,12 @@ def validate_criteria(criteria: list[dict[str, Any]]) -> list[Criterion]:
     """Validate a list of criteria and attach cached predicate ASTs.
 
     Required keys on every entry: ``criterion_id`` (non-empty str),
-    ``kind`` (one of the three :class:`CriterionKind` values), and
+    ``kind`` (one of the :class:`CriterionKind` values), and
     ``required`` (bool). Each entry must also provide the kind-specific
     keys: ``metric``/``op``/``target`` for ``metric_threshold``,
-    ``event_name`` for ``event``, ``expression`` for ``predicate``.
+    ``metric``/``direction`` (plus optional ``window``/``min_points``) for
+    ``metric_trend``, ``event_name`` for ``event``, ``tool_name`` for
+    ``tool_call_succeeded``, and ``expression`` for ``predicate``.
 
     The ``criterion_id`` must be unique across the list. For each
     ``predicate`` entry, the expression is parsed via
@@ -379,6 +444,8 @@ def validate_criteria(criteria: list[dict[str, Any]]) -> list[Criterion]:
         normalized_entry: dict[str, Any] = dict(entry)
         if kind == "metric_threshold":
             _validate_metric_threshold(entry, criterion_id)
+        elif kind == "metric_trend":
+            _validate_metric_trend(entry, criterion_id)
         elif kind == "event":
             _validate_event_criterion(entry, criterion_id)
         elif kind == "tool_call_succeeded":

--- a/mcp/tools/README.md
+++ b/mcp/tools/README.md
@@ -19,6 +19,7 @@ MCP tool definitions — one file per domain. Each module registers tools agains
 | `stacks.py` | 4 | `list_stacks`, `stack_status`, `setup_cluster_access`, `fsx_status` |
 | `storage.py` | 2 | `list_storage_contents`, `list_file_systems` |
 | `models.py` | 2 | `list_models`, `get_model_uri` |
+| `metrics.py` | 4 (3 default-on, 1 gated) | All `safe`: `metrics_cloudwatch_get`, `metrics_from_job_logs`, `metrics_from_shared_storage_file` (default-on); `metrics_from_local_file` (gated by `GCO_ENABLE_LOCAL_METRICS`, default-off) |
 | `tasks.py` | 2 | `task_status`, `task_tail` (read-only observability for long-running tools) |
 
 ## How Tools Work

--- a/mcp/tools/__init__.py
+++ b/mcp/tools/__init__.py
@@ -20,6 +20,7 @@ def register_all_tools() -> None:
         images,
         inference,
         jobs,
+        metrics,
         mission,
         models,
         nodepools,

--- a/mcp/tools/metrics.py
+++ b/mcp/tools/metrics.py
@@ -62,13 +62,13 @@ from metric_readers.shape import (  # noqa: E402
     validate_metric_name,
 )
 
-# Job-log tail bounds (R5.10): a caller-supplied or default tail size is clamped
+# Job-log tail bounds: a caller-supplied or default tail size is clamped
 # into this inclusive range before any log volume is retrieved.
 _TAIL_MIN = 1
 _TAIL_MAX = 10_000
 _TAIL_DEFAULT = 1000
 
-# File-reader default size cap (R6.8): 10 MiB. The artifact's size is checked
+# File-reader default size cap: 10 MiB. The artifact's size is checked
 # before its full content is read into memory.
 _MAX_BYTES_DEFAULT = 10_485_760
 
@@ -77,8 +77,8 @@ def _resolve_key(output_name: str | None, source_hint: str) -> str:
     """Return a validated metric key from an explicit name or a source hint.
 
     When ``output_name`` is supplied it must satisfy the single-Dot_Path-segment
-    naming constraint (R1.3, R1.7); otherwise a deterministic, well-formed key
-    is derived from ``source_hint`` (R1.4).
+    naming constraint; otherwise a deterministic, well-formed key
+    is derived from ``source_hint``.
     """
     if output_name:
         return validate_metric_name(output_name)
@@ -219,7 +219,7 @@ async def metrics_from_job_logs(
     try:
         has_key = bool(json_key)
         has_regex = bool(regex)
-        # Exactly one extraction mode (R5.4).
+        # Exactly one extraction mode.
         if has_key == has_regex:
             raise MetricReaderError(
                 ErrorCode.INVALID_EXTRACTION_MODE,
@@ -236,7 +236,7 @@ async def metrics_from_job_logs(
         pattern: re.Pattern[str] | None = None
         if has_regex:
             # Compile and reject uncompilable or zero-capture-group patterns
-            # (R5.11).
+            # .
             try:
                 pattern = re.compile(regex)  # type: ignore[arg-type]
             except re.error as exc:
@@ -250,13 +250,13 @@ async def metrics_from_job_logs(
                     {"regex": regex, "reason": "no capture group"},
                 )
 
-        # Resolve the metric key (R1.3, R1.4, R1.7).
+        # Resolve the metric key.
         if has_key:
             key = _resolve_key(output_name, json_key.rsplit(".", 1)[-1])  # type: ignore[union-attr]
         else:
             key = _resolve_key(output_name, "value")
 
-        # Clamp the tail size into [1, 10_000] (R5.10).
+        # Clamp the tail size into [1, 10_000].
         clamped = max(_TAIL_MIN, min(int(tail), _TAIL_MAX))
 
         raw = await asyncio.to_thread(
@@ -273,7 +273,7 @@ async def metrics_from_job_logs(
         )
 
         # Translate an ``{"error": ...}`` CLI payload into a retrieval failure
-        # (R5.12). Plain log text is not JSON and is used as-is.
+        # . Plain log text is not JSON and is used as-is.
         try:
             payload = json.loads(raw)
         except ValueError:
@@ -293,7 +293,7 @@ async def metrics_from_job_logs(
         else:
             candidates = logs.extract_by_json_key(lines, json_key)  # type: ignore[arg-type]
 
-        # No line matched the key/pattern (R5.8).
+        # No line matched the key/pattern.
         if not candidates:
             raise MetricReaderError(
                 ErrorCode.NO_MATCH,
@@ -302,7 +302,7 @@ async def metrics_from_job_logs(
 
         # Coerce each matched value to a Numeric_Value; a value that cannot be
         # parsed surfaces as ``non_numeric_value`` with the offending raw value
-        # (R5.9).
+        # .
         numeric = [logs.coerce_scalar(candidate) for candidate in candidates]
         value = aggregate.reduce_sequence(numeric, aggregation)
 
@@ -336,8 +336,8 @@ def _read_shared_storage(path: str, region: str, max_bytes: int) -> bytes:
     Reuses ``gco files download`` (the existing read-only storage path) to fetch
     the artifact into a short-lived temporary file, then checks its size before
     its full content is read into memory: an artifact larger than ``max_bytes``
-    raises ``FILE_TOO_LARGE`` and **no** content is returned (R6.8, R6.9). A
-    missing or unreadable artifact raises ``FILE_NOT_FOUND`` (R6.4). The reader
+    raises ``FILE_TOO_LARGE`` and **no** content is returned. A
+    missing or unreadable artifact raises ``FILE_NOT_FOUND``. The reader
     never writes to, moves, or deletes the source artifact.
     """
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -409,7 +409,7 @@ async def metrics_from_shared_storage_file(
     ``format_dependency_unavailable``) on failure.
     """
     try:
-        # Reject an unsupported format up front (R6.2, R6.10).
+        # Reject an unsupported format up front.
         if format not in files._HANDLERS:
             raise MetricReaderError(
                 ErrorCode.UNSUPPORTED_FORMAT,
@@ -445,7 +445,7 @@ async def metrics_from_shared_storage_file(
     except MetricReaderError as err:
         return error_envelope(err.code, **(err.details or {}))
     except Exception as exc:  # noqa: BLE001 - no exception may escape the tool boundary
-        # Catch-all for the file reader maps to the unreadable class (R6.4).
+        # Catch-all for the file reader maps to the unreadable class.
         return error_envelope(
             ErrorCode.FILE_NOT_FOUND,
             path=path,
@@ -461,23 +461,23 @@ async def metrics_from_shared_storage_file(
 # MCP host's *local* filesystem, a real security concern even for a read-only
 # tool, so its decorator is wrapped in ``if is_enabled("GCO_ENABLE_LOCAL_METRICS")``
 # (mirroring the module-body gate in ``mcp/tools/mission.py``). With the flag
-# unset the decorator never fires and FastMCP never sees the tool (R18.1). The
+# unset the decorator never fires and FastMCP never sees the tool. The
 # gate is evaluated **only** through ``feature_flags.is_enabled`` — never by
-# reading ``os.environ`` for the flag decision (R18.2) — and inherits the
-# umbrella ``GCO_ENABLE_ALL_TOOLS`` override (R18.3).
+# reading ``os.environ`` for the flag decision — and inherits the
+# umbrella ``GCO_ENABLE_ALL_TOOLS`` override.
 
 
 def _read_local_file(resolved_path: Path, path: str, max_bytes: int) -> bytes:
-    """Read a confined local artifact, enforcing the same size cap (R18.13).
+    """Read a confined local artifact, enforcing the same size cap.
 
     ``resolved_path`` is the Local_Root-confined path produced by
     :func:`localfs.resolve_within_root`; ``path`` is the caller-supplied path,
     carried through only for error provenance. The artifact's size is checked
     via ``stat`` **before** its full content is read into memory: an artifact
     larger than ``max_bytes`` raises ``FILE_TOO_LARGE`` and **no** content is
-    returned (R18.13). A missing or unreadable artifact raises
-    ``FILE_NOT_FOUND`` (R18.15). The reader only reads — it never writes to,
-    moves, or deletes the artifact (R18.5).
+    returned. A missing or unreadable artifact raises
+    ``FILE_NOT_FOUND``. The reader only reads — it never writes to,
+    moves, or deletes the artifact.
     """
     if not resolved_path.is_file():
         raise MetricReaderError(ErrorCode.FILE_NOT_FOUND, {"path": path})
@@ -540,14 +540,14 @@ if is_enabled("GCO_ENABLE_LOCAL_METRICS"):
         ``empty_sequence``, ``format_dependency_unavailable``) on failure.
         """
         try:
-            # Reject an unsupported format up front (R18.11).
+            # Reject an unsupported format up front.
             if format not in files._HANDLERS:
                 raise MetricReaderError(
                     ErrorCode.UNSUPPORTED_FORMAT,
                     {"format": format, "supported": sorted(files._HANDLERS)},
                 )
 
-            # Fail fast on an unknown aggregation mode before any read (R18.12).
+            # Fail fast on an unknown aggregation mode before any read.
             if aggregation not in aggregate.VALID_MODES:
                 raise MetricReaderError(
                     ErrorCode.INVALID_AGGREGATION_MODE,
@@ -561,7 +561,7 @@ if is_enabled("GCO_ENABLE_LOCAL_METRICS"):
             # unset/empty root raises LOCAL_ROOT_NOT_CONFIGURED, a ``..`` escape
             # raises PATH_TRAVERSAL_ESCAPE, and a symlink escape raises
             # SYMLINK_ESCAPE — in every escape case no file is read and the
-            # canonical shape is never returned (R18.6, R18.8, R18.9, R18.10).
+            # canonical shape is never returned.
             root = os.environ.get("GCO_METRICS_LOCAL_ROOT", "")
             resolved_path = localfs.resolve_within_root(path, root)
 
@@ -571,7 +571,7 @@ if is_enabled("GCO_ENABLE_LOCAL_METRICS"):
 
             # Dispatch to the SAME per-format handler the shared-storage reader
             # uses. Handlers raise MALFORMED_FILE / FIELD_NOT_FOUND /
-            # numeric-guard / dependency codes (R18.15).
+            # numeric-guard / dependency codes.
             handler = files._HANDLERS[format]
             value = handler(content, field, aggregation)
 
@@ -586,7 +586,7 @@ if is_enabled("GCO_ENABLE_LOCAL_METRICS"):
             return error_envelope(err.code, **(err.details or {}))
         except Exception as exc:  # noqa: BLE001 - no exception may escape the tool boundary
             # Catch-all for the local-file reader maps to the unreadable class
-            # (R18.15) so the criterion is left inconclusive rather than crashing
+            # so the criterion is left inconclusive rather than crashing
             # the loop.
             return error_envelope(
                 ErrorCode.FILE_NOT_FOUND,

--- a/mcp/tools/metrics.py
+++ b/mcp/tools/metrics.py
@@ -1,0 +1,595 @@
+"""Read-only metric-reader MCP tools.
+
+These tools surface a single training-style scalar (loss, accuracy, throughput,
+GPU utilisation, …) in the canonical ``{"metrics": {"<key>": <number>}}`` shape
+the Mission Observe_Phase already merges, so a ``metric_threshold`` criterion can
+observe progress with zero scripting.
+
+Three readers are registered **default-on** here:
+
+* :func:`metrics_cloudwatch_get` — one CloudWatch ``GetMetricStatistics``
+  datapoint, region-scoped.
+* :func:`metrics_from_job_logs` — a scalar pulled from the tail of a job's logs
+  by JSON key or regex, reusing the existing read-only job-log retrieval path.
+* :func:`metrics_from_shared_storage_file` — a named field read from a small
+  metrics file on shared storage, reusing the existing read-only ``gco files``
+  path and dispatching on a ``format`` parameter.
+
+Every tool returns a plain ``dict`` (so FastMCP passes the top-level ``metrics``
+key through verbatim as ``structured_content``) and **never raises**: each wraps
+its body in a ``try/except MetricReaderError`` that renders a structured error
+envelope, plus a final ``except Exception`` that maps any unexpected
+library/API failure to the reader's stable catch-all code. A failed read
+therefore merges as ``inconclusive`` and the Mission loop keeps running.
+
+All three are strictly read-only against *remote* AWS / storage / job-log
+surfaces. A fourth reader, :func:`metrics_from_local_file`, surfaces a field
+from a *local-filesystem* metrics file confined to an allowlisted root; because
+reading the local filesystem is a real security concern even for a read-only
+tool, it is **flag-gated, default-off** behind ``GCO_ENABLE_LOCAL_METRICS`` and
+its decorator only fires when that flag (or the umbrella ``GCO_ENABLE_ALL_TOOLS``)
+is enabled.
+"""
+
+import asyncio
+import json
+import os
+import re
+import sys
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import cli_runner
+from audit import audit_logged
+from feature_flags import is_enabled
+from server import mcp
+
+# The pure ``metric_readers`` package lives under ``mcp/`` alongside this
+# ``tools`` package. ``mcp/run_mcp.py`` puts ``mcp/`` on ``sys.path`` at
+# runtime; mirror the mission.py path-injection convention so ``import
+# metric_readers`` resolves the same way regardless of entrypoint.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from metric_readers import aggregate, cloudwatch, files, localfs, logs  # noqa: E402
+from metric_readers.shape import (  # noqa: E402
+    ErrorCode,
+    MetricReaderError,
+    default_metric_key,
+    error_envelope,
+    metrics_result,
+    validate_metric_name,
+)
+
+# Job-log tail bounds (R5.10): a caller-supplied or default tail size is clamped
+# into this inclusive range before any log volume is retrieved.
+_TAIL_MIN = 1
+_TAIL_MAX = 10_000
+_TAIL_DEFAULT = 1000
+
+# File-reader default size cap (R6.8): 10 MiB. The artifact's size is checked
+# before its full content is read into memory.
+_MAX_BYTES_DEFAULT = 10_485_760
+
+
+def _resolve_key(output_name: str | None, source_hint: str) -> str:
+    """Return a validated metric key from an explicit name or a source hint.
+
+    When ``output_name`` is supplied it must satisfy the single-Dot_Path-segment
+    naming constraint (R1.3, R1.7); otherwise a deterministic, well-formed key
+    is derived from ``source_hint`` (R1.4).
+    """
+    if output_name:
+        return validate_metric_name(output_name)
+    return default_metric_key(source_hint)
+
+
+# =============================================================================
+# CloudWatch reader (default-on)
+# =============================================================================
+
+
+@mcp.tool(tags={"safe", "metrics"})
+@audit_logged
+async def metrics_cloudwatch_get(
+    metric_name: str,
+    namespace: str,
+    region: str,
+    dimensions: dict[str, str] | None = None,
+    statistic: str = "Average",
+    period: int = 300,
+    minutes_back: int = 60,
+    start_time: str | None = None,
+    end_time: str | None = None,
+    output_name: str | None = None,
+) -> dict[str, Any]:
+    """[read-only] Read one CloudWatch datapoint as a canonical metric.
+
+    Issues a single region-scoped, read-only ``GetMetricStatistics`` request and
+    returns the most-recent datapoint's statistic value in the canonical
+    ``{"metrics": {...}}`` shape consumable by a ``metric_threshold`` criterion.
+    The metric key defaults to the CloudWatch metric name when ``output_name``
+    is omitted.
+
+    Args:
+        metric_name: The CloudWatch metric name.
+        namespace: The CloudWatch namespace the metric lives in.
+        region: AWS region to scope the read to (supports Multi_Region).
+        dimensions: Name/value dimension pairs passed through unchanged.
+        statistic: The statistic to request (Average, Sum, Maximum, Minimum,
+            SampleCount).
+        period: Aggregation period in seconds (default 300).
+        minutes_back: Lookback window in minutes when start/end are not given.
+        start_time: ISO-8601 window start (used with ``end_time``).
+        end_time: ISO-8601 window end (used with ``start_time``).
+        output_name: Explicit metric key; defaults to ``metric_name``.
+
+    Returns the Canonical_Metrics_Shape on success, or a Tool_Error_Envelope
+    (``metric_name_invalid``, ``no_datapoints``, ``aws_unreachable``) on failure.
+    """
+    try:
+        key = _resolve_key(output_name, metric_name)
+
+        if start_time is not None and end_time is not None:
+            start_dt = datetime.fromisoformat(start_time)
+            end_dt = datetime.fromisoformat(end_time)
+        else:
+            end_dt = datetime.now(UTC)
+            start_dt = end_dt - timedelta(minutes=minutes_back)
+
+        # The boto3 call blocks, so run it off the event loop.
+        value, iso_timestamp = await asyncio.to_thread(
+            cloudwatch.get_datapoint,
+            metric_name=metric_name,
+            namespace=namespace,
+            dimensions=dimensions,
+            region=region,
+            period=period,
+            statistic=statistic,
+            start_time=start_dt,
+            end_time=end_dt,
+        )
+
+        return metrics_result(
+            key,
+            value,
+            source=f"cloudwatch:{namespace}/{metric_name}",
+            region=region,
+            statistic=statistic,
+            datapoint_timestamp=iso_timestamp,
+        )
+    except MetricReaderError as err:
+        return error_envelope(err.code, **(err.details or {}))
+    except Exception as exc:  # noqa: BLE001 - no exception may escape the tool boundary
+        # Catch-all for the CloudWatch reader maps to the unreachable class so
+        # the criterion is left inconclusive rather than crashing the loop.
+        return error_envelope(
+            ErrorCode.AWS_UNREACHABLE,
+            kind="client_error",
+            region=region,
+            message=str(exc),
+        )
+
+
+# =============================================================================
+# Job-log reader (default-on)
+# =============================================================================
+
+
+@mcp.tool(tags={"safe", "metrics"})
+@audit_logged
+async def metrics_from_job_logs(
+    job_name: str,
+    region: str,
+    namespace: str = "gco-jobs",
+    json_key: str | None = None,
+    regex: str | None = None,
+    aggregation: str = "last",
+    tail: int = _TAIL_DEFAULT,
+    output_name: str | None = None,
+) -> dict[str, Any]:
+    """[read-only] Extract a scalar from the tail of a job's logs.
+
+    Tails a job's logs through the existing read-only retrieval path and pulls a
+    candidate scalar from each line by **either** a JSON key (resolved as a
+    dot-path) **or** a regex (first capture group) — exactly one must be set.
+    The matched values are coerced to numbers and reduced to one Numeric_Value
+    via the aggregation mode (default ``last`` = most recent match). Returns the
+    canonical ``{"metrics": {...}}`` shape. The metric key defaults to the last
+    segment of ``json_key`` (or ``value`` in regex mode) when ``output_name`` is
+    omitted.
+
+    Args:
+        job_name: Name of the job whose logs to read.
+        region: AWS region where the job ran.
+        namespace: Kubernetes namespace (default ``gco-jobs``).
+        json_key: JSON dot-path key to resolve per line (mutually exclusive
+            with ``regex``).
+        regex: Regex whose first capture group is the scalar (mutually
+            exclusive with ``json_key``).
+        aggregation: One of last, first, min, max, mean (default ``last``).
+        tail: Number of log lines to read; clamped to [1, 10000] (default 1000).
+        output_name: Explicit metric key.
+
+    Returns the Canonical_Metrics_Shape on success, or a Tool_Error_Envelope
+    (``invalid_extraction_mode``, ``invalid_regex``, ``invalid_aggregation_mode``,
+    ``log_retrieval_failed``, ``no_match``, ``non_numeric_value``) on failure.
+    """
+    try:
+        has_key = bool(json_key)
+        has_regex = bool(regex)
+        # Exactly one extraction mode (R5.4).
+        if has_key == has_regex:
+            raise MetricReaderError(
+                ErrorCode.INVALID_EXTRACTION_MODE,
+                {"json_key": json_key, "regex": regex},
+            )
+
+        # Fail fast on an unknown aggregation mode before any log retrieval.
+        if aggregation not in aggregate.VALID_MODES:
+            raise MetricReaderError(
+                ErrorCode.INVALID_AGGREGATION_MODE,
+                {"mode": aggregation, "valid_modes": sorted(aggregate.VALID_MODES)},
+            )
+
+        pattern: re.Pattern[str] | None = None
+        if has_regex:
+            # Compile and reject uncompilable or zero-capture-group patterns
+            # (R5.11).
+            try:
+                pattern = re.compile(regex)  # type: ignore[arg-type]
+            except re.error as exc:
+                raise MetricReaderError(
+                    ErrorCode.INVALID_REGEX,
+                    {"regex": regex, "reason": str(exc)},
+                ) from exc
+            if pattern.groups < 1:
+                raise MetricReaderError(
+                    ErrorCode.INVALID_REGEX,
+                    {"regex": regex, "reason": "no capture group"},
+                )
+
+        # Resolve the metric key (R1.3, R1.4, R1.7).
+        if has_key:
+            key = _resolve_key(output_name, json_key.rsplit(".", 1)[-1])  # type: ignore[union-attr]
+        else:
+            key = _resolve_key(output_name, "value")
+
+        # Clamp the tail size into [1, 10_000] (R5.10).
+        clamped = max(_TAIL_MIN, min(int(tail), _TAIL_MAX))
+
+        raw = await asyncio.to_thread(
+            cli_runner._run_cli,
+            "jobs",
+            "logs",
+            job_name,
+            "-r",
+            region,
+            "-n",
+            namespace,
+            "--tail",
+            str(clamped),
+        )
+
+        # Translate an ``{"error": ...}`` CLI payload into a retrieval failure
+        # (R5.12). Plain log text is not JSON and is used as-is.
+        try:
+            payload = json.loads(raw)
+        except ValueError:
+            payload = None
+        if isinstance(payload, dict) and "error" in payload:
+            message = str(payload["error"])
+            kind = "unknown_job" if "not found" in message.lower() else "unreachable"
+            raise MetricReaderError(
+                ErrorCode.LOG_RETRIEVAL_FAILED,
+                {"kind": kind, "job_name": job_name, "message": message},
+            )
+
+        lines = raw.splitlines()
+
+        if pattern is not None:
+            candidates: list[object] = list(logs.extract_by_regex(lines, pattern))
+        else:
+            candidates = logs.extract_by_json_key(lines, json_key)  # type: ignore[arg-type]
+
+        # No line matched the key/pattern (R5.8).
+        if not candidates:
+            raise MetricReaderError(
+                ErrorCode.NO_MATCH,
+                {"job_name": job_name, "mode": "json_key" if has_key else "regex"},
+            )
+
+        # Coerce each matched value to a Numeric_Value; a value that cannot be
+        # parsed surfaces as ``non_numeric_value`` with the offending raw value
+        # (R5.9).
+        numeric = [logs.coerce_scalar(candidate) for candidate in candidates]
+        value = aggregate.reduce_sequence(numeric, aggregation)
+
+        return metrics_result(
+            key,
+            value,
+            source=f"job_logs:{job_name}",
+            region=region,
+            aggregation=aggregation,
+            match_count=len(candidates),
+        )
+    except MetricReaderError as err:
+        return error_envelope(err.code, **(err.details or {}))
+    except Exception as exc:  # noqa: BLE001 - no exception may escape the tool boundary
+        return error_envelope(
+            ErrorCode.LOG_RETRIEVAL_FAILED,
+            kind="unreachable",
+            job_name=job_name,
+            message=str(exc),
+        )
+
+
+# =============================================================================
+# Shared-storage file reader (default-on)
+# =============================================================================
+
+
+def _read_shared_storage(path: str, region: str, max_bytes: int) -> bytes:
+    """Read a shared-storage artifact through the read-only ``gco files`` path.
+
+    Reuses ``gco files download`` (the existing read-only storage path) to fetch
+    the artifact into a short-lived temporary file, then checks its size before
+    its full content is read into memory: an artifact larger than ``max_bytes``
+    raises ``FILE_TOO_LARGE`` and **no** content is returned (R6.8, R6.9). A
+    missing or unreadable artifact raises ``FILE_NOT_FOUND`` (R6.4). The reader
+    never writes to, moves, or deletes the source artifact.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        local_path = os.path.join(tmp_dir, "artifact")
+        raw = cli_runner._run_cli("files", "download", path, local_path, "-r", region)
+
+        # An explicit CLI error payload means the artifact could not be read.
+        try:
+            payload = json.loads(raw)
+        except ValueError:
+            payload = None
+        if isinstance(payload, dict) and "error" in payload:
+            raise MetricReaderError(
+                ErrorCode.FILE_NOT_FOUND,
+                {"path": path, "message": str(payload["error"])},
+            )
+
+        if not os.path.isfile(local_path):
+            raise MetricReaderError(ErrorCode.FILE_NOT_FOUND, {"path": path})
+
+        # Size check before the full content is read into memory.
+        size = os.path.getsize(local_path)
+        if size > max_bytes:
+            raise MetricReaderError(
+                ErrorCode.FILE_TOO_LARGE,
+                {"path": path, "size": size, "max_bytes": max_bytes},
+            )
+
+        with open(local_path, "rb") as handle:
+            return handle.read()
+
+
+@mcp.tool(tags={"safe", "metrics"})
+@audit_logged
+async def metrics_from_shared_storage_file(
+    path: str,
+    region: str,
+    field: str,
+    format: str,
+    aggregation: str = "last",
+    max_bytes: int = _MAX_BYTES_DEFAULT,
+    output_name: str | None = None,
+) -> dict[str, Any]:
+    """[read-only] Read a named field from a shared-storage metrics file.
+
+    Reads a small metrics file from shared storage (EFS / the cluster shared
+    bucket) through the existing read-only ``gco files`` path and surfaces a
+    named field as a metric in the canonical ``{"metrics": {...}}`` shape,
+    dispatching on ``format``. Sequence-bearing formats (a list, a CSV column, a
+    Hugging Face ``log_history``, a JSONL stream, a Parquet column) are reduced
+    to one Numeric_Value via the aggregation mode. The metric key defaults to
+    ``field`` when ``output_name`` is omitted.
+
+    Args:
+        path: Shared-storage path to the metrics file.
+        region: AWS region of the storage.
+        field: Field/column/key name to read (dot-path for document formats).
+        format: One of json, csv, hf_trainer_state, jsonl, yaml, parquet,
+            tfevents.
+        aggregation: One of last, first, min, max, mean (default ``last``).
+        max_bytes: Maximum artifact size in bytes (default 10 MiB); the size is
+            checked before the content is read.
+        output_name: Explicit metric key; defaults to ``field``.
+
+    Returns the Canonical_Metrics_Shape on success, or a Tool_Error_Envelope
+    (``unsupported_format``, ``metric_name_invalid``, ``file_not_found``,
+    ``file_too_large``, ``malformed_file``, ``field_not_found``,
+    ``non_numeric_value``, ``no_numeric_value``, ``empty_sequence``,
+    ``format_dependency_unavailable``) on failure.
+    """
+    try:
+        # Reject an unsupported format up front (R6.2, R6.10).
+        if format not in files._HANDLERS:
+            raise MetricReaderError(
+                ErrorCode.UNSUPPORTED_FORMAT,
+                {"format": format, "supported": sorted(files._HANDLERS)},
+            )
+
+        # Fail fast on an unknown aggregation mode before any storage read.
+        if aggregation not in aggregate.VALID_MODES:
+            raise MetricReaderError(
+                ErrorCode.INVALID_AGGREGATION_MODE,
+                {"mode": aggregation, "valid_modes": sorted(aggregate.VALID_MODES)},
+            )
+
+        key = _resolve_key(output_name, field)
+
+        # Stat-and-read through the read-only storage path (blocking, so off the
+        # event loop). Raises FILE_NOT_FOUND / FILE_TOO_LARGE as appropriate.
+        content = await asyncio.to_thread(_read_shared_storage, path, region, max_bytes)
+
+        # Dispatch to the shared per-format handler. Handlers raise
+        # MALFORMED_FILE / FIELD_NOT_FOUND / numeric-guard / dependency codes.
+        handler = files._HANDLERS[format]
+        value = handler(content, field, aggregation)
+
+        return metrics_result(
+            key,
+            value,
+            source=f"file:{path}",
+            region=region,
+            format=format,
+            aggregation=aggregation,
+        )
+    except MetricReaderError as err:
+        return error_envelope(err.code, **(err.details or {}))
+    except Exception as exc:  # noqa: BLE001 - no exception may escape the tool boundary
+        # Catch-all for the file reader maps to the unreadable class (R6.4).
+        return error_envelope(
+            ErrorCode.FILE_NOT_FOUND,
+            path=path,
+            message=str(exc),
+        )
+
+
+# =============================================================================
+# Local-filesystem file reader (flag-gated, default-off)
+# =============================================================================
+#
+# This reader is the deliberate exception to the default-on rule: it reads the
+# MCP host's *local* filesystem, a real security concern even for a read-only
+# tool, so its decorator is wrapped in ``if is_enabled("GCO_ENABLE_LOCAL_METRICS")``
+# (mirroring the module-body gate in ``mcp/tools/mission.py``). With the flag
+# unset the decorator never fires and FastMCP never sees the tool (R18.1). The
+# gate is evaluated **only** through ``feature_flags.is_enabled`` — never by
+# reading ``os.environ`` for the flag decision (R18.2) — and inherits the
+# umbrella ``GCO_ENABLE_ALL_TOOLS`` override (R18.3).
+
+
+def _read_local_file(resolved_path: Path, path: str, max_bytes: int) -> bytes:
+    """Read a confined local artifact, enforcing the same size cap (R18.13).
+
+    ``resolved_path`` is the Local_Root-confined path produced by
+    :func:`localfs.resolve_within_root`; ``path`` is the caller-supplied path,
+    carried through only for error provenance. The artifact's size is checked
+    via ``stat`` **before** its full content is read into memory: an artifact
+    larger than ``max_bytes`` raises ``FILE_TOO_LARGE`` and **no** content is
+    returned (R18.13). A missing or unreadable artifact raises
+    ``FILE_NOT_FOUND`` (R18.15). The reader only reads — it never writes to,
+    moves, or deletes the artifact (R18.5).
+    """
+    if not resolved_path.is_file():
+        raise MetricReaderError(ErrorCode.FILE_NOT_FOUND, {"path": path})
+
+    # Size check before the full content is read into memory.
+    size = resolved_path.stat().st_size
+    if size > max_bytes:
+        raise MetricReaderError(
+            ErrorCode.FILE_TOO_LARGE,
+            {"path": path, "size": size, "max_bytes": max_bytes},
+        )
+
+    with open(resolved_path, "rb") as handle:
+        return handle.read()
+
+
+if is_enabled("GCO_ENABLE_LOCAL_METRICS"):
+
+    @mcp.tool(tags={"safe", "metrics"})
+    @audit_logged
+    async def metrics_from_local_file(
+        path: str,
+        field: str,
+        format: str,
+        aggregation: str = "last",
+        max_bytes: int = _MAX_BYTES_DEFAULT,
+        output_name: str | None = None,
+    ) -> dict[str, Any]:
+        """[gated by GCO_ENABLE_LOCAL_METRICS] [read-only] Read a named field from a LOCAL metrics file.
+
+        Reads a small metrics file from a LOCAL filesystem path confined to the
+        allowlisted root ``GCO_METRICS_LOCAL_ROOT`` and surfaces a named field
+        as a metric in the canonical ``{"metrics": {...}}`` shape, dispatching
+        on ``format``. Reuses the same format handlers, aggregation modes, size
+        cap, and error model as ``metrics_from_shared_storage_file`` — the only
+        difference is that the path is resolved and confined to the allowlisted
+        root via realpath containment instead of going through the shared-storage
+        path. There is **no** ``region`` parameter: local reads are not
+        region-scoped. Sequence-bearing formats (a list, a CSV column, a Hugging
+        Face ``log_history``, a JSONL stream, a Parquet column) are reduced to one
+        Numeric_Value via the aggregation mode. The metric key defaults to
+        ``field`` when ``output_name`` is omitted.
+
+        Args:
+            path: Local filesystem path to the metrics file (confined to
+                ``GCO_METRICS_LOCAL_ROOT``).
+            field: Field/column/key name to read (dot-path for document formats).
+            format: One of json, csv, hf_trainer_state, jsonl, yaml, parquet,
+                tfevents.
+            aggregation: One of last, first, min, max, mean (default ``last``).
+            max_bytes: Maximum artifact size in bytes (default 10 MiB); the size
+                is checked before the content is read.
+            output_name: Explicit metric key; defaults to ``field``.
+
+        Returns the Canonical_Metrics_Shape on success, or a Tool_Error_Envelope
+        (``local_root_not_configured``, ``path_traversal_escape``,
+        ``symlink_escape``, ``unsupported_format``, ``metric_name_invalid``,
+        ``file_not_found``, ``file_too_large``, ``malformed_file``,
+        ``field_not_found``, ``non_numeric_value``, ``no_numeric_value``,
+        ``empty_sequence``, ``format_dependency_unavailable``) on failure.
+        """
+        try:
+            # Reject an unsupported format up front (R18.11).
+            if format not in files._HANDLERS:
+                raise MetricReaderError(
+                    ErrorCode.UNSUPPORTED_FORMAT,
+                    {"format": format, "supported": sorted(files._HANDLERS)},
+                )
+
+            # Fail fast on an unknown aggregation mode before any read (R18.12).
+            if aggregation not in aggregate.VALID_MODES:
+                raise MetricReaderError(
+                    ErrorCode.INVALID_AGGREGATION_MODE,
+                    {"mode": aggregation, "valid_modes": sorted(aggregate.VALID_MODES)},
+                )
+
+            key = _resolve_key(output_name, field)
+
+            # Read the Local_Root once at the tool boundary and hand it to the
+            # pure confinement helper. The helper never touches os.environ; an
+            # unset/empty root raises LOCAL_ROOT_NOT_CONFIGURED, a ``..`` escape
+            # raises PATH_TRAVERSAL_ESCAPE, and a symlink escape raises
+            # SYMLINK_ESCAPE — in every escape case no file is read and the
+            # canonical shape is never returned (R18.6, R18.8, R18.9, R18.10).
+            root = os.environ.get("GCO_METRICS_LOCAL_ROOT", "")
+            resolved_path = localfs.resolve_within_root(path, root)
+
+            # Stat-and-read the confined local path (blocking, so off the event
+            # loop). Raises FILE_NOT_FOUND / FILE_TOO_LARGE as appropriate.
+            content = await asyncio.to_thread(_read_local_file, resolved_path, path, max_bytes)
+
+            # Dispatch to the SAME per-format handler the shared-storage reader
+            # uses. Handlers raise MALFORMED_FILE / FIELD_NOT_FOUND /
+            # numeric-guard / dependency codes (R18.15).
+            handler = files._HANDLERS[format]
+            value = handler(content, field, aggregation)
+
+            return metrics_result(
+                key,
+                value,
+                source=f"local_file:{path}",
+                format=format,
+                aggregation=aggregation,
+            )
+        except MetricReaderError as err:
+            return error_envelope(err.code, **(err.details or {}))
+        except Exception as exc:  # noqa: BLE001 - no exception may escape the tool boundary
+            # Catch-all for the local-file reader maps to the unreadable class
+            # (R18.15) so the criterion is left inconclusive rather than crashing
+            # the loop.
+            return error_envelope(
+                ErrorCode.FILE_NOT_FOUND,
+                path=path,
+                message=str(exc),
+            )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -141,13 +141,16 @@ class TestToolRegistration:
 
     def test_tool_count(self):
         tools = asyncio.run(run_mcp.mcp._list_tools())
-        # 92 base tools after delete_job and delete_inference moved under
-        # GCO_ENABLE_DESTRUCTIVE_OPERATIONS. The breakdown:
+        # 95 base tools after delete_job and delete_inference moved under
+        # GCO_ENABLE_DESTRUCTIVE_OPERATIONS and the three default-on metric
+        # readers were added. The breakdown:
         #   * the original 81 (read-only + low-risk + discovery) minus 2
         #     (delete_job + delete_inference) = 79
         #   * 11 unconditional image-registry tools (read-only + administrative)
         #   * 2 unconditional task observability tools (task_status, task_tail)
-        # = 92 total at default registration.
+        #   * 3 unconditional, default-on metric readers (metrics_cloudwatch_get,
+        #     metrics_from_job_logs, metrics_from_shared_storage_file)
+        # = 95 total at default registration.
         # reserve_capacity adds 1 when GCO_ENABLE_CAPACITY_PURCHASE=true.
         # Image-publish-gated tools (images_build, images_push) add 2 when
         # GCO_ENABLE_IMAGE_PUBLISH=true. Destructive-gated tools add 12 when
@@ -161,7 +164,10 @@ class TestToolRegistration:
         # bootstrap_cdk) add 3 when GCO_ENABLE_INFRASTRUCTURE_DEPLOY=true.
         # Infrastructure-destroy gated tools (destroy_stack, destroy_all)
         # add 2 when GCO_ENABLE_INFRASTRUCTURE_DESTROY=true.
-        base_count = 92
+        # The local-file metric reader (metrics_from_local_file) adds 1 when
+        # GCO_ENABLE_LOCAL_METRICS=true. With every flag enabled the ceiling is
+        # 95 + 1 + 2 + 12 + 1 + 3 + 2 + 1 = 117.
+        base_count = 95
         tool_names = [t.name for t in tools]
         expected = base_count
         if "reserve_capacity" in tool_names:
@@ -178,6 +184,8 @@ class TestToolRegistration:
             expected += 3  # deploy_stack + deploy_all + bootstrap_cdk
         if "destroy_stack" in tool_names:
             expected += 2  # destroy_stack + destroy_all
+        if "metrics_from_local_file" in tool_names:
+            expected += 1  # gated by GCO_ENABLE_LOCAL_METRICS
         assert len(tools) == expected
 
     def test_all_tool_names(self):
@@ -238,6 +246,10 @@ class TestToolRegistration:
             # ── Model weights (all read-only) ──
             "list_models",
             "get_model_uri",
+            # ── Metrics (read-only, default-on) ──
+            "metrics_cloudwatch_get",
+            "metrics_from_job_logs",
+            "metrics_from_shared_storage_file",
             #
             # Async tools (all read-only, "safe" risk tier)
             #
@@ -363,6 +375,9 @@ class TestToolRegistration:
         # GCO_ENABLE_INFRASTRUCTURE_DESTROY.
         if "destroy_stack" in names:
             expected.update({"destroy_stack", "destroy_all"})
+        # Local-file metric reader registers under GCO_ENABLE_LOCAL_METRICS.
+        if "metrics_from_local_file" in names:
+            expected.add("metrics_from_local_file")
         assert names == expected
 
     def test_each_tool_has_description(self):

--- a/tests/test_metric_readers_aggregate.py
+++ b/tests/test_metric_readers_aggregate.py
@@ -139,7 +139,7 @@ def test_reduce_sequence_matches_reference_over_numbers_only(
 
 
 # ===========================================================================
-# Property 5: the reducer's three "nothing to reduce" failures
+# The reducer's three "nothing to reduce" failures
 # ===========================================================================
 #
 # The reducer rejects three distinct degenerate inputs, and it does so in a
@@ -149,9 +149,9 @@ def test_reduce_sequence_matches_reference_over_numbers_only(
 # numbers is refused *after* filtering. Each failure carries its own stable
 # code, and the codes are distinct so a caller can tell the three apart:
 #
-#   * unknown mode                -> INVALID_AGGREGATION_MODE   (R7.8)
-#   * empty sequence              -> EMPTY_SEQUENCE             (R7.12)
-#   * non-empty, all non-numeric  -> NO_NUMERIC_VALUE           (R7.11)
+#   * unknown mode                -> INVALID_AGGREGATION_MODE
+#   * empty sequence              -> EMPTY_SEQUENCE
+#   * non-empty, all non-numeric  -> NO_NUMERIC_VALUE
 #
 # The properties below generate inputs in each category (and combinations
 # that exercise the precedence) and assert exactly one code is raised, never
@@ -187,7 +187,6 @@ def _assert_raises_code(values: Sequence[object], mode: str, code: str) -> None:
     )
 
 
-# Feature: mission-metric-reader-tools, Property 5: Reducer empty-vs-all-non-numeric-vs-invalid-mode split
 @settings(
     max_examples=200,
     deadline=None,
@@ -199,12 +198,11 @@ def test_unknown_mode_is_rejected_before_anything_else(values: list[object], mod
 
     The mode is validated first, so the verdict does not depend on the
     sequence: an unknown mode wins over an empty sequence and over an
-    all-non-numeric sequence alike (R7.8, by reducer precedence).
+    all-non-numeric sequence alike (by reducer precedence).
     """
     _assert_raises_code(values, mode, ErrorCode.INVALID_AGGREGATION_MODE)
 
 
-# Feature: mission-metric-reader-tools, Property 5: Reducer empty-vs-all-non-numeric-vs-invalid-mode split
 @settings(
     max_examples=200,
     deadline=None,
@@ -216,12 +214,11 @@ def test_empty_sequence_under_a_valid_mode_yields_empty_sequence(mode: str) -> N
 
     With a recognized mode the next gate is the empty check, which fires
     before numeric filtering, so an empty input is reported as an empty
-    sequence rather than as "no numeric value" (R7.12).
+    sequence rather than as "no numeric value".
     """
     _assert_raises_code([], mode, ErrorCode.EMPTY_SEQUENCE)
 
 
-# Feature: mission-metric-reader-tools, Property 5: Reducer empty-vs-all-non-numeric-vs-invalid-mode split
 @settings(
     max_examples=200,
     deadline=None,
@@ -235,14 +232,13 @@ def test_all_non_numeric_under_a_valid_mode_yields_no_numeric_value(
 
     The sequence has entries (so it is not empty) but none survive the
     numeric guard, so the reducer reports the distinct "had data, none of it
-    numeric" code rather than the empty-sequence code (R7.11).
+    numeric" code rather than the empty-sequence code.
     """
     # Guard the generator's intent: every entry really is non-numeric.
     assert all(not is_numeric_value(v) for v in values)
     _assert_raises_code(values, mode, ErrorCode.NO_NUMERIC_VALUE)
 
 
-# Feature: mission-metric-reader-tools, Property 5: Reducer empty-vs-all-non-numeric-vs-invalid-mode split
 @settings(
     max_examples=200,
     deadline=None,
@@ -257,8 +253,7 @@ def test_three_failures_are_mutually_exclusive_with_distinct_codes(
     A single draw picks one of the three failure categories, builds a
     matching ``(values, mode)`` input, and asserts the reducer raises exactly
     the code that category owns. Across categories the three codes are
-    pairwise distinct, so the outcomes cannot be confused (R7.8, R7.11,
-    R7.12).
+    pairwise distinct, so the outcomes cannot be confused.
     """
     # The three codes are distinct constants — the contract that makes the
     # outcomes distinguishable in the first place.

--- a/tests/test_metric_readers_aggregate.py
+++ b/tests/test_metric_readers_aggregate.py
@@ -1,0 +1,283 @@
+"""Tests for the sequence reducer that collapses history to one number.
+
+Several metric sources carry more than one value: a training run logs a loss
+every step, a CSV column holds one number per row, a log tail matches a
+pattern many times. The reducer turns such a sequence into a single number
+according to a caller-chosen mode (``last``, ``first``, ``min``, ``max``,
+``mean``), and it does so over only the entries that are real, finite numbers
+— booleans, NaN, the infinities, strings, and ``None`` are skipped before any
+reduction happens.
+
+The property test below pins that contract down. It builds sequences that mix
+genuine numbers with a variety of non-numeric junk, then checks that every
+mode produces exactly the number a reference reduction computes over the
+number-only subsequence. Because the junk is dropped first, ``last`` and
+``first`` mean "the most recent / earliest *number*", and ``min``, ``max``,
+and ``mean`` range over the surviving numbers alone.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ``mcp/run_mcp.py`` puts ``mcp/`` on ``sys.path`` at runtime; mirror that
+# here so the pure ``metric_readers`` package imports the same way it does
+# in production, matching the convention used by the sibling tests.
+sys.path.insert(0, str(Path(__file__).parent.parent / "mcp"))
+
+from metric_readers.aggregate import VALID_MODES, reduce_sequence  # noqa: E402
+from metric_readers.shape import (  # noqa: E402
+    ErrorCode,
+    MetricReaderError,
+    is_numeric_value,
+)
+
+# Every mode the reducer accepts. The test exercises all of them on each
+# generated sequence.
+_MODES = ("last", "first", "min", "max", "mean")
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+# Entries that the numeric guard accepts: ints (never bools, since
+# ``st.integers`` does not emit them) and finite floats (never NaN or +/-inf).
+_numeric_entries = st.one_of(
+    st.integers(),
+    st.floats(allow_nan=False, allow_infinity=False),
+)
+
+# Entries that the numeric guard rejects and the reducer must ignore:
+# booleans, NaN, the infinities, strings, and ``None``.
+_non_numeric_entries = st.one_of(
+    st.booleans(),
+    st.just(float("nan")),
+    st.sampled_from([float("inf"), float("-inf")]),
+    st.text(max_size=8),
+    st.none(),
+)
+
+
+@st.composite
+def _mixed_sequences_with_at_least_one_number(draw: st.DrawFn) -> list[object]:
+    """Draw a sequence mixing numbers with non-numeric junk, in random order.
+
+    At least one real number is guaranteed so the reduction always succeeds,
+    and the non-numeric entries are shuffled in among the numbers so their
+    position relative to the numbers is arbitrary.
+    """
+    numbers = draw(st.lists(_numeric_entries, min_size=1, max_size=20))
+    junk = draw(st.lists(_non_numeric_entries, max_size=10))
+    return draw(st.permutations(numbers + junk))
+
+
+# ---------------------------------------------------------------------------
+# Reference reduction
+# ---------------------------------------------------------------------------
+
+
+def _reference_reduce(values: Sequence[object], mode: str) -> float:
+    """Reduce ``values`` the obvious way, over the number-only subsequence.
+
+    Mirrors the reducer's own definition: filter to real, finite numbers
+    using the same guard, preserve their original order, then apply the mode.
+    This is intentionally a straightforward re-derivation so a divergence
+    points at the reducer, not at clever test logic.
+    """
+    numbers = [v for v in values if is_numeric_value(v)]
+    if mode == "last":
+        return numbers[-1]
+    if mode == "first":
+        return numbers[0]
+    if mode == "min":
+        return min(numbers)
+    if mode == "max":
+        return max(numbers)
+    # mode == "mean"
+    return sum(numbers) / len(numbers)
+
+
+# ---------------------------------------------------------------------------
+# Property: every mode reduces over the number-only subsequence
+# ---------------------------------------------------------------------------
+
+
+@settings(
+    max_examples=200,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
+)
+@given(values=_mixed_sequences_with_at_least_one_number())
+def test_reduce_sequence_matches_reference_over_numbers_only(
+    values: list[object],
+) -> None:
+    """Each mode equals a reference reduction over the number-only entries.
+
+    For an arbitrary sequence containing at least one number plus arbitrary
+    non-numeric junk, every mode (``last``, ``first``, ``min``, ``max``,
+    ``mean``) returns exactly what the same reduction yields once the junk is
+    dropped — confirming non-numeric entries are always ignored.
+    """
+    for mode in _MODES:
+        expected = _reference_reduce(values, mode)
+        actual = reduce_sequence(values, mode)
+        # The reducer and the reference perform identical arithmetic in the
+        # same order, so exact equality holds (NaN never survives filtering,
+        # so there is no NaN-inequality pitfall here).
+        assert actual == expected, (
+            f"mode={mode!r} values={values!r} expected={expected!r} actual={actual!r}"
+        )
+        # A reduction over finite numbers stays a real, finite number unless
+        # a sum genuinely overflows; guard against silently passing on a NaN.
+        assert not (isinstance(actual, float) and math.isnan(actual))
+
+
+# ===========================================================================
+# Property 5: the reducer's three "nothing to reduce" failures
+# ===========================================================================
+#
+# The reducer rejects three distinct degenerate inputs, and it does so in a
+# fixed precedence order (see ``reduce_sequence``): an unrecognized mode is
+# refused *before* the sequence is even looked at, an empty sequence is
+# refused *before* numeric filtering, and a sequence that had entries but no
+# numbers is refused *after* filtering. Each failure carries its own stable
+# code, and the codes are distinct so a caller can tell the three apart:
+#
+#   * unknown mode                -> INVALID_AGGREGATION_MODE   (R7.8)
+#   * empty sequence              -> EMPTY_SEQUENCE             (R7.12)
+#   * non-empty, all non-numeric  -> NO_NUMERIC_VALUE           (R7.11)
+#
+# The properties below generate inputs in each category (and combinations
+# that exercise the precedence) and assert exactly one code is raised, never
+# a returned value, confirming the three outcomes are mutually exclusive.
+
+import pytest  # noqa: E402
+
+# Mode strings the reducer must reject: any text that is not one of the five
+# valid modes. Near-misses like "LAST", "median", and "" are all in range.
+_invalid_modes = st.text(max_size=12).filter(lambda s: s not in VALID_MODES)
+
+# Any single entry, numeric or not — used to build arbitrary sequences for
+# the precedence checks.
+_arbitrary_entries = st.one_of(_numeric_entries, _non_numeric_entries)
+
+# Arbitrary sequences of any length, including empty.
+_any_sequences = st.lists(_arbitrary_entries, max_size=15)
+
+# Non-empty sequences whose every entry the numeric guard rejects.
+_nonempty_non_numeric_sequences = st.lists(_non_numeric_entries, min_size=1, max_size=15)
+
+
+def _assert_raises_code(values: Sequence[object], mode: str, code: str) -> None:
+    """Assert ``reduce_sequence`` raises ``MetricReaderError`` with ``code``.
+
+    Also confirms the reducer never produced a value for a degenerate input:
+    ``pytest.raises`` would fail the test if the call returned instead.
+    """
+    with pytest.raises(MetricReaderError) as excinfo:
+        reduce_sequence(values, mode)
+    assert excinfo.value.code == code, (
+        f"values={values!r} mode={mode!r} expected code={code!r} got code={excinfo.value.code!r}"
+    )
+
+
+# Feature: mission-metric-reader-tools, Property 5: Reducer empty-vs-all-non-numeric-vs-invalid-mode split
+@settings(
+    max_examples=200,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
+)
+@given(values=_any_sequences, mode=_invalid_modes)
+def test_unknown_mode_is_rejected_before_anything_else(values: list[object], mode: str) -> None:
+    """An unrecognized mode always yields ``INVALID_AGGREGATION_MODE``.
+
+    The mode is validated first, so the verdict does not depend on the
+    sequence: an unknown mode wins over an empty sequence and over an
+    all-non-numeric sequence alike (R7.8, by reducer precedence).
+    """
+    _assert_raises_code(values, mode, ErrorCode.INVALID_AGGREGATION_MODE)
+
+
+# Feature: mission-metric-reader-tools, Property 5: Reducer empty-vs-all-non-numeric-vs-invalid-mode split
+@settings(
+    max_examples=200,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
+)
+@given(mode=st.sampled_from(_MODES))
+def test_empty_sequence_under_a_valid_mode_yields_empty_sequence(mode: str) -> None:
+    """An empty sequence under any valid mode yields ``EMPTY_SEQUENCE``.
+
+    With a recognized mode the next gate is the empty check, which fires
+    before numeric filtering, so an empty input is reported as an empty
+    sequence rather than as "no numeric value" (R7.12).
+    """
+    _assert_raises_code([], mode, ErrorCode.EMPTY_SEQUENCE)
+
+
+# Feature: mission-metric-reader-tools, Property 5: Reducer empty-vs-all-non-numeric-vs-invalid-mode split
+@settings(
+    max_examples=200,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
+)
+@given(values=_nonempty_non_numeric_sequences, mode=st.sampled_from(_MODES))
+def test_all_non_numeric_under_a_valid_mode_yields_no_numeric_value(
+    values: list[object], mode: str
+) -> None:
+    """A non-empty all-non-numeric sequence yields ``NO_NUMERIC_VALUE``.
+
+    The sequence has entries (so it is not empty) but none survive the
+    numeric guard, so the reducer reports the distinct "had data, none of it
+    numeric" code rather than the empty-sequence code (R7.11).
+    """
+    # Guard the generator's intent: every entry really is non-numeric.
+    assert all(not is_numeric_value(v) for v in values)
+    _assert_raises_code(values, mode, ErrorCode.NO_NUMERIC_VALUE)
+
+
+# Feature: mission-metric-reader-tools, Property 5: Reducer empty-vs-all-non-numeric-vs-invalid-mode split
+@settings(
+    max_examples=200,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
+)
+@given(data=st.data())
+def test_three_failures_are_mutually_exclusive_with_distinct_codes(
+    data: st.DataObject,
+) -> None:
+    """The three degenerate inputs map to three distinct, exclusive codes.
+
+    A single draw picks one of the three failure categories, builds a
+    matching ``(values, mode)`` input, and asserts the reducer raises exactly
+    the code that category owns. Across categories the three codes are
+    pairwise distinct, so the outcomes cannot be confused (R7.8, R7.11,
+    R7.12).
+    """
+    # The three codes are distinct constants — the contract that makes the
+    # outcomes distinguishable in the first place.
+    codes = {
+        ErrorCode.INVALID_AGGREGATION_MODE,
+        ErrorCode.EMPTY_SEQUENCE,
+        ErrorCode.NO_NUMERIC_VALUE,
+    }
+    assert len(codes) == 3
+
+    category = data.draw(st.sampled_from(("invalid_mode", "empty", "all_non_numeric")))
+    if category == "invalid_mode":
+        values = data.draw(_any_sequences)
+        mode = data.draw(_invalid_modes)
+        _assert_raises_code(values, mode, ErrorCode.INVALID_AGGREGATION_MODE)
+    elif category == "empty":
+        mode = data.draw(st.sampled_from(_MODES))
+        _assert_raises_code([], mode, ErrorCode.EMPTY_SEQUENCE)
+    else:  # all_non_numeric
+        values = data.draw(_nonempty_non_numeric_sequences)
+        mode = data.draw(st.sampled_from(_MODES))
+        _assert_raises_code(values, mode, ErrorCode.NO_NUMERIC_VALUE)

--- a/tests/test_metric_readers_cloudwatch.py
+++ b/tests/test_metric_readers_cloudwatch.py
@@ -146,8 +146,6 @@ def test_get_datapoint_issues_readonly_call_with_exact_shape() -> None:
     arguments mirror the inputs unchanged: namespace, metric name, dimensions
     (as ``{"Name","Value"}`` pairs), the lookback window, period, and the
     single requested statistic. No mutating CloudWatch API may be touched.
-
-    Validates: Requirements 2.3, 4.7, 16.6
     """
     mock_client = MagicMock()
     mock_client.get_metric_statistics.return_value = {
@@ -190,10 +188,7 @@ def test_get_datapoint_issues_readonly_call_with_exact_shape() -> None:
 
 
 def test_get_datapoint_passes_none_dimensions_as_empty_list() -> None:
-    """``dimensions=None`` is sent to CloudWatch as an empty dimension list.
-
-    Validates: Requirements 4.7, 16.6
-    """
+    """``dimensions=None`` is sent to CloudWatch as an empty dimension list."""
     mock_client = MagicMock()
     mock_client.get_metric_statistics.return_value = {"Datapoints": [{"Timestamp": _END, "Sum": 7}]}
 
@@ -215,10 +210,7 @@ def test_get_datapoint_passes_none_dimensions_as_empty_list() -> None:
 
 
 def test_get_datapoint_zero_datapoints_raises_no_datapoints() -> None:
-    """An empty ``Datapoints`` list maps to ``NO_DATAPOINTS`` (no metrics shape).
-
-    Validates: Requirements 4.7, 16.6
-    """
+    """An empty ``Datapoints`` list maps to ``NO_DATAPOINTS`` (no metrics shape)."""
     mock_client = MagicMock()
     mock_client.get_metric_statistics.return_value = {"Datapoints": []}
 
@@ -245,10 +237,7 @@ def test_get_datapoint_zero_datapoints_raises_no_datapoints() -> None:
 
 
 def test_get_datapoint_client_error_maps_to_aws_unreachable_client_error_kind() -> None:
-    """A generic ``ClientError`` maps to ``AWS_UNREACHABLE`` with ``kind='client_error'``.
-
-    Validates: Requirements 4.8, 16.6
-    """
+    """A generic ``ClientError`` maps to ``AWS_UNREACHABLE`` with ``kind='client_error'``."""
     mock_client = MagicMock()
     mock_client.get_metric_statistics.side_effect = ClientError(
         {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
@@ -277,10 +266,7 @@ def test_get_datapoint_client_error_maps_to_aws_unreachable_client_error_kind() 
 
 
 def test_get_datapoint_access_denied_maps_to_unauthorized_kind() -> None:
-    """A credentials/permissions ``ClientError`` maps to ``kind='unauthorized'``.
-
-    Validates: Requirements 4.8, 16.6
-    """
+    """A credentials/permissions ``ClientError`` maps to ``kind='unauthorized'``."""
     mock_client = MagicMock()
     mock_client.get_metric_statistics.side_effect = ClientError(
         {"Error": {"Code": "AccessDenied", "Message": "not authorized"}},
@@ -307,10 +293,7 @@ def test_get_datapoint_access_denied_maps_to_unauthorized_kind() -> None:
 
 
 def test_get_datapoint_endpoint_connection_error_maps_to_unreachable_kind() -> None:
-    """An ``EndpointConnectionError`` maps to ``AWS_UNREACHABLE`` with ``kind='unreachable'``.
-
-    Validates: Requirements 4.8, 16.6
-    """
+    """An ``EndpointConnectionError`` maps to ``AWS_UNREACHABLE`` with ``kind='unreachable'``."""
     mock_client = MagicMock()
     mock_client.get_metric_statistics.side_effect = EndpointConnectionError(
         endpoint_url="https://monitoring.us-east-1.amazonaws.com"
@@ -336,10 +319,7 @@ def test_get_datapoint_endpoint_connection_error_maps_to_unreachable_kind() -> N
 
 
 def test_get_datapoint_botocore_error_maps_to_unreachable_kind() -> None:
-    """A generic ``BotoCoreError`` maps to ``AWS_UNREACHABLE`` with ``kind='unreachable'``.
-
-    Validates: Requirements 4.8, 16.6
-    """
+    """A generic ``BotoCoreError`` maps to ``AWS_UNREACHABLE`` with ``kind='unreachable'``."""
     mock_client = MagicMock()
     mock_client.get_metric_statistics.side_effect = BotoCoreError()
 

--- a/tests/test_metric_readers_cloudwatch.py
+++ b/tests/test_metric_readers_cloudwatch.py
@@ -1,0 +1,362 @@
+"""Tests for the CloudWatch datapoint reader.
+
+A CloudWatch ``GetMetricStatistics`` response can carry several datapoints —
+one per aggregation period inside the requested window. The reader has to pick
+exactly one, deterministically, and it picks the freshest: the datapoint whose
+``Timestamp`` is the latest. ``select_most_recent`` is the pure helper that
+does this, returning that datapoint's statistic reading (as a float) together
+with its timestamp rendered in ISO-8601 form.
+
+The property test below pins down that "latest wins" contract across a wide
+range of datapoint lists with distinct timestamps and mixed int/float
+readings: whatever the input order, the value and timestamp handed back must
+belong to the datapoint with the maximum ``Timestamp``.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import BotoCoreError, ClientError, EndpointConnectionError
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ``mcp/run_mcp.py`` puts ``mcp/`` on ``sys.path`` at runtime; mirror that
+# here so the pure ``metric_readers`` package imports the same way it does
+# in production, matching the convention used by the sibling Mission tests.
+sys.path.insert(0, str(Path(__file__).parent.parent / "mcp"))
+
+from metric_readers.cloudwatch import get_datapoint, select_most_recent  # noqa: E402
+from metric_readers.shape import ErrorCode, MetricReaderError  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+# The statistic key carried by each datapoint. These are the read-only
+# statistics CloudWatch can return; the reader reads whichever one was asked
+# for, so every datapoint in a single example carries the same key.
+_statistics = st.sampled_from(["Average", "Sum", "Maximum", "Minimum", "SampleCount"])
+
+# A real, finite statistic reading: an int (never a bool) or a finite float.
+_readings = st.one_of(
+    st.integers(),
+    st.floats(allow_nan=False, allow_infinity=False),
+)
+
+
+@st.composite
+def _datapoints_with_distinct_timestamps(draw: st.DrawFn) -> tuple[str, list[dict[str, Any]]]:
+    """Draw a non-empty datapoint list with strictly distinct timestamps.
+
+    Each datapoint is a dict shaped like a CloudWatch datapoint: a
+    timezone-aware UTC ``Timestamp`` plus one statistic key mapping to a
+    finite number. Timestamps are unique within the list so the latest
+    datapoint is unambiguous, mirroring real ``GetMetricStatistics`` output
+    where each period yields at most one datapoint.
+    """
+    statistic = draw(_statistics)
+    timestamps = draw(
+        st.lists(
+            st.datetimes(timezones=st.just(UTC)),
+            min_size=1,
+            max_size=20,
+            unique=True,
+        )
+    )
+    datapoints = [{"Timestamp": timestamp, statistic: draw(_readings)} for timestamp in timestamps]
+    # Shuffle so the helper cannot accidentally rely on input ordering.
+    draw(st.randoms(use_true_random=False)).shuffle(datapoints)
+    return statistic, datapoints
+
+
+# ---------------------------------------------------------------------------
+# Property: the latest datapoint wins
+# ---------------------------------------------------------------------------
+
+
+@settings(
+    max_examples=200,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
+)
+@given(_datapoints_with_distinct_timestamps())
+def test_select_most_recent_returns_latest_datapoint(
+    case: tuple[str, list[dict[str, Any]]],
+) -> None:
+    """``select_most_recent`` returns the value and ISO timestamp of the latest datapoint.
+
+    For any non-empty datapoint list with distinct timestamps, the helper must
+    return the statistic reading (coerced to float) and the ISO-8601 timestamp
+    of the datapoint whose ``Timestamp`` is the maximum — regardless of the
+    order the datapoints arrive in.
+    """
+    statistic, datapoints = case
+
+    # Independent reference: order by timestamp and take the last one. With
+    # distinct timestamps this is exactly the unique maximum.
+    latest = sorted(datapoints, key=lambda dp: dp["Timestamp"])[-1]
+    expected_value = float(latest[statistic])
+    expected_iso = latest["Timestamp"].isoformat()
+
+    value, iso_timestamp = select_most_recent(datapoints, statistic)
+
+    assert value == expected_value
+    assert isinstance(value, float)
+    assert iso_timestamp == expected_iso
+
+
+# ---------------------------------------------------------------------------
+# Mocked-CloudWatch unit tests for ``get_datapoint`` (the boto3 wrapper)
+# ---------------------------------------------------------------------------
+#
+# ``get_datapoint`` does a lazy ``import boto3`` inside the function and then
+# calls ``boto3.client("cloudwatch", region_name=region)``. Patching
+# ``boto3.client`` at the boto3 module level therefore intercepts the client
+# construction without any live AWS call being made. Each test below builds a
+# ``MagicMock`` client, wires its ``get_metric_statistics`` to either return a
+# canned response or raise a botocore exception, and asserts the read-only call
+# shape and the structured-error translation.
+
+# A fixed, timezone-aware lookback window reused across the call-shape tests so
+# the asserted ``StartTime``/``EndTime`` are unambiguous.
+_START = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+_END = datetime(2024, 1, 1, 13, 0, 0, tzinfo=UTC)
+
+
+def _patched_client(mock_client: MagicMock) -> Any:
+    """Patch ``boto3.client`` so it returns ``mock_client``.
+
+    Returns the patcher object so the caller can use it as a context manager
+    and inspect the ``boto3.client`` mock (e.g. to assert the region scoping).
+    """
+    return patch("boto3.client", return_value=mock_client)
+
+
+def test_get_datapoint_issues_readonly_call_with_exact_shape() -> None:
+    """The wrapper scopes the client to the region and passes the exact read-only args.
+
+    On the success path ``get_datapoint`` must construct a region-scoped
+    CloudWatch client and issue a single ``get_metric_statistics`` call whose
+    arguments mirror the inputs unchanged: namespace, metric name, dimensions
+    (as ``{"Name","Value"}`` pairs), the lookback window, period, and the
+    single requested statistic. No mutating CloudWatch API may be touched.
+
+    Validates: Requirements 2.3, 4.7, 16.6
+    """
+    mock_client = MagicMock()
+    mock_client.get_metric_statistics.return_value = {
+        "Datapoints": [{"Timestamp": _END, "Average": 42.5}]
+    }
+
+    with _patched_client(mock_client) as mock_boto_client:
+        value, iso_timestamp = get_datapoint(
+            metric_name="GPUUtilization",
+            namespace="GCO/Training",
+            dimensions={"JobName": "megatrain", "Region": "us-east-1"},
+            region="us-west-2",
+            period=300,
+            statistic="Average",
+            start_time=_START,
+            end_time=_END,
+        )
+
+    # The client is scoped to the requested region (and only the cloudwatch service).
+    mock_boto_client.assert_called_once_with("cloudwatch", region_name="us-west-2")
+
+    # Exactly one CloudWatch call, and it is the read-only GetMetricStatistics.
+    assert [c[0] for c in mock_client.method_calls] == ["get_metric_statistics"]
+    mock_client.get_metric_statistics.assert_called_once_with(
+        Namespace="GCO/Training",
+        MetricName="GPUUtilization",
+        Dimensions=[
+            {"Name": "JobName", "Value": "megatrain"},
+            {"Name": "Region", "Value": "us-east-1"},
+        ],
+        StartTime=_START,
+        EndTime=_END,
+        Period=300,
+        Statistics=["Average"],
+    )
+
+    # And the selected datapoint flows back out unchanged.
+    assert value == 42.5
+    assert iso_timestamp == _END.isoformat()
+
+
+def test_get_datapoint_passes_none_dimensions_as_empty_list() -> None:
+    """``dimensions=None`` is sent to CloudWatch as an empty dimension list.
+
+    Validates: Requirements 4.7, 16.6
+    """
+    mock_client = MagicMock()
+    mock_client.get_metric_statistics.return_value = {"Datapoints": [{"Timestamp": _END, "Sum": 7}]}
+
+    with _patched_client(mock_client):
+        get_datapoint(
+            metric_name="Throughput",
+            namespace="GCO/Training",
+            dimensions=None,
+            region="eu-central-1",
+            period=60,
+            statistic="Sum",
+            start_time=_START,
+            end_time=_END,
+        )
+
+    _, kwargs = mock_client.get_metric_statistics.call_args
+    assert kwargs["Dimensions"] == []
+    assert kwargs["Statistics"] == ["Sum"]
+
+
+def test_get_datapoint_zero_datapoints_raises_no_datapoints() -> None:
+    """An empty ``Datapoints`` list maps to ``NO_DATAPOINTS`` (no metrics shape).
+
+    Validates: Requirements 4.7, 16.6
+    """
+    mock_client = MagicMock()
+    mock_client.get_metric_statistics.return_value = {"Datapoints": []}
+
+    with _patched_client(mock_client), pytest.raises(MetricReaderError) as exc_info:
+        get_datapoint(
+            metric_name="Loss",
+            namespace="GCO/Training",
+            dimensions={"JobName": "megatrain"},
+            region="us-east-1",
+            period=300,
+            statistic="Average",
+            start_time=_START,
+            end_time=_END,
+        )
+
+    error = exc_info.value
+    assert error.code == ErrorCode.NO_DATAPOINTS
+    assert error.code == "no_datapoints"
+    assert error.details is not None
+    assert error.details["metric_name"] == "Loss"
+    assert error.details["namespace"] == "GCO/Training"
+    assert error.details["region"] == "us-east-1"
+    assert error.details["statistic"] == "Average"
+
+
+def test_get_datapoint_client_error_maps_to_aws_unreachable_client_error_kind() -> None:
+    """A generic ``ClientError`` maps to ``AWS_UNREACHABLE`` with ``kind='client_error'``.
+
+    Validates: Requirements 4.8, 16.6
+    """
+    mock_client = MagicMock()
+    mock_client.get_metric_statistics.side_effect = ClientError(
+        {"Error": {"Code": "Throttling", "Message": "Rate exceeded"}},
+        "GetMetricStatistics",
+    )
+
+    with _patched_client(mock_client), pytest.raises(MetricReaderError) as exc_info:
+        get_datapoint(
+            metric_name="Loss",
+            namespace="GCO/Training",
+            dimensions=None,
+            region="us-east-1",
+            period=300,
+            statistic="Average",
+            start_time=_START,
+            end_time=_END,
+        )
+
+    error = exc_info.value
+    assert error.code == ErrorCode.AWS_UNREACHABLE
+    assert error.code == "aws_unreachable"
+    assert error.details is not None
+    assert error.details["kind"] == "client_error"
+    assert error.details["region"] == "us-east-1"
+    assert error.details["aws_error_code"] == "Throttling"
+
+
+def test_get_datapoint_access_denied_maps_to_unauthorized_kind() -> None:
+    """A credentials/permissions ``ClientError`` maps to ``kind='unauthorized'``.
+
+    Validates: Requirements 4.8, 16.6
+    """
+    mock_client = MagicMock()
+    mock_client.get_metric_statistics.side_effect = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "not authorized"}},
+        "GetMetricStatistics",
+    )
+
+    with _patched_client(mock_client), pytest.raises(MetricReaderError) as exc_info:
+        get_datapoint(
+            metric_name="Loss",
+            namespace="GCO/Training",
+            dimensions=None,
+            region="us-east-1",
+            period=300,
+            statistic="Average",
+            start_time=_START,
+            end_time=_END,
+        )
+
+    error = exc_info.value
+    assert error.code == ErrorCode.AWS_UNREACHABLE
+    assert error.details is not None
+    assert error.details["kind"] == "unauthorized"
+    assert error.details["aws_error_code"] == "AccessDenied"
+
+
+def test_get_datapoint_endpoint_connection_error_maps_to_unreachable_kind() -> None:
+    """An ``EndpointConnectionError`` maps to ``AWS_UNREACHABLE`` with ``kind='unreachable'``.
+
+    Validates: Requirements 4.8, 16.6
+    """
+    mock_client = MagicMock()
+    mock_client.get_metric_statistics.side_effect = EndpointConnectionError(
+        endpoint_url="https://monitoring.us-east-1.amazonaws.com"
+    )
+
+    with _patched_client(mock_client), pytest.raises(MetricReaderError) as exc_info:
+        get_datapoint(
+            metric_name="Loss",
+            namespace="GCO/Training",
+            dimensions=None,
+            region="us-east-1",
+            period=300,
+            statistic="Average",
+            start_time=_START,
+            end_time=_END,
+        )
+
+    error = exc_info.value
+    assert error.code == ErrorCode.AWS_UNREACHABLE
+    assert error.details is not None
+    assert error.details["kind"] == "unreachable"
+    assert error.details["region"] == "us-east-1"
+
+
+def test_get_datapoint_botocore_error_maps_to_unreachable_kind() -> None:
+    """A generic ``BotoCoreError`` maps to ``AWS_UNREACHABLE`` with ``kind='unreachable'``.
+
+    Validates: Requirements 4.8, 16.6
+    """
+    mock_client = MagicMock()
+    mock_client.get_metric_statistics.side_effect = BotoCoreError()
+
+    with _patched_client(mock_client), pytest.raises(MetricReaderError) as exc_info:
+        get_datapoint(
+            metric_name="Loss",
+            namespace="GCO/Training",
+            dimensions=None,
+            region="ap-southeast-2",
+            period=300,
+            statistic="Average",
+            start_time=_START,
+            end_time=_END,
+        )
+
+    error = exc_info.value
+    assert error.code == ErrorCode.AWS_UNREACHABLE
+    assert error.details is not None
+    assert error.details["kind"] == "unreachable"
+    assert error.details["region"] == "ap-southeast-2"

--- a/tests/test_metric_readers_doc_hygiene.py
+++ b/tests/test_metric_readers_doc_hygiene.py
@@ -1,0 +1,102 @@
+"""Doc-hygiene guard for the metric-reader feature files.
+
+The metric-reader package, its tool wrapper, and its test modules are
+shipped, standalone code. They should read as such: their comments and
+docstrings explain behaviour in plain terms, not by pointing at an
+internal planning artifact the repository does not contain. References
+like ``R6.5``, ``Validates: Requirements 1.3``, ``Property 7``, or "the
+design's per-format table" are scaffolding from the authoring process —
+useful while building, noise (and dangling pointers) once merged.
+
+This test scans the feature's own files and fails if any such reference
+survives, listing every offending line so the fix is mechanical. It
+deliberately excludes itself from the scan so the pattern catalogue
+below does not trip the very check it defines.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_THIS_FILE = Path(__file__).resolve()
+
+# The feature's files: the pure package, the tool wrapper, and the test
+# modules. Documentation files (READMEs, docs/MISSION.md) and example
+# artifacts are intentionally out of scope — those legitimately describe
+# the feature and may reference requirements in operator-facing prose.
+_FEATURE_PATHS: tuple[Path, ...] = (
+    _REPO_ROOT / "mcp" / "metric_readers",
+    _REPO_ROOT / "mcp" / "tools" / "metrics.py",
+    _REPO_ROOT / "tests",
+)
+
+# Only the metric-reader test modules under ``tests/`` are in scope; the
+# rest of the suite is unrelated.
+_TEST_PREFIX = "test_metric_readers_"
+
+
+def _iter_feature_files() -> list[Path]:
+    """Collect the Python files this guard scans, excluding itself."""
+    files: list[Path] = []
+    for base in _FEATURE_PATHS:
+        if base.is_file():
+            files.append(base)
+            continue
+        for path in sorted(base.rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            if path.resolve() == _THIS_FILE:
+                continue
+            # Under ``tests/`` only the metric-reader modules are in scope.
+            if path.parent.name == "tests" and not path.name.startswith(_TEST_PREFIX):
+                continue
+            files.append(path)
+    return files
+
+
+# Each pattern names a class of authoring-scaffolding reference that must
+# not survive into shipped code. The label is shown in the failure report
+# so a contributor knows what to rewrite.
+_FORBIDDEN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    # Requirement IDs like R6.5, R18.10.
+    ("requirement-id", re.compile(r"\bR\d+\.\d+\b")),
+    # The "Validates: Requirements ..." docstring annotation.
+    ("validates-annotation", re.compile(r"Validates:\s*Requirement", re.IGNORECASE)),
+    # The "# Feature: mission-metric-reader-tools, Property N" tag.
+    ("feature-property-tag", re.compile(r"Feature:\s*mission-metric-reader-tools")),
+    # Bare "Property N" property-numbering references.
+    ("property-number", re.compile(r"\bProperty\s+\d+\b")),
+    # "Requirement 18" / "Requirements 1.3" prose references.
+    ("requirement-word", re.compile(r"\bRequirements?\s+\d", re.IGNORECASE)),
+    # Numbered task references pointing at the implementation plan.
+    ("task-number", re.compile(r"\btask\s+\d+(?:\.\d+)?\b", re.IGNORECASE)),
+    # Pointers at planning documents the repository does not ship.
+    ("planning-doc", re.compile(r"\b(?:requirements|design|tasks)\.md\b", re.IGNORECASE)),
+    # "the design" / "design's" / "the spec" prose pointers.
+    ("spec-prose", re.compile(r"\bthe design\b|\bdesign's\b|\bthe spec\b", re.IGNORECASE)),
+)
+
+
+def test_feature_files_have_no_spec_internal_references() -> None:
+    """No metric-reader file may reference the authoring spec artifacts.
+
+    Scans every feature source and test file line by line for the
+    scaffolding patterns above and fails with a complete, grouped list of
+    offences so they can be rewritten in one pass.
+    """
+    violations: list[str] = []
+
+    for path in _iter_feature_files():
+        rel = path.relative_to(_REPO_ROOT)
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for label, pattern in _FORBIDDEN_PATTERNS:
+                if pattern.search(line):
+                    violations.append(f"{rel}:{lineno} [{label}] {line.strip()}")
+
+    assert not violations, (
+        "Spec-internal references must not appear in shipped feature files. "
+        f"Found {len(violations)}:\n" + "\n".join(violations)
+    )

--- a/tests/test_metric_readers_files.py
+++ b/tests/test_metric_readers_files.py
@@ -15,9 +15,9 @@ embedded sequence is numeric and each artifact round-trips its values exactly,
 a divergence points at the handler, not at the artifact.
 
 The ``parquet`` sub-case depends on pandas/pyarrow (the analytics extra) and on
-the columnar handler having been registered (task 5.2). When either is absent
-the parquet sub-case is skipped rather than failing, so the test still runs in
-a minimal environment.
+the columnar handler having been registered. When either is absent the parquet
+sub-case is skipped rather than failing, so the test still runs in a minimal
+environment.
 """
 
 from __future__ import annotations
@@ -147,11 +147,10 @@ _BUILDERS = {
 
 
 # ---------------------------------------------------------------------------
-# Property 7: per-format round-trip recovers the reduced scalar
+# Per-format round-trip recovers the reduced scalar
 # ---------------------------------------------------------------------------
 
 
-# Feature: mission-metric-reader-tools, Property 7: Per-format round-trip recovers the reduced scalar
 @settings(
     max_examples=150,
     deadline=None,
@@ -160,9 +159,6 @@ _BUILDERS = {
 @given(seq=_numeric_sequences)
 def test_per_format_round_trip_recovers_reduced_scalar(seq: list[object]) -> None:
     """Reading a constructed artifact back recovers the reference reduction.
-
-    Validates: Requirements 8.1, 8.2, 8.3, 8.4, 8.5, 9.2, 9.3, 10.1, 10.2,
-    10.3, 11.2, 11.3, 12.1, 12.2, 16.2, 16.5
 
     For every text parsing format (``json``, ``csv``, ``hf_trainer_state``,
     ``jsonl``, ``yaml``) and every Aggregation_Mode, the scalar the handler
@@ -182,11 +178,10 @@ def test_per_format_round_trip_recovers_reduced_scalar(seq: list[object]) -> Non
 
 
 # ---------------------------------------------------------------------------
-# Property 7 (parquet arm): dependency- and handler-guarded round-trip
+# Parquet round-trip: dependency- and handler-guarded
 # ---------------------------------------------------------------------------
 
 
-# Feature: mission-metric-reader-tools, Property 7: Per-format round-trip recovers the reduced scalar
 @settings(
     max_examples=100,
     deadline=None,
@@ -195,8 +190,6 @@ def test_per_format_round_trip_recovers_reduced_scalar(seq: list[object]) -> Non
 @given(seq=_numeric_sequences)
 def test_parquet_round_trip_recovers_reduced_scalar(seq: list[object]) -> None:
     """The columnar reader recovers the reference reduction of a Parquet column.
-
-    Validates: Requirements 12.1, 12.2, 16.2, 16.5
 
     Mirrors the text-format property for ``parquet``: a single-column Parquet
     artifact embedding ``seq`` reads back, under each Aggregation_Mode, to the
@@ -207,7 +200,7 @@ def test_parquet_round_trip_recovers_reduced_scalar(seq: list[object]) -> None:
     pd = pytest.importorskip("pandas")
     pytest.importorskip("pyarrow")
     if "parquet" not in files._HANDLERS:
-        pytest.skip("parquet handler not yet registered (task 5.2)")
+        pytest.skip("parquet handler not registered")
 
     buffer = io.BytesIO()
     pd.DataFrame({"metric": list(seq)}).to_parquet(buffer, index=False)
@@ -223,11 +216,11 @@ def test_parquet_round_trip_recovers_reduced_scalar(seq: list[object]) -> None:
 
 
 # ===========================================================================
-# Task 5.4 — file-reader error-class unit tests
+# File-reader error-class unit tests
 # ===========================================================================
 #
 # Plain (non-property) unit tests pinning down which stable ErrorCode each
-# failure class surfaces, one assertion per documented code (Requirement 16.3).
+# failure class surfaces, one assertion per documented code.
 #
 # Layering note. The per-format *handlers* in ``files.py`` raise the codes that
 # describe the *content* of an artifact:
@@ -240,9 +233,9 @@ def test_parquet_round_trip_recovers_reduced_scalar(seq: list[object]) -> None:
 # The remaining two codes live at the *tool* boundary in ``mcp/tools/metrics.py``,
 # not in any handler:
 #
-#   * ``file_too_large``    — the ``_read_shared_storage`` size cap (R6.9), checked
+#   * ``file_too_large``    — the ``_read_shared_storage`` size cap, checked
 #                             before the artifact's content is read.
-#   * ``unsupported_format`` — the ``format not in files._HANDLERS`` guard (R6.10),
+#   * ``unsupported_format`` — the ``format not in files._HANDLERS`` guard,
 #                             reached when the caller names a format with no handler.
 #
 # These two are tested against the pure mechanisms in the tool module: the
@@ -250,17 +243,17 @@ def test_parquet_round_trip_recovers_reduced_scalar(seq: list[object]) -> None:
 # format guard is exercised by invoking the tool with a bogus format (the guard
 # runs before any storage read, so it stays offline).
 #
-# On ``tfevents`` and ``unsupported_format`` (R13.5). The design *implements*
-# ``tfevents`` rather than deferring it: it is a registered ``_HANDLERS`` entry
-# whose lazy ``tbparse`` import, when the dependency is absent, yields
-# ``format_dependency_unavailable`` (R13.3) — the path exercised below. R13.5's
-# "if deferred entirely -> unsupported_format" branch is therefore the same
+# On ``tfevents`` and ``unsupported_format``. ``tfevents`` is implemented
+# rather than deferred: it is a registered ``_HANDLERS`` entry whose lazy
+# ``tbparse`` import, when the dependency is absent, yields
+# ``format_dependency_unavailable`` — the path exercised below. Were the format
+# ever deferred entirely, a ``tfevents`` request would instead surface the same
 # ``unsupported_format`` code the tool-boundary guard raises for any format with
 # no handler; that code is covered by the unknown-format test below.
 
 
 # ---------------------------------------------------------------------------
-# field_not_found — a named field / column is absent (R6.6, R8.6, R12.3)
+# field_not_found — a named field / column is absent
 # ---------------------------------------------------------------------------
 
 
@@ -274,7 +267,7 @@ def test_json_missing_field_raises_field_not_found() -> None:
 
 
 def test_csv_missing_column_raises_field_not_found() -> None:
-    """A column name absent from the CSV header is a field-not-found error (R8.6)."""
+    """A column name absent from the CSV header is a field-not-found error."""
     content = b"colA,colB\n1,2\n3,4\n"
     with pytest.raises(MetricReaderError) as excinfo:
         files._handle_csv(content, "colC", "last")
@@ -283,7 +276,7 @@ def test_csv_missing_column_raises_field_not_found() -> None:
 
 
 def test_hf_missing_field_raises_field_not_found() -> None:
-    """A field in neither ``log_history`` nor a top-level key is missing (R9.4)."""
+    """A field in neither ``log_history`` nor a top-level key is missing."""
     content = json.dumps({"log_history": [{"loss": 1.0}]}).encode("utf-8")
     with pytest.raises(MetricReaderError) as excinfo:
         files._handle_hf(content, "accuracy", "last")
@@ -292,7 +285,7 @@ def test_hf_missing_field_raises_field_not_found() -> None:
 
 
 # ---------------------------------------------------------------------------
-# malformed_file — bytes do not parse under the requested format (R6.5, R11.4)
+# malformed_file — bytes do not parse under the requested format
 # ---------------------------------------------------------------------------
 
 
@@ -305,7 +298,7 @@ def test_json_unparseable_bytes_raise_malformed_file() -> None:
 
 
 def test_yaml_unparseable_bytes_raise_malformed_file() -> None:
-    """A document the safe loader rejects is a malformed-file error (R11.4)."""
+    """A document the safe loader rejects is a malformed-file error."""
     with pytest.raises(MetricReaderError) as excinfo:
         files._handle_yaml(b":\n  - [unbalanced", "field", "last")
     assert excinfo.value.code == ErrorCode.MALFORMED_FILE
@@ -321,7 +314,7 @@ def test_csv_invalid_utf8_raises_malformed_file() -> None:
 
 
 # ---------------------------------------------------------------------------
-# no_numeric_value — a JSONL stream yields no usable number (R10.5)
+# no_numeric_value — a JSONL stream yields no usable number
 # ---------------------------------------------------------------------------
 
 
@@ -334,7 +327,7 @@ def test_jsonl_all_non_numeric_raises_no_numeric_value() -> None:
 
 
 def test_jsonl_field_never_present_raises_no_numeric_value() -> None:
-    """A stream that never carries the field collapses to the same code (R10.5).
+    """A stream that never carries the field collapses to the same code.
 
     Lines that are valid JSON objects but lack the requested key contribute
     nothing, so the gathered sequence is empty — the reader maps that to the
@@ -348,14 +341,14 @@ def test_jsonl_field_never_present_raises_no_numeric_value() -> None:
 
 
 # ---------------------------------------------------------------------------
-# format_dependency_unavailable — a lazy optional import fails (R12.4, R13.3)
+# format_dependency_unavailable — a lazy optional import fails
 # ---------------------------------------------------------------------------
 
 
 def test_parquet_missing_dependency_raises_format_dependency_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A missing pandas/pyarrow wheel is a dependency-unavailable envelope (R12.4).
+    """A missing pandas/pyarrow wheel is a dependency-unavailable envelope.
 
     Setting ``sys.modules["pandas"]`` to ``None`` makes ``import pandas`` inside
     the handler raise ``ImportError`` deterministically, regardless of whether
@@ -372,11 +365,11 @@ def test_parquet_missing_dependency_raises_format_dependency_unavailable(
 def test_tfevents_missing_dependency_raises_format_dependency_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A missing tbparse/tensorboard parser is a dependency-unavailable envelope (R13.3).
+    """A missing tbparse/tensorboard parser is a dependency-unavailable envelope.
 
     ``tfevents`` is implemented (a registered handler), not deferred, so an
     absent parser surfaces as ``format_dependency_unavailable`` and never as an
-    import crash (R13.4). Forcing ``import tbparse`` to fail via ``sys.modules``
+    import crash. Forcing ``import tbparse`` to fail via ``sys.modules``
     exercises that lazy-import guard.
     """
     monkeypatch.setitem(sys.modules, "tbparse", None)
@@ -387,7 +380,7 @@ def test_tfevents_missing_dependency_raises_format_dependency_unavailable(
 
 
 # ---------------------------------------------------------------------------
-# Tool-boundary codes: file_too_large (R6.9) and unsupported_format (R6.10, R13.5)
+# Tool-boundary codes: file_too_large and unsupported_format
 # ---------------------------------------------------------------------------
 
 
@@ -409,7 +402,7 @@ def _import_metrics_tool_module():
 def test_oversize_artifact_raises_file_too_large(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An artifact larger than ``max_bytes`` is a file-too-large error (R6.9).
+    """An artifact larger than ``max_bytes`` is a file-too-large error.
 
     Exercises the tool-boundary size cap in ``_read_shared_storage`` without any
     AWS/network: the ``gco files download`` call is stubbed to drop an oversized
@@ -439,11 +432,11 @@ def test_oversize_artifact_raises_file_too_large(
 
 
 def test_unknown_format_returns_unsupported_format() -> None:
-    """A ``format`` with no handler is an unsupported-format envelope (R6.10, R13.5).
+    """A ``format`` with no handler is an unsupported-format envelope.
 
     The tool's format guard runs before any storage read, so invoking the
     shared-storage reader with a bogus format returns the ``unsupported_format``
-    envelope offline. This is also the code R13.5 reserves for a ``tfevents``
+    envelope offline. This is also the code reserved for a ``tfevents``
     request were the format ever deferred entirely.
     """
     metrics_module = _import_metrics_tool_module()

--- a/tests/test_metric_readers_files.py
+++ b/tests/test_metric_readers_files.py
@@ -1,0 +1,460 @@
+"""Round-trip tests for the file-format metric reader.
+
+A job can persist its metrics in many shapes — a JSON or YAML document, a CSV
+table, a Hugging Face ``Trainer`` state file, a stream of one-JSON-object-per
+line records, or a columnar Parquet file. Whatever the shape, reading a named
+field back out and collapsing it with an Aggregation_Mode must recover exactly
+the number a straightforward reduction of the embedded sequence would produce.
+
+The property test below pins that contract down for every parsing format. For
+each format it constructs an artifact that embeds a *known* numeric sequence,
+reads it back through the format's handler under each mode (``last``,
+``first``, ``min``, ``max``, ``mean``), and asserts the recovered scalar equals
+a reference reduction of the same sequence under the same mode. Because the
+embedded sequence is numeric and each artifact round-trips its values exactly,
+a divergence points at the handler, not at the artifact.
+
+The ``parquet`` sub-case depends on pandas/pyarrow (the analytics extra) and on
+the columnar handler having been registered (task 5.2). When either is absent
+the parquet sub-case is skipped rather than failing, so the test still runs in
+a minimal environment.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+import yaml
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ``mcp/run_mcp.py`` puts ``mcp/`` on ``sys.path`` at runtime; mirror that here
+# so the pure ``metric_readers`` package imports the same way it does in
+# production, matching the convention used by the sibling metric-reader tests.
+sys.path.insert(0, str(Path(__file__).parent.parent / "mcp"))
+
+from metric_readers import files  # noqa: E402
+from metric_readers.shape import ErrorCode, MetricReaderError, is_numeric_value  # noqa: E402
+
+# Every Aggregation_Mode the reducer accepts. The property exercises all of
+# them against each generated sequence.
+_MODES = ("last", "first", "min", "max", "mean")
+
+# The parsing formats handled in the always-run property below. The columnar
+# ``parquet`` format is exercised by its own dependency-guarded test.
+_TEXT_FORMATS = ("json", "csv", "hf_trainer_state", "jsonl", "yaml")
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+# A real, finite number that round-trips exactly through text serialization:
+# a bounded int or a bounded, non-subnormal finite float. The bounds keep a
+# ``mean`` sum well clear of overflow so every mode stays finite.
+_numbers = st.one_of(
+    st.integers(min_value=-1_000_000, max_value=1_000_000),
+    st.floats(
+        min_value=-1e6,
+        max_value=1e6,
+        allow_nan=False,
+        allow_infinity=False,
+        allow_subnormal=False,
+    ),
+)
+
+# A non-empty sequence of numbers — the reducer rejects an empty sequence, so
+# every embedded sequence carries at least one value.
+_numeric_sequences = st.lists(_numbers, min_size=1, max_size=20)
+
+
+# ---------------------------------------------------------------------------
+# Reference reduction
+# ---------------------------------------------------------------------------
+
+
+def _reference_reduce(values: Sequence[object], mode: str) -> float:
+    """Reduce ``values`` the obvious way, over the number-only subsequence.
+
+    Mirrors the reducer's own definition: filter to real, finite numbers with
+    the same guard, preserve their original order, then apply the mode. A
+    deliberately straightforward re-derivation so a divergence points at the
+    handler under test, not at clever test logic.
+    """
+    numbers = [v for v in values if is_numeric_value(v)]
+    if mode == "last":
+        return numbers[-1]
+    if mode == "first":
+        return numbers[0]
+    if mode == "min":
+        return min(numbers)
+    if mode == "max":
+        return max(numbers)
+    # mode == "mean"
+    return sum(numbers) / len(numbers)
+
+
+# ---------------------------------------------------------------------------
+# Per-format artifact builders
+# ---------------------------------------------------------------------------
+#
+# Each builder embeds ``seq`` into an artifact of its format and returns
+# ``(content_bytes, field)`` — the raw bytes a handler receives and the field
+# name to resolve. The field is always a single Dot_Path segment so the
+# document handlers resolve it directly.
+
+
+def _build_json(seq: list[object]) -> tuple[bytes, str]:
+    """A plain JSON document whose ``metric`` field holds the sequence as a list."""
+    return json.dumps({"metric": list(seq)}).encode("utf-8"), "metric"
+
+
+def _build_yaml(seq: list[object]) -> tuple[bytes, str]:
+    """A YAML document whose ``metric`` field holds the sequence as a list."""
+    return yaml.safe_dump({"metric": list(seq)}).encode("utf-8"), "metric"
+
+
+def _build_csv(seq: list[object]) -> tuple[bytes, str]:
+    """A CSV table with a single ``metric`` column, one value per data row."""
+    lines = ["metric", *[str(v) for v in seq]]
+    return "\n".join(lines).encode("utf-8"), "metric"
+
+
+def _build_jsonl(seq: list[object]) -> tuple[bytes, str]:
+    """A JSON-lines stream of one ``{"metric": v}`` record per value."""
+    lines = [json.dumps({"metric": v}) for v in seq]
+    return "\n".join(lines).encode("utf-8"), "metric"
+
+
+def _build_hf(seq: list[object]) -> tuple[bytes, str]:
+    """A Hugging Face ``Trainer`` state file logging ``loss`` once per step."""
+    doc = {"log_history": [{"loss": v} for v in seq]}
+    return json.dumps(doc).encode("utf-8"), "loss"
+
+
+_BUILDERS = {
+    "json": _build_json,
+    "csv": _build_csv,
+    "hf_trainer_state": _build_hf,
+    "jsonl": _build_jsonl,
+    "yaml": _build_yaml,
+}
+
+
+# ---------------------------------------------------------------------------
+# Property 7: per-format round-trip recovers the reduced scalar
+# ---------------------------------------------------------------------------
+
+
+# Feature: mission-metric-reader-tools, Property 7: Per-format round-trip recovers the reduced scalar
+@settings(
+    max_examples=150,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
+)
+@given(seq=_numeric_sequences)
+def test_per_format_round_trip_recovers_reduced_scalar(seq: list[object]) -> None:
+    """Reading a constructed artifact back recovers the reference reduction.
+
+    Validates: Requirements 8.1, 8.2, 8.3, 8.4, 8.5, 9.2, 9.3, 10.1, 10.2,
+    10.3, 11.2, 11.3, 12.1, 12.2, 16.2, 16.5
+
+    For every text parsing format (``json``, ``csv``, ``hf_trainer_state``,
+    ``jsonl``, ``yaml``) and every Aggregation_Mode, the scalar the handler
+    recovers from an artifact embedding ``seq`` equals the reference reduction
+    of ``seq`` under that mode. The artifacts round-trip their numeric values
+    exactly, so any divergence is the handler's.
+    """
+    for fmt in _TEXT_FORMATS:
+        content, field = _BUILDERS[fmt](seq)
+        handler = files._HANDLERS[fmt]
+        for mode in _MODES:
+            expected = _reference_reduce(seq, mode)
+            actual = handler(content, field, mode)
+            assert actual == expected, (
+                f"format={fmt!r} mode={mode!r} seq={seq!r} expected={expected!r} actual={actual!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Property 7 (parquet arm): dependency- and handler-guarded round-trip
+# ---------------------------------------------------------------------------
+
+
+# Feature: mission-metric-reader-tools, Property 7: Per-format round-trip recovers the reduced scalar
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
+)
+@given(seq=_numeric_sequences)
+def test_parquet_round_trip_recovers_reduced_scalar(seq: list[object]) -> None:
+    """The columnar reader recovers the reference reduction of a Parquet column.
+
+    Validates: Requirements 12.1, 12.2, 16.2, 16.5
+
+    Mirrors the text-format property for ``parquet``: a single-column Parquet
+    artifact embedding ``seq`` reads back, under each Aggregation_Mode, to the
+    same scalar a reference reduction yields. Skipped gracefully when pandas/
+    pyarrow (the analytics extra) are unavailable, or when the columnar handler
+    has not yet been registered, so a minimal environment does not hard-fail.
+    """
+    pd = pytest.importorskip("pandas")
+    pytest.importorskip("pyarrow")
+    if "parquet" not in files._HANDLERS:
+        pytest.skip("parquet handler not yet registered (task 5.2)")
+
+    buffer = io.BytesIO()
+    pd.DataFrame({"metric": list(seq)}).to_parquet(buffer, index=False)
+    content = buffer.getvalue()
+    handler = files._HANDLERS["parquet"]
+
+    for mode in _MODES:
+        expected = _reference_reduce(seq, mode)
+        actual = handler(content, "metric", mode)
+        assert actual == expected, (
+            f"format='parquet' mode={mode!r} seq={seq!r} expected={expected!r} actual={actual!r}"
+        )
+
+
+# ===========================================================================
+# Task 5.4 — file-reader error-class unit tests
+# ===========================================================================
+#
+# Plain (non-property) unit tests pinning down which stable ErrorCode each
+# failure class surfaces, one assertion per documented code (Requirement 16.3).
+#
+# Layering note. The per-format *handlers* in ``files.py`` raise the codes that
+# describe the *content* of an artifact:
+#
+#   * ``field_not_found``                — a named field/column is absent
+#   * ``malformed_file``                 — bytes do not parse under the format
+#   * ``no_numeric_value``               — a JSONL stream yields no usable number
+#   * ``format_dependency_unavailable``  — a parquet/tfevents lazy import fails
+#
+# The remaining two codes live at the *tool* boundary in ``mcp/tools/metrics.py``,
+# not in any handler:
+#
+#   * ``file_too_large``    — the ``_read_shared_storage`` size cap (R6.9), checked
+#                             before the artifact's content is read.
+#   * ``unsupported_format`` — the ``format not in files._HANDLERS`` guard (R6.10),
+#                             reached when the caller names a format with no handler.
+#
+# These two are tested against the pure mechanisms in the tool module: the
+# size-cap helper is exercised with a stubbed read (no AWS/network), and the
+# format guard is exercised by invoking the tool with a bogus format (the guard
+# runs before any storage read, so it stays offline).
+#
+# On ``tfevents`` and ``unsupported_format`` (R13.5). The design *implements*
+# ``tfevents`` rather than deferring it: it is a registered ``_HANDLERS`` entry
+# whose lazy ``tbparse`` import, when the dependency is absent, yields
+# ``format_dependency_unavailable`` (R13.3) — the path exercised below. R13.5's
+# "if deferred entirely -> unsupported_format" branch is therefore the same
+# ``unsupported_format`` code the tool-boundary guard raises for any format with
+# no handler; that code is covered by the unknown-format test below.
+
+
+# ---------------------------------------------------------------------------
+# field_not_found — a named field / column is absent (R6.6, R8.6, R12.3)
+# ---------------------------------------------------------------------------
+
+
+def test_json_missing_field_raises_field_not_found() -> None:
+    """A JSON dot-path that resolves nowhere is a field-not-found error."""
+    content = json.dumps({"present": 1.0}).encode("utf-8")
+    with pytest.raises(MetricReaderError) as excinfo:
+        files._handle_json(content, "absent", "last")
+    assert excinfo.value.code == ErrorCode.FIELD_NOT_FOUND
+    assert excinfo.value.details == {"field": "absent"}
+
+
+def test_csv_missing_column_raises_field_not_found() -> None:
+    """A column name absent from the CSV header is a field-not-found error (R8.6)."""
+    content = b"colA,colB\n1,2\n3,4\n"
+    with pytest.raises(MetricReaderError) as excinfo:
+        files._handle_csv(content, "colC", "last")
+    assert excinfo.value.code == ErrorCode.FIELD_NOT_FOUND
+    assert excinfo.value.details == {"field": "colC"}
+
+
+def test_hf_missing_field_raises_field_not_found() -> None:
+    """A field in neither ``log_history`` nor a top-level key is missing (R9.4)."""
+    content = json.dumps({"log_history": [{"loss": 1.0}]}).encode("utf-8")
+    with pytest.raises(MetricReaderError) as excinfo:
+        files._handle_hf(content, "accuracy", "last")
+    assert excinfo.value.code == ErrorCode.FIELD_NOT_FOUND
+    assert excinfo.value.details == {"field": "accuracy"}
+
+
+# ---------------------------------------------------------------------------
+# malformed_file — bytes do not parse under the requested format (R6.5, R11.4)
+# ---------------------------------------------------------------------------
+
+
+def test_json_unparseable_bytes_raise_malformed_file() -> None:
+    """Bytes that are not valid JSON are a malformed-file error tagged ``json``."""
+    with pytest.raises(MetricReaderError) as excinfo:
+        files._handle_json(b"{not valid json", "field", "last")
+    assert excinfo.value.code == ErrorCode.MALFORMED_FILE
+    assert (excinfo.value.details or {}).get("format") == "json"
+
+
+def test_yaml_unparseable_bytes_raise_malformed_file() -> None:
+    """A document the safe loader rejects is a malformed-file error (R11.4)."""
+    with pytest.raises(MetricReaderError) as excinfo:
+        files._handle_yaml(b":\n  - [unbalanced", "field", "last")
+    assert excinfo.value.code == ErrorCode.MALFORMED_FILE
+    assert (excinfo.value.details or {}).get("format") == "yaml"
+
+
+def test_csv_invalid_utf8_raises_malformed_file() -> None:
+    """Bytes that are not valid UTF-8 surface as a malformed-file decode error."""
+    with pytest.raises(MetricReaderError) as excinfo:
+        files._handle_csv(b"\xff\xfe\x00not utf-8", "field", "last")
+    assert excinfo.value.code == ErrorCode.MALFORMED_FILE
+    assert (excinfo.value.details or {}).get("format") == "csv"
+
+
+# ---------------------------------------------------------------------------
+# no_numeric_value — a JSONL stream yields no usable number (R10.5)
+# ---------------------------------------------------------------------------
+
+
+def test_jsonl_all_non_numeric_raises_no_numeric_value() -> None:
+    """A JSONL stream whose field is never numeric is a no-numeric-value error."""
+    content = b'{"metric": "high"}\n{"metric": "low"}\n{"metric": null}\n'
+    with pytest.raises(MetricReaderError) as excinfo:
+        files._handle_jsonl(content, "metric", "last")
+    assert excinfo.value.code == ErrorCode.NO_NUMERIC_VALUE
+
+
+def test_jsonl_field_never_present_raises_no_numeric_value() -> None:
+    """A stream that never carries the field collapses to the same code (R10.5).
+
+    Lines that are valid JSON objects but lack the requested key contribute
+    nothing, so the gathered sequence is empty — the reader maps that to the
+    same no-numeric-value outcome as an all-non-numeric stream.
+    """
+    content = b'{"other": 1}\n{"other": 2}\n'
+    with pytest.raises(MetricReaderError) as excinfo:
+        files._handle_jsonl(content, "metric", "last")
+    assert excinfo.value.code == ErrorCode.NO_NUMERIC_VALUE
+    assert (excinfo.value.details or {}).get("field") == "metric"
+
+
+# ---------------------------------------------------------------------------
+# format_dependency_unavailable — a lazy optional import fails (R12.4, R13.3)
+# ---------------------------------------------------------------------------
+
+
+def test_parquet_missing_dependency_raises_format_dependency_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing pandas/pyarrow wheel is a dependency-unavailable envelope (R12.4).
+
+    Setting ``sys.modules["pandas"]`` to ``None`` makes ``import pandas`` inside
+    the handler raise ``ImportError`` deterministically, regardless of whether
+    the analytics extra happens to be installed — so the guard is exercised in
+    every environment rather than only minimal ones.
+    """
+    monkeypatch.setitem(sys.modules, "pandas", None)
+    with pytest.raises(MetricReaderError) as excinfo:
+        files._handle_parquet(b"any bytes", "column", "last")
+    assert excinfo.value.code == ErrorCode.FORMAT_DEPENDENCY_UNAVAILABLE
+    assert (excinfo.value.details or {}).get("format") == "parquet"
+
+
+def test_tfevents_missing_dependency_raises_format_dependency_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing tbparse/tensorboard parser is a dependency-unavailable envelope (R13.3).
+
+    ``tfevents`` is implemented (a registered handler), not deferred, so an
+    absent parser surfaces as ``format_dependency_unavailable`` and never as an
+    import crash (R13.4). Forcing ``import tbparse`` to fail via ``sys.modules``
+    exercises that lazy-import guard.
+    """
+    monkeypatch.setitem(sys.modules, "tbparse", None)
+    with pytest.raises(MetricReaderError) as excinfo:
+        files._handle_tfevents(b"any bytes", "tag", "last")
+    assert excinfo.value.code == ErrorCode.FORMAT_DEPENDENCY_UNAVAILABLE
+    assert (excinfo.value.details or {}).get("format") == "tfevents"
+
+
+# ---------------------------------------------------------------------------
+# Tool-boundary codes: file_too_large (R6.9) and unsupported_format (R6.10, R13.5)
+# ---------------------------------------------------------------------------
+
+
+def _import_metrics_tool_module():
+    """Import ``tools.metrics`` or skip when its FastMCP/server deps are absent.
+
+    The pure ``metric_readers`` package needs nothing beyond the standard
+    library; the tool wrappers pull in ``server`` (FastMCP) and ``audit``. Skip
+    rather than fail when that surface cannot be imported, so this file's
+    handler-level assertions still run in a minimal environment.
+    """
+    try:
+        import tools.metrics as metrics_module
+    except Exception as exc:  # noqa: BLE001 - any import-surface failure -> skip
+        pytest.skip(f"tools.metrics not importable in this environment: {exc}")
+    return metrics_module
+
+
+def test_oversize_artifact_raises_file_too_large(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An artifact larger than ``max_bytes`` is a file-too-large error (R6.9).
+
+    Exercises the tool-boundary size cap in ``_read_shared_storage`` without any
+    AWS/network: the ``gco files download`` call is stubbed to drop an oversized
+    file at the destination, and the helper's stat-before-read check must reject
+    it with ``file_too_large`` and the size/limit provenance, returning no
+    content.
+    """
+    metrics_module = _import_metrics_tool_module()
+
+    def _fake_run_cli(*args: object, **_kwargs: object) -> str:
+        # ``files download <path> <local_path> -r <region>`` — write an
+        # oversized payload to the requested local destination, return no error.
+        local_path = args[3]
+        with open(str(local_path), "wb") as handle:
+            handle.write(b"x" * 4096)
+        return "{}"
+
+    monkeypatch.setattr(metrics_module.cli_runner, "_run_cli", _fake_run_cli)
+
+    with pytest.raises(MetricReaderError) as excinfo:
+        metrics_module._read_shared_storage("some/remote/path", "us-east-1", max_bytes=1024)
+    assert excinfo.value.code == ErrorCode.FILE_TOO_LARGE
+    details = excinfo.value.details or {}
+    assert details.get("path") == "some/remote/path"
+    assert details.get("size") == 4096
+    assert details.get("max_bytes") == 1024
+
+
+def test_unknown_format_returns_unsupported_format() -> None:
+    """A ``format`` with no handler is an unsupported-format envelope (R6.10, R13.5).
+
+    The tool's format guard runs before any storage read, so invoking the
+    shared-storage reader with a bogus format returns the ``unsupported_format``
+    envelope offline. This is also the code R13.5 reserves for a ``tfevents``
+    request were the format ever deferred entirely.
+    """
+    metrics_module = _import_metrics_tool_module()
+    result = asyncio.run(
+        metrics_module.metrics_from_shared_storage_file(
+            path="some/remote/path",
+            region="us-east-1",
+            field="loss",
+            format="bogus_format",
+        )
+    )
+    assert result["code"] == ErrorCode.UNSUPPORTED_FORMAT
+    assert result["details"]["format"] == "bogus_format"
+    assert "metrics" not in result

--- a/tests/test_metric_readers_localfs.py
+++ b/tests/test_metric_readers_localfs.py
@@ -1,0 +1,389 @@
+"""Tests for confining a supplied path to an allowlisted root directory.
+
+The local-file metric reader accepts a path into the host filesystem, so
+before it ever opens anything it must prove the path stays inside a single
+allowlisted root. ``resolve_within_root`` owns that proof. The contract it
+must uphold is a strict safety property: for any input, it either returns a
+fully resolved path that lives *inside* the resolved root, or it refuses with
+a containment error — it must never hand back a path that escaped the root.
+
+The property test below drives the helper with a wide range of relative and
+absolute paths built from ordinary names, ``.`` and ``..`` segments, and a
+symlink that points outside the root, then asserts that every outcome is
+either an in-root path or one of the three containment errors. A second
+property pins down that an unset (empty) root is always refused outright,
+without regard to the path supplied.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import builtins
+import contextlib
+import importlib
+import sys
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ``mcp/run_mcp.py`` puts ``mcp/`` on ``sys.path`` at runtime; mirror that
+# here so the pure ``metric_readers`` package imports the same way it does
+# in production, matching the convention used by the sibling tests.
+sys.path.insert(0, str(Path(__file__).parent.parent / "mcp"))
+
+from metric_readers.localfs import resolve_within_root  # noqa: E402
+from metric_readers.shape import ErrorCode, MetricReaderError  # noqa: E402
+
+# The stable codes that signal a path was refused for containment reasons.
+# Any one of them is an acceptable, safe outcome; a returned out-of-root path
+# is never acceptable.
+_CONTAINMENT_CODES = frozenset(
+    {
+        ErrorCode.PATH_TRAVERSAL_ESCAPE,
+        ErrorCode.SYMLINK_ESCAPE,
+        ErrorCode.LOCAL_ROOT_NOT_CONFIGURED,
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+# An ordinary path-segment name: 1..8 ASCII letters/digits, with no path
+# separator and no "." so it cannot itself encode traversal.
+_normal_segment = st.text(
+    alphabet=st.characters(whitelist_categories=("Ll", "Lu", "Nd"), max_codepoint=127),
+    min_size=1,
+    max_size=8,
+)
+
+# A single path segment drawn from ordinary names plus the three interesting
+# special tokens: ".." (lexical traversal), "." (no-op), and "link" — the name
+# of a symlink each example creates inside the root that points *outside* it,
+# so a path routed through it escapes via the link target rather than via text.
+_segment = st.one_of(
+    _normal_segment,
+    st.just(".."),
+    st.just("."),
+    st.just("link"),
+)
+
+# A path is 0..8 segments joined with "/"; ``absolute`` decides whether it is
+# anchored at "/" (almost always escaping a temp-dir root) or treated relative
+# to the root.
+_segments = st.lists(_segment, min_size=0, max_size=8)
+
+
+def _build_path(segments: list[str], absolute: bool) -> str:
+    """Join drawn segments into a single supplied-path string."""
+    joined = "/".join(segments)
+    return "/" + joined if absolute else joined
+
+
+# ---------------------------------------------------------------------------
+# Property: a returned path is always inside the resolved root
+# ---------------------------------------------------------------------------
+
+
+@settings(
+    max_examples=200,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
+)
+@given(segments=_segments, absolute=st.booleans())
+def test_resolve_within_root_returns_in_root_path_or_containment_error(
+    segments: list[str],
+    absolute: bool,
+) -> None:
+    """Every outcome is an in-root path or a containment error — never an escape.
+
+    For an arbitrary relative or absolute path (including ``..`` sequences and
+    a symlink that points outside the root), ``resolve_within_root`` against a
+    valid root directory must either:
+
+    * return a ``Path`` that is contained within the resolved root, or
+    * raise ``MetricReaderError`` with a containment code (path-traversal
+      escape, symlink escape, or root-not-configured).
+
+    It must never return a path that resolves outside the root.
+    """
+    with (
+        tempfile.TemporaryDirectory() as root_dir,
+        tempfile.TemporaryDirectory() as outside_dir,
+    ):
+        root = Path(root_dir)
+        real_root = root.resolve()
+
+        # A symlink inside the root whose target lives outside it, so a path
+        # that walks through "link" escapes by following the link rather than
+        # by lexical "..". On platforms without symlink support, drop the token.
+        link = root / "link"
+        try:
+            link.symlink_to(outside_dir)
+        except OSError, NotImplementedError:
+            segments = [s for s in segments if s != "link"]
+
+        supplied = _build_path(segments, absolute)
+
+        try:
+            result = resolve_within_root(supplied, str(root))
+        except MetricReaderError as exc:
+            assert exc.code in _CONTAINMENT_CODES
+        else:
+            # A successful return must be a path genuinely inside the root.
+            assert isinstance(result, Path)
+            assert result.is_relative_to(real_root)
+
+
+# ---------------------------------------------------------------------------
+# Property: an unset/empty root is always refused
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=200, deadline=None)
+@given(segments=_segments, absolute=st.booleans())
+def test_empty_root_always_reports_not_configured(
+    segments: list[str],
+    absolute: bool,
+) -> None:
+    """An empty root is refused with the not-configured code for any path.
+
+    When no allowlisted root is configured, the helper must never attempt to
+    resolve or return a path; it always raises the root-not-configured error
+    regardless of what path was supplied.
+    """
+    supplied = _build_path(segments, absolute)
+
+    with pytest.raises(MetricReaderError) as excinfo:
+        resolve_within_root(supplied, "")
+
+    assert excinfo.value.code == ErrorCode.LOCAL_ROOT_NOT_CONFIGURED
+
+
+# ===========================================================================
+# Local-file confinement integration tests (task 8.7)
+# ===========================================================================
+#
+# The property tests above pin down the *pure* helper. These integration tests
+# drive confinement through the gated reader tool itself —
+# ``mcp/tools/metrics.py::metrics_from_local_file`` — which reads
+# ``GCO_METRICS_LOCAL_ROOT`` from ``os.environ`` once at the boundary and calls
+# ``localfs.resolve_within_root``. Because the tool is defined inside an
+# ``if is_enabled("GCO_ENABLE_LOCAL_METRICS")`` block, it only exists after the
+# flag is set and the module is (re)imported. The three required cases assert
+# both the correct Tool_Error_Envelope code AND that **no file outside the
+# Local_Root is ever opened** (Requirements 18.8, 18.9, 18.10).
+
+
+@contextlib.contextmanager
+def _local_file_tool(local_root: str | None) -> Iterator:
+    """Yield the gated ``tools.metrics`` module loaded under the flag.
+
+    Sets ``GCO_ENABLE_LOCAL_METRICS`` so the decorator inside the
+    ``if is_enabled(...)`` block fires, points ``GCO_METRICS_LOCAL_ROOT`` at
+    ``local_root`` (or removes it when ``None``, to model an unset root), then
+    re-imports ``tools.metrics`` so the gated ``metrics_from_local_file`` tool
+    is bound. The module is yielded (not just the tool) so a test can spy on
+    the ``_read_local_file`` reader seam to prove no read is attempted. On exit
+    the tool is force-unregistered from the module-level FastMCP singleton —
+    mirroring the cleanup the destructive-gating tests use — so this gated
+    registration never leaks into a sibling test's tool-registry snapshot.
+    """
+    # ``tools.metrics`` injects ``mcp/`` onto sys.path at import time, but the
+    # property tests above already put it there; importing run-time deps below
+    # resolves against that same entry.
+    import os
+
+    prev_flag = os.environ.get("GCO_ENABLE_LOCAL_METRICS")
+    prev_root = os.environ.get("GCO_METRICS_LOCAL_ROOT")
+    os.environ["GCO_ENABLE_LOCAL_METRICS"] = "true"
+    if local_root is None:
+        os.environ.pop("GCO_METRICS_LOCAL_ROOT", None)
+    else:
+        os.environ["GCO_METRICS_LOCAL_ROOT"] = local_root
+
+    # Re-import under the flag so the gated decorator runs and binds the tool.
+    if "tools.metrics" in sys.modules:
+        del sys.modules["tools.metrics"]
+    metrics_module = importlib.import_module("tools.metrics")
+
+    try:
+        yield metrics_module
+    finally:
+        # Drop the gated registration off the shared FastMCP singleton so the
+        # canonical tool-name/tool-count snapshots in sibling tests stay clean.
+        with contextlib.suppress(Exception):
+            import server
+
+            server.mcp.local_provider.remove_tool("metrics_from_local_file")
+        # Restore the environment we mutated.
+        for key, prev in (
+            ("GCO_ENABLE_LOCAL_METRICS", prev_flag),
+            ("GCO_METRICS_LOCAL_ROOT", prev_root),
+        ):
+            if prev is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = prev
+
+
+@contextlib.contextmanager
+def _guarded_reader(metrics_module) -> Iterator[tuple[list[Path], list[str]]]:
+    """Trip-wire any read of a confined artifact, recording paths opened.
+
+    Confinement must reject before the reader ever touches the filesystem, so
+    two seams are watched at once:
+
+    * ``tools.metrics._read_local_file`` — the only function that opens a
+      confined artifact. It is replaced with a recorder that captures the
+      resolved path it was handed and then delegates to the real reader, so a
+      test can assert it was **never reached** in an escape/unconfigured case.
+    * ``builtins.open`` — captures the raw path of every file actually opened
+      while active, so a test can assert a specific out-of-root target was
+      never opened.
+
+    Yields ``(read_calls, opened)``: the resolved paths handed to the reader
+    seam, and the raw paths passed to ``open``.
+    """
+    read_calls: list[Path] = []
+    opened: list[str] = []
+
+    real_reader = metrics_module._read_local_file
+
+    def _recording_reader(resolved_path, path, max_bytes):  # type: ignore[no-untyped-def]
+        read_calls.append(resolved_path)
+        return real_reader(resolved_path, path, max_bytes)
+
+    real_open = builtins.open
+
+    def _recording_open(file, *args, **kwargs):  # type: ignore[no-untyped-def]
+        opened.append(str(file))
+        return real_open(file, *args, **kwargs)
+
+    metrics_module._read_local_file = _recording_reader
+    builtins.open = _recording_open
+    try:
+        yield read_calls, opened
+    finally:
+        builtins.open = real_open
+        metrics_module._read_local_file = real_reader
+
+
+def _opened_resolved(opened: list[str]) -> set[Path]:
+    """Resolve every recorded ``open`` path for membership comparisons."""
+    resolved: set[Path] = set()
+    for raw in opened:
+        with contextlib.suppress(OSError, ValueError):
+            resolved.add(Path(raw).resolve())
+    return resolved
+
+
+def test_traversal_escape_returns_envelope_and_reads_nothing(tmp_path: Path) -> None:
+    """A ``..``-traversal path escaping the root yields ``path_traversal_escape``.
+
+    Using ``tmp_path`` as the Local_Root, a supplied path whose ``..`` segments
+    climb out of the root must be refused with the path-traversal-escape code,
+    carry the supplied path in the envelope details, return **no** canonical
+    ``metrics`` shape, and read nothing out of root (Requirement 18.8). The
+    out-of-root target the path resolves to is proven never opened, and the
+    reader seam is proven never reached.
+    """
+    supplied = "../../etc/passwd"
+    # The path the supplied traversal resolves to, lexically, from the root.
+    escape_target = (tmp_path / supplied).resolve()
+
+    with (
+        _local_file_tool(str(tmp_path)) as metrics_module,
+        _guarded_reader(metrics_module) as (read_calls, opened),
+    ):
+        result = asyncio.run(
+            metrics_module.metrics_from_local_file(path=supplied, field="loss", format="json")
+        )
+
+    assert result["code"] == ErrorCode.PATH_TRAVERSAL_ESCAPE
+    assert result["details"]["supplied_path"] == supplied
+    # An escape never produces the Canonical_Metrics_Shape.
+    assert "metrics" not in result
+    # The reader seam was never reached, so no confined artifact was read.
+    assert read_calls == []
+    # The out-of-root target the traversal pointed at was never opened.
+    assert escape_target not in _opened_resolved(opened)
+
+
+def test_symlink_escape_returns_envelope_and_never_reads_target(tmp_path: Path) -> None:
+    """A symlink inside the root pointing outside yields ``symlink_escape``.
+
+    A real symlink is created *inside* the Local_Root whose target lives
+    *outside* it; the in-root symlink path is supplied. The reader must refuse
+    with the symlink-escape code, carry the supplied path in the details,
+    return **no** canonical ``metrics`` shape, and — critically — never open
+    the link target file nor reach the reader seam (Requirement 18.9).
+    """
+    # The escape target lives outside the root, in a sibling temp dir that the
+    # in-root symlink points at. Writing a real file there lets the spy prove
+    # it is never opened.
+    with tempfile.TemporaryDirectory() as outside_dir:
+        outside = Path(outside_dir)
+        secret = outside / "secret.json"
+        secret.write_text('{"loss": 0.5}')
+
+        link = tmp_path / "link"
+        try:
+            link.symlink_to(outside)
+        except OSError, NotImplementedError:
+            pytest.skip("platform does not support symlinks")
+
+        supplied = "link/secret.json"
+
+        with (
+            _local_file_tool(str(tmp_path)) as metrics_module,
+            _guarded_reader(metrics_module) as (read_calls, opened),
+        ):
+            result = asyncio.run(
+                metrics_module.metrics_from_local_file(path=supplied, field="loss", format="json")
+            )
+
+        assert result["code"] == ErrorCode.SYMLINK_ESCAPE
+        assert result["details"]["supplied_path"] == supplied
+        assert "metrics" not in result
+        # The reader seam was never reached.
+        assert read_calls == []
+        # The link target must never have been opened, by either name.
+        opened_resolved = _opened_resolved(opened)
+        assert str(secret) not in opened
+        assert secret.resolve() not in opened_resolved
+
+
+def test_unconfigured_root_returns_envelope_and_reads_nothing(tmp_path: Path) -> None:
+    """An unset/empty Local_Root yields ``local_root_not_configured``.
+
+    With the gate enabled but ``GCO_METRICS_LOCAL_ROOT`` unset, the reader must
+    refuse with the not-configured code, return **no** canonical ``metrics``
+    shape, and read no file at all (Requirement 18.10). ``tmp_path`` holds a
+    real metrics file the reader would have read had it not refused first;
+    proving that file is never opened and the reader seam is never reached
+    shows the refusal happens before any read.
+    """
+    present = tmp_path / "metrics.json"
+    present.write_text('{"loss": 0.25}')
+
+    # local_root=None models the unset env var while the gate stays on.
+    with (
+        _local_file_tool(None) as metrics_module,
+        _guarded_reader(metrics_module) as (read_calls, opened),
+    ):
+        result = asyncio.run(
+            metrics_module.metrics_from_local_file(path=str(present), field="loss", format="json")
+        )
+
+    assert result["code"] == ErrorCode.LOCAL_ROOT_NOT_CONFIGURED
+    assert "metrics" not in result
+    # The reader seam was never reached, so nothing was read.
+    assert read_calls == []
+    # The file that exists under tmp_path was never opened.
+    assert str(present) not in opened
+    assert present.resolve() not in _opened_resolved(opened)

--- a/tests/test_metric_readers_localfs.py
+++ b/tests/test_metric_readers_localfs.py
@@ -165,7 +165,7 @@ def test_empty_root_always_reports_not_configured(
 
 
 # ===========================================================================
-# Local-file confinement integration tests (task 8.7)
+# Local-file confinement integration tests
 # ===========================================================================
 #
 # The property tests above pin down the *pure* helper. These integration tests
@@ -176,7 +176,7 @@ def test_empty_root_always_reports_not_configured(
 # ``if is_enabled("GCO_ENABLE_LOCAL_METRICS")`` block, it only exists after the
 # flag is set and the module is (re)imported. The three required cases assert
 # both the correct Tool_Error_Envelope code AND that **no file outside the
-# Local_Root is ever opened** (Requirements 18.8, 18.9, 18.10).
+# Local_Root is ever opened**.
 
 
 @contextlib.contextmanager
@@ -288,7 +288,7 @@ def test_traversal_escape_returns_envelope_and_reads_nothing(tmp_path: Path) -> 
     Using ``tmp_path`` as the Local_Root, a supplied path whose ``..`` segments
     climb out of the root must be refused with the path-traversal-escape code,
     carry the supplied path in the envelope details, return **no** canonical
-    ``metrics`` shape, and read nothing out of root (Requirement 18.8). The
+    ``metrics`` shape, and read nothing out of root. The
     out-of-root target the path resolves to is proven never opened, and the
     reader seam is proven never reached.
     """
@@ -321,7 +321,7 @@ def test_symlink_escape_returns_envelope_and_never_reads_target(tmp_path: Path) 
     *outside* it; the in-root symlink path is supplied. The reader must refuse
     with the symlink-escape code, carry the supplied path in the details,
     return **no** canonical ``metrics`` shape, and — critically — never open
-    the link target file nor reach the reader seam (Requirement 18.9).
+    the link target file nor reach the reader seam.
     """
     # The escape target lives outside the root, in a sibling temp dir that the
     # in-root symlink points at. Writing a real file there lets the spy prove
@@ -363,7 +363,7 @@ def test_unconfigured_root_returns_envelope_and_reads_nothing(tmp_path: Path) ->
 
     With the gate enabled but ``GCO_METRICS_LOCAL_ROOT`` unset, the reader must
     refuse with the not-configured code, return **no** canonical ``metrics``
-    shape, and read no file at all (Requirement 18.10). ``tmp_path`` holds a
+    shape, and read no file at all. ``tmp_path`` holds a
     real metrics file the reader would have read had it not refused first;
     proving that file is never opened and the reader seam is never reached
     shows the refusal happens before any read.

--- a/tests/test_metric_readers_logs.py
+++ b/tests/test_metric_readers_logs.py
@@ -1,0 +1,183 @@
+"""Tests for pulling a scalar out of a job's log lines.
+
+A job prints its progress to stdout in one of two shapes: a structured JSON
+object per line, or free text a regular expression can pick apart. The log
+helpers turn either shape into an ordered list of candidate values, and a
+final coercion step turns one of those candidates into a real number.
+
+These tests pin down three behaviors that matter most:
+
+* JSON-key extraction tolerates noise — a line that is not a JSON object
+  contributes nothing and never raises, while well-formed object lines still
+  yield their value.
+* Regex extraction collects the first capture group from each matching line
+  and ignores lines that do not match.
+* Coercion of a value that is not a real number fails with a structured error
+  that records the offending raw value.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+# ``mcp/run_mcp.py`` puts ``mcp/`` on ``sys.path`` at runtime; mirror that
+# here so the pure ``metric_readers`` package imports the same way it does
+# in production, matching the convention used by the sibling tests.
+sys.path.insert(0, str(Path(__file__).parent.parent / "mcp"))
+
+from metric_readers.logs import (  # noqa: E402
+    coerce_scalar,
+    extract_by_json_key,
+    extract_by_regex,
+)
+from metric_readers.shape import ErrorCode, MetricReaderError  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# JSON-key extraction: non-object lines are skipped, object lines still extract
+# ---------------------------------------------------------------------------
+
+
+def test_non_json_lines_are_skipped_during_key_extraction() -> None:
+    """Lines that are not JSON objects contribute nothing; object lines still extract.
+
+    The input mixes well-formed object lines carrying the key with every kind
+    of line the parser must tolerate: truncated/garbage JSON, a bare number, a
+    bare string, a JSON array, a JSON ``null``, and an empty line. Only the
+    values from the two valid object lines come back, in order.
+    """
+    lines = [
+        '{"loss": 0.5}',  # valid object, has the key
+        "not json at all",  # not parseable as JSON
+        "{bad json",  # truncated JSON
+        "42",  # bare number, not an object
+        '"just a string"',  # bare JSON string, not an object
+        "[1, 2, 3]",  # JSON array, not an object
+        "null",  # JSON null, not an object
+        "",  # empty line
+        '{"loss": 0.25}',  # valid object, has the key
+    ]
+
+    assert extract_by_json_key(lines, "loss") == [0.5, 0.25]
+
+
+def test_dotted_key_resolves_nested_json_objects() -> None:
+    """A dotted key walks nested objects segment by segment."""
+    lines = [
+        '{"metrics": {"loss": 1.0}}',
+        '{"metrics": {"loss": 0.75}}',
+    ]
+
+    assert extract_by_json_key(lines, "metrics.loss") == [1.0, 0.75]
+
+
+def test_lines_missing_the_key_path_contribute_nothing() -> None:
+    """Object lines that do not resolve the full key path are skipped.
+
+    Lines whose object lacks the key, or whose intermediate segment is not an
+    object, drop out — only the line that resolves the whole path remains.
+    """
+    lines = [
+        '{"accuracy": 0.9}',  # object, but missing the key entirely
+        '{"metrics": 5}',  # intermediate segment is not an object
+        '{"metrics": {"loss": 0.1}}',  # resolves the full path
+    ]
+
+    assert extract_by_json_key(lines, "metrics.loss") == [0.1]
+
+
+def test_key_extraction_returns_empty_list_for_no_lines() -> None:
+    """No input lines yields no candidate values."""
+    assert extract_by_json_key([], "loss") == []
+
+
+# ---------------------------------------------------------------------------
+# Regex extraction: first capture group from matching lines, others ignored
+# ---------------------------------------------------------------------------
+
+
+def test_regex_extraction_collects_first_capture_group() -> None:
+    """Matching lines yield their first capture group; non-matching lines are ignored.
+
+    The pattern captures the numeric text after ``loss=``. The two lines that
+    contain the token contribute their captured substrings in order; the line
+    without it contributes nothing.
+    """
+    pattern = re.compile(r"loss=([0-9.]+)")
+    lines = [
+        "step 1 loss=0.50 acc=0.9",
+        "no metric on this line",
+        "step 2 loss=0.25 acc=0.95",
+    ]
+
+    assert extract_by_regex(lines, pattern) == ["0.50", "0.25"]
+
+
+def test_regex_extraction_captures_only_the_first_group() -> None:
+    """When a pattern defines several groups, only the first capture is collected."""
+    pattern = re.compile(r"loss=([0-9.]+) acc=([0-9.]+)")
+    lines = ["loss=0.3 acc=0.8"]
+
+    assert extract_by_regex(lines, pattern) == ["0.3"]
+
+
+def test_regex_extraction_returns_empty_list_when_nothing_matches() -> None:
+    """A pattern that matches no line yields no candidate values."""
+    pattern = re.compile(r"loss=([0-9.]+)")
+    lines = ["nothing here", "still nothing"]
+
+    assert extract_by_regex(lines, pattern) == []
+
+
+# ---------------------------------------------------------------------------
+# coerce_scalar: success cases and the non-numeric error with the raw value
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_scalar_accepts_numbers_and_numeric_strings() -> None:
+    """Real numbers pass through and numeric strings parse to numbers."""
+    assert coerce_scalar(42) == 42
+    assert coerce_scalar(0.5) == 0.5
+    assert coerce_scalar("7") == 7
+    assert coerce_scalar("3.14") == 3.14
+
+
+def test_coerce_scalar_raises_non_numeric_for_unparseable_string() -> None:
+    """A string that is not a number raises the non-numeric error with the raw value."""
+    with pytest.raises(MetricReaderError) as exc_info:
+        coerce_scalar("not-a-number")
+
+    error = exc_info.value
+    assert error.code == ErrorCode.NON_NUMERIC_VALUE
+    assert error.details is not None
+    assert error.details["raw"] == "not-a-number"
+
+
+def test_coerce_scalar_error_records_offending_non_string_value() -> None:
+    """A non-string, non-numeric value is reported with the offending raw value.
+
+    ``None`` is neither a number nor a parseable string, so coercion fails and
+    the structured error carries the original value plus its type name.
+    """
+    with pytest.raises(MetricReaderError) as exc_info:
+        coerce_scalar(None)
+
+    error = exc_info.value
+    assert error.code == ErrorCode.NON_NUMERIC_VALUE
+    assert error.details is not None
+    assert error.details["raw"] is None
+    assert error.details["type"] == "NoneType"
+
+
+def test_coerce_scalar_rejects_booleans_with_raw_value() -> None:
+    """A boolean is not a metric value and is reported as non-numeric."""
+    with pytest.raises(MetricReaderError) as exc_info:
+        coerce_scalar(True)
+
+    error = exc_info.value
+    assert error.code == ErrorCode.NON_NUMERIC_VALUE
+    assert error.details is not None
+    assert error.details["raw"] is True

--- a/tests/test_metric_readers_observe.py
+++ b/tests/test_metric_readers_observe.py
@@ -1,0 +1,349 @@
+"""Observe_Phase merge-contract integration test.
+
+This module proves the load-bearing claim of the whole feature: a metric-reader
+tool's return value flows through the **real, unmodified** Mission engine and
+lands where a ``metric_threshold`` criterion can read it — and an error
+envelope flows through the same path and leaves the criterion ``inconclusive``
+rather than failing the loop.
+
+Nothing here patches, subclasses, or otherwise alters
+``mcp/mission/engine.py``. The test imports ``MissionEngine`` as-is and drives
+two surfaces of it:
+
+* the private :meth:`MissionEngine._build_observation` /
+  :meth:`MissionEngine._evaluate_metric_threshold` pair directly, so the merge
+  contract is pinned at the smallest possible scope (the exact
+  ``metrics.update(result_metrics)`` merge the design quotes); and
+* a full :meth:`MissionEngine.run_iteration` session against a stub dispatcher
+  that returns a reader-shaped result, mirroring the existing
+  ``test_mission_e2e_*`` modules, so the merge is also confirmed end-to-end
+  through the production Observe → Evaluate path.
+
+The reader-shaped inputs are built with the **real** reader helpers
+``metric_readers.shape.metrics_result`` and ``metric_readers.shape.error_envelope``
+so the test exercises the genuine wire shapes, not hand-rolled look-alikes.
+
+Validates the merge contract from the design's "merge contract" section and
+Requirements 1.6 (the merged Observation resolves ``metrics.<name>`` to the
+emitted Numeric_Value), 14.4 (an error envelope has no top-level ``metrics``
+key, so the criterion is left inconclusive), and 16.4 (the reader result is
+consumable by a ``metric_threshold`` criterion against the engine as-is).
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ``mcp/run_mcp.py`` puts ``mcp/`` on ``sys.path`` at runtime; pytest mirrors
+# that before any ``mission.*`` / ``metric_readers.*`` import resolves. Same
+# idiom used by every other ``test_mission_*`` and ``test_metric_readers_*``
+# module.
+sys.path.insert(0, str(Path(__file__).parent.parent / "mcp"))
+
+from metric_readers.shape import error_envelope, metrics_result  # noqa: E402
+from mission import SCHEMA_VERSION  # noqa: E402
+from mission.engine import MissionEngine  # noqa: E402
+from mission.state import FilesystemBackend  # noqa: E402
+from mission.types import ToolCallRecord  # noqa: E402
+
+# The metric key the reader emits and the criterion reads back by dot-path.
+_METRIC_KEY = "loss"
+# The Numeric_Value the reader emits. Chosen so a ``< 0.5`` threshold is met
+# and a ``< 0.4`` threshold is unmet, exercising both decided outcomes.
+_METRIC_VALUE = 0.42
+# The dot-path a ``metric_threshold`` criterion uses to resolve the merged
+# value: ``metrics.<caller_supplied_name>``.
+_METRIC_PATH = f"metrics.{_METRIC_KEY}"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _minimal_engine() -> MissionEngine:
+    """Construct a ``MissionEngine`` adequate for the direct merge tests.
+
+    ``_build_observation`` and ``_evaluate_metric_threshold`` touch neither the
+    backend nor the dispatcher — the former only reads ``self.now()`` and calls
+    the static annotator, the latter is a pure staticmethod. We still pass a
+    real (if unused) async dispatcher so the construction matches the engine's
+    declared protocol rather than relying on ``None`` slipping through.
+    """
+
+    async def _noop_dispatcher(tool_name: str, args: dict[str, Any], ctx: Any) -> Any:
+        return None
+
+    return MissionEngine(
+        backend=None,
+        tool_dispatcher=_noop_dispatcher,
+        sampling_callable=None,
+        sandbox_runner=None,
+    )
+
+
+def _ok_call(result_summary: Any, tool_name: str) -> ToolCallRecord:
+    """Wrap a tool result as a successful :class:`ToolCallRecord`.
+
+    The Observe_Phase merge only fires for a call whose ``status`` is ``"ok"``
+    and whose ``result_summary`` is a dict carrying a top-level ``metrics``
+    dict — exactly the shape a reader tool returns. An error envelope is also
+    a successful return (the tool did not raise; it reported a structured
+    failure), so the error-envelope case below uses ``status="ok"`` too. That
+    is the whole point: the merge, not the call status, is what skips the
+    envelope.
+    """
+    return {
+        "tool_name": tool_name,
+        "args": {},
+        "status": "ok",
+        "result_summary": result_summary,
+        "duration_ms": 1,
+    }
+
+
+def _metric_threshold_criterion(op: str, target: float) -> dict[str, Any]:
+    """Build a ``metric_threshold`` criterion reading ``metrics.loss``."""
+    return {
+        "criterion_id": f"loss_{op}_{target}",
+        "kind": "metric_threshold",
+        "required": True,
+        "metric": _METRIC_PATH,
+        "op": op,
+        "target": target,
+    }
+
+
+def _make_session(session_id: str, op: str, target: float) -> dict[str, Any]:
+    """Build a one-criterion Mission session for the end-to-end driver.
+
+    Mirrors the hand-built ``SessionState`` dicts in
+    ``tests/test_mission_e2e_budget.py``: the typed fields are consumed by the
+    engine directly (validators are exercised in their own module). The single
+    criterion is a ``metric_threshold`` reading ``metrics.loss`` so the
+    Observe_Phase merge is what decides its outcome.
+    """
+    return {
+        "version": SCHEMA_VERSION,
+        "session_id": session_id,
+        "directive_text": "Observe a reader-emitted scalar via metric_threshold.",
+        "criteria": [_metric_threshold_criterion(op, target)],
+        "budget": {"max_iterations": 1, "max_wall_clock_seconds": 600},
+        "tool_allowlist": ["metrics_cloudwatch_get"],
+        "checkpoint_cadence": {"kind": "every_iteration"},
+        "stagnation_threshold": 100,
+        "use_sampling": False,
+        "allow_scripted_strategies": False,
+        "status": "pending",
+        "created_at": "2025-01-01T00:00:00Z",
+        "iterations": [],
+        "no_progress_counter": 0,
+    }
+
+
+def _reader_result_dispatcher(result: dict[str, Any]) -> Any:
+    """Return an async dispatcher that always emits ``result``.
+
+    Stands in for the FastMCP tool dispatcher: the engine's Execute_Phase
+    invokes it and stashes the return as the call's ``result_summary``, which
+    the Observe_Phase then merges. ``tool_name`` / ``args`` are ignored because
+    the engine alone enforces Tool_Allowlist gating before this is called.
+    """
+
+    async def dispatcher(tool_name: str, args: dict[str, Any], ctx: Any) -> dict[str, Any]:
+        return dict(result)
+
+    return dispatcher
+
+
+# ---------------------------------------------------------------------------
+# Direct merge-contract tests (smallest scope)
+# ---------------------------------------------------------------------------
+
+
+class TestObserveMergeContractDirect:
+    """Pin the merge contract at the ``_build_observation`` boundary."""
+
+    def test_success_result_merges_and_resolves_by_dot_path(self) -> None:
+        """A reader success result lands at ``observation['metrics']['loss']``.
+
+        The reader emits the canonical shape with provenance *outside*
+        ``metrics``; after the engine's permissive
+        ``metrics.update(result_metrics)`` merge, the dot-path the criterion
+        uses resolves to exactly the emitted Numeric_Value, and the provenance
+        never pollutes the merged ``metrics`` dict. (Requirement 1.6)
+        """
+        engine = _minimal_engine()
+        result = metrics_result(
+            _METRIC_KEY,
+            _METRIC_VALUE,
+            source="cloudwatch:Loss",
+            region="us-east-1",
+        )
+        # Sanity: the reader keeps provenance out of the metrics object.
+        assert result["metrics"] == {_METRIC_KEY: _METRIC_VALUE}
+        assert "source" in result and "source" not in result["metrics"]
+
+        observation = engine._build_observation(
+            [_ok_call(result, "metrics_cloudwatch_get")],
+            datetime.now(UTC),
+        )
+
+        assert observation["metrics"][_METRIC_KEY] == _METRIC_VALUE
+        # Only the numeric value made it into the merged metrics dict.
+        assert observation["metrics"] == {_METRIC_KEY: _METRIC_VALUE}
+
+    def test_merged_value_evaluates_met_and_unmet(self) -> None:
+        """The merged value drives a ``metric_threshold`` criterion both ways.
+
+        ``metrics.loss < 0.5`` is met and ``metrics.loss < 0.4`` is unmet for
+        the emitted 0.42, and the evidence the engine returns is the merged
+        Numeric_Value itself. (Requirements 1.6, 16.4)
+        """
+        engine = _minimal_engine()
+        observation = engine._build_observation(
+            [_ok_call(metrics_result(_METRIC_KEY, _METRIC_VALUE), "metrics_cloudwatch_get")],
+            datetime.now(UTC),
+        )
+
+        met_status, met_evidence = MissionEngine._evaluate_metric_threshold(
+            _metric_threshold_criterion("<", 0.5), observation
+        )
+        assert met_status == "met"
+        assert met_evidence == _METRIC_VALUE
+
+        unmet_status, unmet_evidence = MissionEngine._evaluate_metric_threshold(
+            _metric_threshold_criterion("<", 0.4), observation
+        )
+        assert unmet_status == "unmet"
+        assert unmet_evidence == _METRIC_VALUE
+
+    def test_error_envelope_is_skipped_and_criterion_inconclusive(self) -> None:
+        """An error envelope merges no metric and leaves the criterion undecided.
+
+        The envelope ``{"code", "details"}`` has no top-level ``metrics`` key,
+        so the permissive merge skips it: the merged ``metrics`` dict stays
+        empty and the dot-path lookup misses, so the criterion is
+        ``inconclusive`` (with ``metric_path_missing`` evidence) rather than
+        failing the loop. (Requirement 14.4)
+        """
+        engine = _minimal_engine()
+        envelope = error_envelope("file_not_found", path="x")
+        # Sanity: the envelope structurally carries no top-level metrics key.
+        assert "metrics" not in envelope
+        assert envelope["code"] == "file_not_found"
+
+        observation = engine._build_observation(
+            [_ok_call(envelope, "metrics_from_shared_storage_file")],
+            datetime.now(UTC),
+        )
+        # Nothing was merged.
+        assert observation["metrics"] == {}
+
+        status, evidence = MissionEngine._evaluate_metric_threshold(
+            _metric_threshold_criterion("<", 0.5), observation
+        )
+        assert status == "inconclusive"
+        assert isinstance(evidence, str)
+        assert evidence.startswith("metric_path_missing:")
+
+
+# ---------------------------------------------------------------------------
+# End-to-end driver tests (full run_iteration through the engine as-is)
+# ---------------------------------------------------------------------------
+
+
+class TestObserveMergeContractEndToEnd:
+    """Confirm the merge through the production Observe → Evaluate path."""
+
+    @pytest.mark.mission_e2e
+    async def test_success_result_drives_criterion_met(self, tmp_path: Path) -> None:
+        """A reader success result run through ``run_iteration`` evaluates met.
+
+        The stub dispatcher returns the canonical reader shape; the unmodified
+        engine merges it in Observe_Phase and evaluates the ``metrics.loss <
+        0.5`` criterion as met in the iteration's ``criteria_evaluation``.
+        (Requirements 1.6, 16.4)
+        """
+        backend = FilesystemBackend(root=tmp_path)
+        session = _make_session("sess-observe-met", "<", 0.5)
+        backend.save_session(session)
+
+        engine = MissionEngine(
+            backend=backend,
+            tool_dispatcher=_reader_result_dispatcher(
+                metrics_result(_METRIC_KEY, _METRIC_VALUE, source="cloudwatch", region="us-east-1")
+            ),
+            sampling_callable=None,
+            sandbox_runner=None,
+        )
+
+        record = await engine.run_iteration(session["session_id"])
+
+        observation = record["observation"]
+        assert observation["metrics"][_METRIC_KEY] == _METRIC_VALUE
+
+        results = record["criteria_evaluation"]
+        assert len(results) == 1
+        assert results[0]["status"] == "met"
+        assert results[0]["evidence"] == _METRIC_VALUE
+
+    @pytest.mark.mission_e2e
+    async def test_success_result_drives_criterion_unmet(self, tmp_path: Path) -> None:
+        """The same merged value evaluates unmet against a tighter threshold.
+
+        ``metrics.loss < 0.4`` is unmet for the emitted 0.42 — the merge is
+        identical; only the target differs. (Requirements 1.6, 16.4)
+        """
+        backend = FilesystemBackend(root=tmp_path)
+        session = _make_session("sess-observe-unmet", "<", 0.4)
+        backend.save_session(session)
+
+        engine = MissionEngine(
+            backend=backend,
+            tool_dispatcher=_reader_result_dispatcher(
+                metrics_result(_METRIC_KEY, _METRIC_VALUE, source="cloudwatch", region="us-east-1")
+            ),
+            sampling_callable=None,
+            sandbox_runner=None,
+        )
+
+        record = await engine.run_iteration(session["session_id"])
+
+        assert record["observation"]["metrics"][_METRIC_KEY] == _METRIC_VALUE
+        results = record["criteria_evaluation"]
+        assert len(results) == 1
+        assert results[0]["status"] == "unmet"
+        assert results[0]["evidence"] == _METRIC_VALUE
+
+    @pytest.mark.mission_e2e
+    async def test_error_envelope_drives_criterion_inconclusive(self, tmp_path: Path) -> None:
+        """A reader error envelope run through ``run_iteration`` is inconclusive.
+
+        The dispatcher returns an error envelope (no top-level ``metrics``); the
+        unmodified engine merges nothing, so the criterion is ``inconclusive``
+        and the loop is never failed on bad data. (Requirement 14.4)
+        """
+        backend = FilesystemBackend(root=tmp_path)
+        session = _make_session("sess-observe-inconclusive", "<", 0.5)
+        backend.save_session(session)
+
+        engine = MissionEngine(
+            backend=backend,
+            tool_dispatcher=_reader_result_dispatcher(error_envelope("file_not_found", path="x")),
+            sampling_callable=None,
+            sandbox_runner=None,
+        )
+
+        record = await engine.run_iteration(session["session_id"])
+
+        # No metric was merged from the envelope.
+        assert record["observation"]["metrics"] == {}
+        results = record["criteria_evaluation"]
+        assert len(results) == 1
+        assert results[0]["status"] == "inconclusive"

--- a/tests/test_metric_readers_observe.py
+++ b/tests/test_metric_readers_observe.py
@@ -13,7 +13,7 @@ two surfaces of it:
 * the private :meth:`MissionEngine._build_observation` /
   :meth:`MissionEngine._evaluate_metric_threshold` pair directly, so the merge
   contract is pinned at the smallest possible scope (the exact
-  ``metrics.update(result_metrics)`` merge the design quotes); and
+  ``metrics.update(result_metrics)`` merge the engine performs); and
 * a full :meth:`MissionEngine.run_iteration` session against a stub dispatcher
   that returns a reader-shaped result, mirroring the existing
   ``test_mission_e2e_*`` modules, so the merge is also confirmed end-to-end
@@ -23,11 +23,11 @@ The reader-shaped inputs are built with the **real** reader helpers
 ``metric_readers.shape.metrics_result`` and ``metric_readers.shape.error_envelope``
 so the test exercises the genuine wire shapes, not hand-rolled look-alikes.
 
-Validates the merge contract from the design's "merge contract" section and
-Requirements 1.6 (the merged Observation resolves ``metrics.<name>`` to the
-emitted Numeric_Value), 14.4 (an error envelope has no top-level ``metrics``
-key, so the criterion is left inconclusive), and 16.4 (the reader result is
-consumable by a ``metric_threshold`` criterion against the engine as-is).
+Validates the merge contract: the merged Observation resolves
+``metrics.<name>`` to the emitted Numeric_Value; an error envelope has no
+top-level ``metrics`` key, so the criterion is left inconclusive; and the
+reader result is consumable by a ``metric_threshold`` criterion against the
+engine as-is.
 """
 
 from __future__ import annotations
@@ -176,7 +176,7 @@ class TestObserveMergeContractDirect:
         ``metrics``; after the engine's permissive
         ``metrics.update(result_metrics)`` merge, the dot-path the criterion
         uses resolves to exactly the emitted Numeric_Value, and the provenance
-        never pollutes the merged ``metrics`` dict. (Requirement 1.6)
+        never pollutes the merged ``metrics`` dict.
         """
         engine = _minimal_engine()
         result = metrics_result(
@@ -203,7 +203,7 @@ class TestObserveMergeContractDirect:
 
         ``metrics.loss < 0.5`` is met and ``metrics.loss < 0.4`` is unmet for
         the emitted 0.42, and the evidence the engine returns is the merged
-        Numeric_Value itself. (Requirements 1.6, 16.4)
+        Numeric_Value itself.
         """
         engine = _minimal_engine()
         observation = engine._build_observation(
@@ -230,7 +230,7 @@ class TestObserveMergeContractDirect:
         so the permissive merge skips it: the merged ``metrics`` dict stays
         empty and the dot-path lookup misses, so the criterion is
         ``inconclusive`` (with ``metric_path_missing`` evidence) rather than
-        failing the loop. (Requirement 14.4)
+        failing the loop.
         """
         engine = _minimal_engine()
         envelope = error_envelope("file_not_found", path="x")
@@ -268,7 +268,6 @@ class TestObserveMergeContractEndToEnd:
         The stub dispatcher returns the canonical reader shape; the unmodified
         engine merges it in Observe_Phase and evaluates the ``metrics.loss <
         0.5`` criterion as met in the iteration's ``criteria_evaluation``.
-        (Requirements 1.6, 16.4)
         """
         backend = FilesystemBackend(root=tmp_path)
         session = _make_session("sess-observe-met", "<", 0.5)
@@ -298,7 +297,7 @@ class TestObserveMergeContractEndToEnd:
         """The same merged value evaluates unmet against a tighter threshold.
 
         ``metrics.loss < 0.4`` is unmet for the emitted 0.42 — the merge is
-        identical; only the target differs. (Requirements 1.6, 16.4)
+        identical; only the target differs.
         """
         backend = FilesystemBackend(root=tmp_path)
         session = _make_session("sess-observe-unmet", "<", 0.4)
@@ -327,7 +326,7 @@ class TestObserveMergeContractEndToEnd:
 
         The dispatcher returns an error envelope (no top-level ``metrics``); the
         unmodified engine merges nothing, so the criterion is ``inconclusive``
-        and the loop is never failed on bad data. (Requirement 14.4)
+        and the loop is never failed on bad data.
         """
         backend = FilesystemBackend(root=tmp_path)
         session = _make_session("sess-observe-inconclusive", "<", 0.5)

--- a/tests/test_metric_readers_shape.py
+++ b/tests/test_metric_readers_shape.py
@@ -320,7 +320,7 @@ def _names_with_whitespace(draw: st.DrawFn) -> str:
     return left + draw(_whitespace_chars) + right
 
 
-# An invalid metric name spanning all four rejection reasons in R1.7: empty,
+# An invalid metric name spanning all four rejection reasons: empty,
 # longer than 128 characters, containing a "." separator, or containing
 # whitespace.
 _invalid_metric_names = st.one_of(
@@ -339,7 +339,6 @@ _classified_metric_names = st.one_of(
 )
 
 
-# Feature: mission-metric-reader-tools, Property 3: Metric-name validator round-trip
 @settings(
     max_examples=200,
     deadline=None,
@@ -348,8 +347,6 @@ _classified_metric_names = st.one_of(
 @given(case=_classified_metric_names)
 def test_metric_name_validator_round_trip(case: tuple[str, bool]) -> None:
     """``validate_metric_name`` echoes valid names and rejects invalid ones.
-
-    Validates: Requirements 1.3, 1.7
 
     For any generated name:
 
@@ -493,7 +490,6 @@ def _details(draw: st.DrawFn) -> dict[str, Any]:
     return payload
 
 
-# Feature: mission-metric-reader-tools, Property 8: Error envelopes never carry top-level metrics
 @settings(
     max_examples=200,
     deadline=None,
@@ -506,18 +502,16 @@ def test_error_envelope_never_carries_top_level_metrics(
 ) -> None:
     """``error_envelope`` always yields ``{"code","details"}`` with no top-level metrics.
 
-    Validates: Requirements 14.1, 14.4, 14.5
-
     For any error code and arbitrary details payload:
 
     * the result is a dict whose top-level keys are exactly ``code`` and
       ``details`` — nothing else;
     * there is no top-level ``metrics`` key, so the Observe_Phase merge skips
       the envelope and a ``metric_threshold`` criterion is left
-      ``inconclusive`` rather than ``met``/``unmet`` (R14.4); and
+      ``inconclusive`` rather than ``met``/``unmet``; and
     * the supplied code and the full details payload (including a field that
       happens to be named ``metrics``) are preserved verbatim — the details
-      provenance survives nested under ``details`` (R14.5).
+      provenance survives nested under ``details``.
     """
     envelope = error_envelope(code, **details)
 

--- a/tests/test_metric_readers_shape.py
+++ b/tests/test_metric_readers_shape.py
@@ -1,0 +1,576 @@
+"""Tests for the canonical metric-result builder.
+
+A metric reader's success output has a fixed shape: a top-level ``metrics``
+object that maps a single well-formed key to one real number, with every
+piece of provenance (source, region, timestamp, aggregation mode, raw
+datapoint, and so on) placed *beside* ``metrics`` at the top level rather
+than inside it. Downstream consumers merge only the ``metrics`` object, so
+that object must contain nothing but the numeric value, and provenance must
+never leak into it — not even a provenance field that happens to be named
+``metrics``.
+
+These tests pin that invariant down. The property test drives
+``metrics_result`` with a wide range of valid keys, numeric values, and
+arbitrary provenance payloads; the focused unit tests nail the two corner
+cases that matter most: a provenance field colliding with the canonical
+``metrics`` key, and a provenance field colliding with the metric key name.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ``mcp/run_mcp.py`` puts ``mcp/`` on ``sys.path`` at runtime; mirror that
+# here so the pure ``metric_readers`` package imports the same way it does
+# in production, matching the convention used by the sibling Mission tests.
+sys.path.insert(0, str(Path(__file__).parent.parent / "mcp"))
+
+from metric_readers.shape import (  # noqa: E402
+    is_numeric_value,
+    metrics_result,
+    validate_metric_name,
+)
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+# A valid metric key: 1..128 printable non-space ASCII characters with no
+# "." separator. This is exactly the space ``validate_metric_name`` accepts,
+# so every generated key is a legal single path segment.
+_metric_keys = st.text(
+    alphabet=st.characters(min_codepoint=33, max_codepoint=126, blacklist_characters="."),
+    min_size=1,
+    max_size=128,
+)
+
+# A real, finite number: an int (never a bool, since ``st.integers`` does not
+# emit bools) or a finite float (never NaN or +/-inf).
+_numeric_values = st.one_of(
+    st.integers(),
+    st.floats(allow_nan=False, allow_infinity=False),
+)
+
+# Provenance keys are ordinary identifier-ish ASCII strings. Provenance values
+# are JSON-shaped and finite, so a plain ``==`` deep-compare is meaningful.
+_provenance_keys = st.text(
+    alphabet=st.characters(whitelist_categories=("Ll", "Lu", "Nd"), max_codepoint=127),
+    min_size=1,
+    max_size=16,
+)
+_provenance_scalars = st.one_of(
+    st.none(),
+    st.booleans(),
+    st.integers(),
+    st.floats(allow_nan=False, allow_infinity=False),
+    st.text(max_size=24),
+)
+_provenance_values = st.recursive(
+    _provenance_scalars,
+    lambda children: st.one_of(
+        st.lists(children, max_size=4),
+        st.dictionaries(_provenance_keys, children, max_size=4),
+    ),
+    max_leaves=8,
+)
+
+
+@st.composite
+def _provenance(draw: st.DrawFn) -> dict[str, Any]:
+    """Draw an arbitrary provenance payload.
+
+    Roughly half the time a key literally named ``metrics`` is injected, so
+    the property exercises the case where a provenance field collides with
+    the canonical ``metrics`` map and must lose.
+    """
+    payload: dict[str, Any] = draw(
+        st.dictionaries(_provenance_keys, _provenance_values, max_size=6)
+    )
+    if draw(st.booleans()):
+        payload["metrics"] = draw(_provenance_values)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Property: the canonical-shape invariant
+# ---------------------------------------------------------------------------
+
+
+@settings(
+    max_examples=200,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
+)
+@given(key=_metric_keys, value=_numeric_values, provenance=_provenance())
+def test_metrics_result_isolates_numeric_metric_from_provenance(
+    key: str,
+    value: float,
+    provenance: dict[str, Any],
+) -> None:
+    """``metrics_result`` always yields a canonical, provenance-free metrics map.
+
+    For any valid key, finite numeric value, and arbitrary provenance payload:
+
+    * the result is a dict whose top-level ``metrics`` is exactly
+      ``{key: value}`` — one key mapping to one numeric value, nothing else;
+    * the lone value inside ``metrics`` passes the numeric guard;
+    * every provenance field (other than a colliding ``metrics`` key) survives
+      verbatim at the top level, outside the ``metrics`` object; and
+    * a provenance field named ``metrics`` never clobbers the canonical map.
+    """
+    result = metrics_result(key, value, **provenance)
+
+    # Top-level container is a dict carrying a ``metrics`` object.
+    assert isinstance(result, dict)
+    assert isinstance(result["metrics"], dict)
+
+    # The metrics object maps exactly the one key to exactly the numeric
+    # value — no provenance leaked in, and a colliding ``metrics`` provenance
+    # field did not overwrite it.
+    assert result["metrics"] == {key: value}
+    assert set(result["metrics"]) == {key}
+    assert is_numeric_value(result["metrics"][key])
+
+    # Every provenance field lives at the top level, beside ``metrics``.
+    for prov_key, prov_value in provenance.items():
+        if prov_key == "metrics":
+            # The canonical map wins over any provenance field of this name.
+            continue
+        assert result[prov_key] == prov_value
+
+
+# ---------------------------------------------------------------------------
+# Focused unit tests for the two collision corner cases
+# ---------------------------------------------------------------------------
+
+
+def test_provenance_named_metrics_cannot_clobber_canonical_map() -> None:
+    """A provenance field named ``metrics`` loses to the canonical metrics map."""
+    result = metrics_result(
+        "loss",
+        0.42,
+        metrics="not-a-metrics-map",
+        source="job_logs:trainer",
+    )
+    assert result["metrics"] == {"loss": 0.42}
+    assert result["source"] == "job_logs:trainer"
+
+
+def test_provenance_sharing_the_metric_key_name_stays_at_top_level() -> None:
+    """A provenance field whose name equals the metric key sits beside ``metrics``.
+
+    The two values live at different levels: the raw provenance value at the
+    top level, and the numeric metric inside the ``metrics`` object.
+    """
+    result = metrics_result("loss", 0.42, loss="raw-string-value")
+    assert result["metrics"] == {"loss": 0.42}
+    assert result["loss"] == "raw-string-value"
+
+
+def test_metric_key_generator_produces_only_valid_names() -> None:
+    """Sanity check: a representative generated-style key validates cleanly."""
+    name = "eval_loss-step42"
+    assert validate_metric_name(name) == name
+
+
+# ---------------------------------------------------------------------------
+# Property: the numeric-value guard
+# ---------------------------------------------------------------------------
+
+# A grab-bag of values spanning every type the guard must rule on. It mixes
+# the two accepted kinds (plain ints and finite floats) with the look-alikes
+# that must be rejected: booleans (an ``int`` subclass), the non-finite floats
+# (NaN and +/-inf), numeric-looking and arbitrary strings, ``None``, and a
+# range of container and other object types.
+_mixed_values = st.one_of(
+    st.booleans(),
+    st.integers(),
+    st.floats(allow_nan=False, allow_infinity=False),
+    st.just(float("nan")),
+    st.just(float("inf")),
+    st.just(float("-inf")),
+    st.text(),
+    st.from_regex(r"-?\d+(\.\d+)?", fullmatch=True),  # numeric-looking strings
+    st.none(),
+    st.lists(st.integers(), max_size=4),
+    st.tuples(st.integers(), st.integers()),
+    st.dictionaries(st.text(max_size=8), st.integers(), max_size=4),
+    st.sets(st.integers(), max_size=4),
+    st.binary(max_size=8),
+    st.complex_numbers(allow_nan=False, allow_infinity=False),
+)
+
+
+def _is_real_finite_number(x: object) -> bool:
+    """Reference oracle: a real, finite number that is not a boolean.
+
+    Independent of the implementation under test: ``True`` exactly when ``x``
+    is a plain ``int`` (excluding ``bool``) or a finite ``float``.
+    """
+    if isinstance(x, bool):
+        return False
+    if isinstance(x, int):
+        return True
+    if isinstance(x, float):
+        return math.isfinite(x)
+    return False
+
+
+@settings(
+    max_examples=200,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
+)
+@given(value=_mixed_values)
+def test_numeric_guard_accepts_only_real_finite_numbers(value: object) -> None:
+    """``is_numeric_value`` is True iff the value is a non-bool int or finite float.
+
+    Across every generated type, the guard agrees with an independent oracle:
+    plain ints and finite floats pass; booleans, NaN, the infinities, strings
+    (even numeric-looking ones), ``None``, and containers are all rejected.
+    """
+    assert is_numeric_value(value) is _is_real_finite_number(value)
+
+
+def test_numeric_guard_rejects_representative_non_numerics() -> None:
+    """Spot-check the headline rejections the guard must make."""
+    for rejected in (
+        True,
+        False,
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        "3.14",
+        "42",
+        "",
+        None,
+        [1, 2, 3],
+        {"loss": 0.5},
+        (1, 2),
+        b"1.0",
+    ):
+        assert is_numeric_value(rejected) is False
+
+
+def test_numeric_guard_accepts_representative_numerics() -> None:
+    """Spot-check the values the guard must accept."""
+    for accepted in (0, 1, -7, 3.14, -0.0, 1e308):
+        assert is_numeric_value(accepted) is True
+
+
+# ---------------------------------------------------------------------------
+# Property: the metric-name validator round-trip
+# ---------------------------------------------------------------------------
+
+import pytest  # noqa: E402
+from metric_readers.shape import (  # noqa: E402
+    ErrorCode,
+    MetricReaderError,
+)
+
+# A valid metric name: 1..128 characters drawn from printable, non-space
+# ASCII with the "." separator excluded. This is exactly the space
+# ``validate_metric_name`` must accept and echo back unchanged: a single
+# well-formed path segment with no "." and no whitespace.
+_valid_metric_names = st.text(
+    alphabet=st.characters(min_codepoint=33, max_codepoint=126, blacklist_characters="."),
+    min_size=1,
+    max_size=128,
+)
+
+# An over-length name: 129..256 characters, otherwise well-formed, so the
+# *only* reason it is invalid is that it exceeds the 128-character cap.
+_oversize_metric_names = st.text(
+    alphabet=st.characters(min_codepoint=33, max_codepoint=126, blacklist_characters="."),
+    min_size=129,
+    max_size=256,
+)
+
+# Every character ``str.isspace`` recognises as whitespace and that the
+# validator must therefore reject.
+_whitespace_chars = st.sampled_from([" ", "\t", "\n", "\r", "\f", "\v"])
+
+# A short, "." -free, whitespace-free fragment used to build invalid names by
+# splicing in an illegal character.
+_clean_fragments = st.text(
+    alphabet=st.characters(min_codepoint=33, max_codepoint=126, blacklist_characters="."),
+    max_size=64,
+)
+
+
+@st.composite
+def _names_with_dot(draw: st.DrawFn) -> str:
+    """Build a name that is invalid because it contains a ``.`` separator."""
+    left = draw(_clean_fragments)
+    right = draw(_clean_fragments)
+    return left + "." + right
+
+
+@st.composite
+def _names_with_whitespace(draw: st.DrawFn) -> str:
+    """Build a name that is invalid because it contains a whitespace character."""
+    left = draw(_clean_fragments)
+    right = draw(_clean_fragments)
+    return left + draw(_whitespace_chars) + right
+
+
+# An invalid metric name spanning all four rejection reasons in R1.7: empty,
+# longer than 128 characters, containing a "." separator, or containing
+# whitespace.
+_invalid_metric_names = st.one_of(
+    st.just(""),
+    _oversize_metric_names,
+    _names_with_dot(),
+    _names_with_whitespace(),
+)
+
+# A classified name: the string paired with whether the validator must accept
+# it. Drawing both arms in one strategy lets the single property exercise the
+# accept-unchanged and reject-with-code halves of the round-trip together.
+_classified_metric_names = st.one_of(
+    _valid_metric_names.map(lambda n: (n, True)),
+    _invalid_metric_names.map(lambda n: (n, False)),
+)
+
+
+# Feature: mission-metric-reader-tools, Property 3: Metric-name validator round-trip
+@settings(
+    max_examples=200,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
+)
+@given(case=_classified_metric_names)
+def test_metric_name_validator_round_trip(case: tuple[str, bool]) -> None:
+    """``validate_metric_name`` echoes valid names and rejects invalid ones.
+
+    Validates: Requirements 1.3, 1.7
+
+    For any generated name:
+
+    * a valid name — a non-empty string of at most 128 characters with no
+      ``.`` separator and no whitespace — is returned unchanged; and
+    * an invalid name — empty, longer than 128 characters, containing a
+      ``.`` separator, or containing any whitespace character — raises
+      :class:`MetricReaderError` carrying
+      :attr:`ErrorCode.METRIC_NAME_INVALID`.
+    """
+    name, is_valid = case
+    if is_valid:
+        assert validate_metric_name(name) == name
+    else:
+        with pytest.raises(MetricReaderError) as exc_info:
+            validate_metric_name(name)
+        assert exc_info.value.code == ErrorCode.METRIC_NAME_INVALID
+
+
+# ---------------------------------------------------------------------------
+# Focused unit tests for the validator's boundaries and each rejection reason
+# ---------------------------------------------------------------------------
+
+
+def test_valid_name_is_returned_unchanged() -> None:
+    """A well-formed name comes back as the same object, untouched."""
+    name = "eval_loss-step42"
+    assert validate_metric_name(name) is name
+
+
+def test_name_at_the_128_character_boundary_is_accepted() -> None:
+    """Exactly 128 characters is the longest name the validator allows."""
+    name = "a" * 128
+    assert validate_metric_name(name) == name
+
+
+def test_name_one_over_the_boundary_is_rejected() -> None:
+    """129 characters trips the length cap with the invalid-name code."""
+    with pytest.raises(MetricReaderError) as exc_info:
+        validate_metric_name("a" * 129)
+    assert exc_info.value.code == ErrorCode.METRIC_NAME_INVALID
+
+
+def test_empty_name_is_rejected() -> None:
+    """An empty name is invalid."""
+    with pytest.raises(MetricReaderError) as exc_info:
+        validate_metric_name("")
+    assert exc_info.value.code == ErrorCode.METRIC_NAME_INVALID
+
+
+def test_name_with_dot_separator_is_rejected() -> None:
+    """A name containing the ``.`` Dot_Path separator is invalid."""
+    with pytest.raises(MetricReaderError) as exc_info:
+        validate_metric_name("metrics.loss")
+    assert exc_info.value.code == ErrorCode.METRIC_NAME_INVALID
+
+
+def test_name_with_whitespace_is_rejected() -> None:
+    """A name containing any whitespace character is invalid."""
+    for bad in ("eval loss", "loss\t", "\nloss", "loss\r"):
+        with pytest.raises(MetricReaderError) as exc_info:
+            validate_metric_name(bad)
+        assert exc_info.value.code == ErrorCode.METRIC_NAME_INVALID
+
+
+# ---------------------------------------------------------------------------
+# Property: error envelopes never carry top-level ``metrics``
+# ---------------------------------------------------------------------------
+
+from metric_readers.shape import error_envelope  # noqa: E402
+
+# An error code: either one of the frozen stable codes a reader actually
+# surfaces, or an arbitrary string. Mixing the two ensures the builder is
+# pinned for the real codes *and* never special-cases its first argument.
+_error_codes = st.one_of(
+    st.sampled_from(
+        [
+            ErrorCode.METRIC_NAME_INVALID,
+            ErrorCode.INVALID_AGGREGATION_MODE,
+            ErrorCode.EMPTY_SEQUENCE,
+            ErrorCode.NO_NUMERIC_VALUE,
+            ErrorCode.NON_NUMERIC_VALUE,
+            ErrorCode.NO_DATAPOINTS,
+            ErrorCode.AWS_UNREACHABLE,
+            ErrorCode.INVALID_EXTRACTION_MODE,
+            ErrorCode.INVALID_REGEX,
+            ErrorCode.NO_MATCH,
+            ErrorCode.LOG_RETRIEVAL_FAILED,
+            ErrorCode.FILE_NOT_FOUND,
+            ErrorCode.MALFORMED_FILE,
+            ErrorCode.FIELD_NOT_FOUND,
+            ErrorCode.FILE_TOO_LARGE,
+            ErrorCode.UNSUPPORTED_FORMAT,
+            ErrorCode.FORMAT_DEPENDENCY_UNAVAILABLE,
+            ErrorCode.PATH_TRAVERSAL_ESCAPE,
+            ErrorCode.SYMLINK_ESCAPE,
+            ErrorCode.LOCAL_ROOT_NOT_CONFIGURED,
+        ]
+    ),
+    st.text(max_size=40),
+)
+
+# Details keys are passed as keyword arguments, so the reserved positional
+# ``code`` parameter name is excluded; everything else (including a key named
+# ``metrics``) is fair game and must end up nested under ``details``.
+_detail_keys = st.text(
+    alphabet=st.characters(whitelist_categories=("Ll", "Lu", "Nd"), max_codepoint=127),
+    min_size=1,
+    max_size=16,
+).filter(lambda k: k != "code")
+
+_detail_scalars = st.one_of(
+    st.none(),
+    st.booleans(),
+    st.integers(),
+    st.floats(allow_nan=False, allow_infinity=False),
+    st.text(max_size=24),
+)
+_detail_values = st.recursive(
+    _detail_scalars,
+    lambda children: st.one_of(
+        st.lists(children, max_size=4),
+        st.dictionaries(_detail_keys, children, max_size=4),
+    ),
+    max_leaves=8,
+)
+
+
+@st.composite
+def _details(draw: st.DrawFn) -> dict[str, Any]:
+    """Draw an arbitrary error-details payload.
+
+    Roughly half the time a key literally named ``metrics`` is injected, so
+    the property exercises the case where a details field is named
+    ``metrics`` and must be nested *inside* ``details`` rather than leaking
+    to the top level where the Observe_Phase merge would pick it up.
+    """
+    payload: dict[str, Any] = draw(st.dictionaries(_detail_keys, _detail_values, max_size=6))
+    if draw(st.booleans()):
+        payload["metrics"] = draw(_detail_values)
+    return payload
+
+
+# Feature: mission-metric-reader-tools, Property 8: Error envelopes never carry top-level metrics
+@settings(
+    max_examples=200,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
+)
+@given(code=_error_codes, details=_details())
+def test_error_envelope_never_carries_top_level_metrics(
+    code: str,
+    details: dict[str, Any],
+) -> None:
+    """``error_envelope`` always yields ``{"code","details"}`` with no top-level metrics.
+
+    Validates: Requirements 14.1, 14.4, 14.5
+
+    For any error code and arbitrary details payload:
+
+    * the result is a dict whose top-level keys are exactly ``code`` and
+      ``details`` — nothing else;
+    * there is no top-level ``metrics`` key, so the Observe_Phase merge skips
+      the envelope and a ``metric_threshold`` criterion is left
+      ``inconclusive`` rather than ``met``/``unmet`` (R14.4); and
+    * the supplied code and the full details payload (including a field that
+      happens to be named ``metrics``) are preserved verbatim — the details
+      provenance survives nested under ``details`` (R14.5).
+    """
+    envelope = error_envelope(code, **details)
+
+    # Structural shape: exactly ``code`` and ``details``, and crucially no
+    # top-level ``metrics`` key for the merge to pick up.
+    assert isinstance(envelope, dict)
+    assert set(envelope) == {"code", "details"}
+    assert "metrics" not in envelope
+
+    # The code passes through unchanged.
+    assert envelope["code"] == code
+
+    # All provenance is preserved, nested under ``details`` — even a details
+    # field named ``metrics`` stays inside ``details`` and never surfaces at
+    # the top level.
+    assert isinstance(envelope["details"], dict)
+    assert envelope["details"] == details
+
+
+# ---------------------------------------------------------------------------
+# Focused unit tests for the error-envelope builder
+# ---------------------------------------------------------------------------
+
+
+def test_error_envelope_with_no_details_has_empty_details_dict() -> None:
+    """An envelope built with no details carries an empty ``details`` dict."""
+    envelope = error_envelope(ErrorCode.NO_DATAPOINTS)
+    assert envelope == {"code": ErrorCode.NO_DATAPOINTS, "details": {}}
+    assert "metrics" not in envelope
+
+
+def test_error_envelope_preserves_diagnostic_provenance() -> None:
+    """Diagnostic provenance is preserved under ``details`` for operator triage."""
+    envelope = error_envelope(
+        ErrorCode.FILE_NOT_FOUND,
+        path="s3://bucket/run/metrics.json",
+        format="json",
+    )
+    assert envelope["code"] == ErrorCode.FILE_NOT_FOUND
+    assert envelope["details"] == {
+        "path": "s3://bucket/run/metrics.json",
+        "format": "json",
+    }
+    assert "metrics" not in envelope
+
+
+def test_error_envelope_details_field_named_metrics_stays_nested() -> None:
+    """A details field named ``metrics`` is nested, never a top-level key.
+
+    The Observe_Phase merge only reads a *top-level* ``metrics`` object, so a
+    provenance field that happens to be named ``metrics`` must live inside
+    ``details`` where the merge will not pick it up.
+    """
+    envelope = error_envelope(ErrorCode.MALFORMED_FILE, metrics="not-a-metrics-map")
+    assert "metrics" not in envelope
+    assert envelope["details"] == {"metrics": "not-a-metrics-map"}

--- a/tests/test_metric_readers_tools.py
+++ b/tests/test_metric_readers_tools.py
@@ -2,13 +2,13 @@
 
 The pure ``metric_readers`` package is exercised in isolation by its sibling
 test modules; this file pins down the *tool* surface in ``mcp/tools/metrics.py``
-— the thin ``@mcp.tool`` wrappers a Mission session actually calls. The first
-slice (task 8.4) covers the **success path** for every reader: each tool must
-return the Canonical_Metrics_Shape — a top-level ``metrics`` object mapping the
-chosen key to a single Numeric_Value, with every provenance field placed
-*outside* ``metrics`` — and each History_Bearing_Reader must reduce a known
-sequence to the right scalar under each Aggregation_Mode (``last``, ``first``,
-``min``, ``max``, ``mean``).
+— the thin ``@mcp.tool`` wrappers a Mission session actually calls. The
+success-path tests below cover every reader: each tool must return the
+Canonical_Metrics_Shape — a top-level ``metrics`` object mapping the chosen key
+to a single Numeric_Value, with every provenance field placed *outside*
+``metrics`` — and each History_Bearing_Reader must reduce a known sequence to
+the right scalar under each Aggregation_Mode (``last``, ``first``, ``min``,
+``max``, ``mean``).
 
 The readers are exercised offline. ``metrics_cloudwatch_get`` runs against a
 patched ``boto3`` client (no live AWS); ``metrics_from_job_logs`` and
@@ -16,12 +16,10 @@ patched ``boto3`` client (no live AWS); ``metrics_from_job_logs`` and
 (``cli_runner._run_cli`` / ``_read_shared_storage``) that hand back a known
 artifact, so no network, AWS, or job-log access is touched.
 
-Later tasks extend this file: 8.5 adds flag-gated registration tests, 8.6 the
-tool-registry determinism property, 8.7 the local-file confinement integration
-tests, and 8.8 the Observe_Phase merge-contract test. Shared helpers are kept
-at module scope so those slices can reuse them.
-
-Validates: Requirements 16.1, 16.2
+The rest of the file builds on that success-path slice: flag-gated
+registration tests, the tool-registry determinism property, the local-file
+confinement integration tests, and the Observe_Phase merge-contract test.
+Shared helpers are kept at module scope so those slices can reuse them.
 """
 
 from __future__ import annotations
@@ -49,7 +47,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "mcp"))
 
 from metric_readers.shape import is_numeric_value  # noqa: E402
 
-# Every Aggregation_Mode a History_Bearing_Reader must honour (R16.2).
+# Every Aggregation_Mode a History_Bearing_Reader must honour.
 _MODES = ("last", "first", "min", "max", "mean")
 
 # A known sequence whose five reductions are all distinct, so a mode that is
@@ -108,17 +106,17 @@ def _assert_canonical_shape(
 ) -> None:
     """Assert ``result`` is the Canonical_Metrics_Shape carrying one numeric.
 
-    Pins down every clause of Requirement 1 that a success result must satisfy:
-    a top-level ``metrics`` object mapping exactly ``expected_key`` to a single
-    Numeric_Value equal to ``expected_value`` (R1.1), the value passing the
-    Numeric_Value guard (R1.2), no error-envelope ``code`` key, and every named
-    provenance field present at the top level but **never** inside ``metrics``
-    (R1.5).
+        Pins down every clause a success result must satisfy:
+        a top-level ``metrics`` object mapping exactly ``expected_key`` to a single
+        Numeric_Value equal to ``expected_value``, the value passing the
+        Numeric_Value guard, no error-envelope ``code`` key, and every named
+        provenance field present at the top level but **never** inside ``metrics``
+    .
     """
     # Not an error envelope.
     assert "code" not in result, f"expected success shape, got envelope: {result!r}"
 
-    # Top-level metrics object mapping the key to the numeric value (R1.1).
+    # Top-level metrics object mapping the key to the numeric value.
     assert "metrics" in result, f"missing top-level 'metrics': {result!r}"
     metrics = result["metrics"]
     assert isinstance(metrics, dict)
@@ -126,10 +124,10 @@ def _assert_canonical_shape(
         f"expected metrics {{{expected_key!r}: {expected_value!r}}}, got {metrics!r}"
     )
 
-    # The emitted value is a real, finite number (R1.2).
+    # The emitted value is a real, finite number.
     assert is_numeric_value(metrics[expected_key])
 
-    # Provenance lives outside ``metrics`` (R1.5): present at the top level and
+    # Provenance lives outside ``metrics``: present at the top level and
     # absent from the metrics object, which carries only the numeric entry.
     for prov_key in provenance_keys:
         assert prov_key in result, f"missing provenance field {prov_key!r}: {result!r}"
@@ -146,7 +144,7 @@ def _cloudwatch_client_returning(datapoints: list[dict]) -> MagicMock:
 
     The mock stands in for ``boto3.client("cloudwatch", ...)``; its
     ``get_metric_statistics`` returns the supplied datapoints so no live AWS
-    call is made (R16.6).
+    call is made.
     """
     client = MagicMock()
     client.get_metric_statistics.return_value = {"Datapoints": datapoints}
@@ -155,8 +153,6 @@ def _cloudwatch_client_returning(datapoints: list[dict]) -> MagicMock:
 
 def test_cloudwatch_get_success_returns_canonical_shape() -> None:
     """The CloudWatch reader emits the most-recent datapoint as a canonical metric.
-
-    Validates: Requirements 16.1
 
     With ``boto3`` patched to hand back two datapoints carrying distinct
     timestamps, the tool must select the most recent one deterministically and
@@ -199,10 +195,7 @@ def test_cloudwatch_get_success_returns_canonical_shape() -> None:
 
 
 def test_cloudwatch_get_success_honours_output_name() -> None:
-    """An explicit ``output_name`` becomes the metric key on the success path.
-
-    Validates: Requirements 16.1
-    """
+    """An explicit ``output_name`` becomes the metric key on the success path."""
     metrics_module = _import_metrics_tool_module()
 
     client = _cloudwatch_client_returning(
@@ -253,8 +246,6 @@ def test_job_logs_json_key_reduces_known_sequence(
 ) -> None:
     """The job-log reader reduces a known per-line sequence under each mode.
 
-    Validates: Requirements 16.1, 16.2
-
     Each log line is a JSON object carrying one ``loss`` value from the known
     sequence; the reader extracts the dot-path key, reduces under ``mode``, and
     returns the reference reduction in the Canonical_Metrics_Shape (key defaults
@@ -286,10 +277,7 @@ def test_job_logs_json_key_reduces_known_sequence(
 
 
 def test_job_logs_default_aggregation_is_last(monkeypatch: pytest.MonkeyPatch) -> None:
-    """With no aggregation supplied the job-log reader returns the most-recent match.
-
-    Validates: Requirements 16.1, 16.2
-    """
+    """With no aggregation supplied the job-log reader returns the most-recent match."""
     metrics_module = _import_metrics_tool_module()
     lines = [json.dumps({"loss": v}) for v in _KNOWN_SEQUENCE]
     _patch_job_logs(metrics_module, monkeypatch, lines)
@@ -314,8 +302,6 @@ def test_job_logs_default_aggregation_is_last(monkeypatch: pytest.MonkeyPatch) -
 @pytest.mark.parametrize("mode", _MODES)
 def test_job_logs_regex_reduces_known_sequence(mode: str, monkeypatch: pytest.MonkeyPatch) -> None:
     """Regex extraction's first capture group reduces under each mode.
-
-    Validates: Requirements 16.1, 16.2
 
     The free-text lines print ``loss=<n>``; the reader captures the first group
     per line, coerces to a number, and reduces under ``mode`` to the reference
@@ -368,8 +354,6 @@ def test_shared_storage_single_value_returns_canonical_shape(
 ) -> None:
     """A single JSON scalar reads back as a canonical metric.
 
-    Validates: Requirements 16.1
-
     The non-history success path: a plain ``json`` document whose field is one
     number returns that number in the Canonical_Metrics_Shape with the
     source / region / format / aggregation provenance outside ``metrics``.
@@ -401,8 +385,6 @@ def test_shared_storage_hf_log_history_reduces_known_sequence(
     mode: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A Hugging Face ``log_history`` reduces under each mode.
-
-    Validates: Requirements 16.1, 16.2
 
     The ``hf_trainer_state`` format gathers one ``loss`` per ``log_history``
     entry from the known sequence and reduces under ``mode`` to the reference
@@ -439,8 +421,6 @@ def test_shared_storage_jsonl_reduces_known_sequence(
 ) -> None:
     """A JSONL step-log stream reduces under each mode.
 
-    Validates: Requirements 16.1, 16.2
-
     The ``jsonl`` format gathers the named field from each record of the known
     sequence and reduces under ``mode`` to the reference scalar in the
     canonical shape, covering a second sequence-bearing format.
@@ -469,7 +449,7 @@ def test_shared_storage_jsonl_reduces_known_sequence(
 
 
 # ===========================================================================
-# Flag-gated registration (task 8.5)
+# Flag-gated registration
 # ===========================================================================
 #
 # The success-path slice above pins down what each reader *returns*. This slice
@@ -478,15 +458,14 @@ def test_shared_storage_jsonl_reduces_known_sequence(
 #
 #   * the three default-on readers (``metrics_cloudwatch_get``,
 #     ``metrics_from_job_logs``, ``metrics_from_shared_storage_file``) are
-#     always present, independent of any flag (R3.5);
+#     always present, independent of any flag;
 #   * ``metrics_from_local_file`` is default-off — absent when neither
 #     ``GCO_ENABLE_LOCAL_METRICS`` nor the umbrella ``GCO_ENABLE_ALL_TOOLS`` is
-#     set (R18.1), present when ``GCO_ENABLE_LOCAL_METRICS=true`` (R18.1) or the
-#     umbrella ``GCO_ENABLE_ALL_TOOLS=true`` is set with the local flag unset
-#     (R18.3);
+#     set, present when ``GCO_ENABLE_LOCAL_METRICS=true`` or the
+#     umbrella ``GCO_ENABLE_ALL_TOOLS=true`` is set with the local flag unset;
 #   * when present, its description begins with the literal prefix
-#     ``"[gated by GCO_ENABLE_LOCAL_METRICS]"`` (R18.4) and it carries the
-#     ``safe`` Tool_Tag (R18.5 / R3.2).
+#     ``"[gated by GCO_ENABLE_LOCAL_METRICS]"`` and it carries the
+#     ``safe`` Tool_Tag.
 #
 # Registry introspection note: the server (``mcp/server.py``) wires the
 # BM25/Code-Mode catalog-replacement transforms, so the *public*
@@ -570,8 +549,6 @@ def _local_metrics_flag(env: dict[str, str | None]) -> Iterator[dict]:
 def test_local_file_reader_absent_when_flag_unset() -> None:
     """With the gate unset, ``metrics_from_local_file`` is not registered.
 
-    Validates: Requirements 18.1
-
     With neither ``GCO_ENABLE_LOCAL_METRICS`` nor the umbrella
     ``GCO_ENABLE_ALL_TOOLS`` set, the gated decorator never fires and the tool
     is absent from the registry; the three default-on readers remain present.
@@ -589,8 +566,6 @@ def test_local_file_reader_absent_when_flag_unset() -> None:
 def test_local_file_reader_present_when_local_flag_set() -> None:
     """``GCO_ENABLE_LOCAL_METRICS=true`` registers ``metrics_from_local_file``.
 
-    Validates: Requirements 18.1
-
     Setting the per-tool flag fires the gated decorator so the tool appears in
     the registry; the default-on readers stay present alongside it.
     """
@@ -606,8 +581,6 @@ def test_local_file_reader_present_when_local_flag_set() -> None:
 
 def test_local_file_reader_present_under_umbrella_flag() -> None:
     """The umbrella ``GCO_ENABLE_ALL_TOOLS=true`` also registers the gated reader.
-
-    Validates: Requirements 18.3
 
     With the per-tool ``GCO_ENABLE_LOCAL_METRICS`` left unset, setting only the
     umbrella ``GCO_ENABLE_ALL_TOOLS=true`` must still enable the tool, mirroring
@@ -628,11 +601,9 @@ def test_local_file_reader_present_under_umbrella_flag() -> None:
 def test_local_file_reader_docstring_prefix_and_safe_tag() -> None:
     """When registered, the gated reader is prefixed and carries the ``safe`` tag.
 
-    Validates: Requirements 18.4
-
     With the gate on, the tool's description must begin with the literal prefix
-    ``"[gated by GCO_ENABLE_LOCAL_METRICS]"`` (R18.4) and its Tool_Tag set must
-    include ``safe`` (R18.5 / R3.2), marking it read-only like its siblings.
+    ``"[gated by GCO_ENABLE_LOCAL_METRICS]"`` and its Tool_Tag set must
+    include ``safe``, marking it read-only like its siblings.
     """
     _import_metrics_tool_module()
     env = {"GCO_ENABLE_LOCAL_METRICS": "true", "GCO_ENABLE_ALL_TOOLS": None}
@@ -640,21 +611,19 @@ def test_local_file_reader_docstring_prefix_and_safe_tag() -> None:
         tool = registry.get(_LOCAL_FILE_TOOL)
         assert tool is not None, "metrics_from_local_file must register under the flag"
 
-        # The description begins with the literal gating prefix (R18.4).
+        # The description begins with the literal gating prefix.
         assert tool.description is not None
         assert tool.description.startswith(_GATED_DOCSTRING_PREFIX), (
             f"description must begin with {_GATED_DOCSTRING_PREFIX!r}, "
             f"got {tool.description[: len(_GATED_DOCSTRING_PREFIX)]!r}"
         )
 
-        # It carries the read-only ``safe`` Tool_Tag (R18.5 / R3.2).
+        # It carries the read-only ``safe`` Tool_Tag.
         assert "safe" in tool.tags, f"expected 'safe' tag, got {tool.tags!r}"
 
 
 def test_default_on_readers_present_regardless_of_flag() -> None:
     """The three default-on readers register whether the gate is on or off.
-
-    Validates: Requirements 3.5, 18.1
 
     A default-registered Metric_Reader_Tool must appear in the registry
     independent of any flag. Toggling ``GCO_ENABLE_LOCAL_METRICS`` only adds or
@@ -685,7 +654,7 @@ def test_default_on_readers_present_regardless_of_flag() -> None:
 
 
 # ===========================================================================
-# Tool-registry determinism (task 8.6)
+# Tool-registry determinism
 # ===========================================================================
 #
 # The flag-gated slice above pins down individual flag combinations with hand
@@ -694,12 +663,12 @@ def test_default_on_readers_present_regardless_of_flag() -> None:
 # flags that govern the local-file reader, the registry must be a deterministic
 # function of those flags. Concretely, for each generated combination:
 #
-#   1. Determinism (R3.7) — re-running ``_list_tools()`` under the SAME flag
+#   1. Determinism — re-running ``_list_tools()`` under the SAME flag
 #      values yields the IDENTICAL set of tool names. The Tool_Registry must
 #      not depend on call order, time, or any hidden state.
-#   2. Default-on presence (R3.5) — the three default-on readers are ALWAYS in
+#   2. Default-on presence — the three default-on readers are ALWAYS in
 #      the registry, independent of the flags.
-#   3. Gated presence (R18.1, R18.3) — ``metrics_from_local_file`` is present
+#   3. Gated presence — ``metrics_from_local_file`` is present
 #      IFF the gate is enabled, i.e. ``GCO_ENABLE_LOCAL_METRICS=true`` OR the
 #      umbrella ``GCO_ENABLE_ALL_TOOLS=true`` — exactly the
 #      ``feature_flags.is_enabled`` truth rule.
@@ -707,7 +676,8 @@ def test_default_on_readers_present_regardless_of_flag() -> None:
 # Each example flips env vars and re-imports ``tools.metrics`` (slow), so the
 # settings mirror the sibling metric-reader property tests: ``deadline=None``
 # and the ``too_slow``/``data_too_large`` health checks suppressed. The
-# ``_local_metrics_flag`` context manager (defined above for task 8.5) is used
+# ``_local_metrics_flag`` context manager (defined above for the flag-gated
+# registration tests) is used
 # as a context manager *inside* the test body so its force-unregister +
 # environ-restore teardown runs for EVERY example — no gated registration ever
 # leaks into a sibling test's tool-count / tool-name snapshot.
@@ -736,7 +706,6 @@ def _gate_expected_present(env: dict[str, str | None]) -> bool:
     )
 
 
-# Feature: mission-metric-reader-tools, Property 10: Tool-registry determinism
 @settings(
     max_examples=100,
     deadline=None,
@@ -746,14 +715,12 @@ def _gate_expected_present(env: dict[str, str | None]) -> bool:
 def test_tool_registry_determinism(local_flag: str | None, umbrella_flag: str | None) -> None:
     """The Tool_Registry is a deterministic function of the gating flags.
 
-    Validates: Requirements 3.5, 3.7, 18.1, 18.3
-
     For any combination of ``GCO_ENABLE_LOCAL_METRICS`` and the umbrella
     ``GCO_ENABLE_ALL_TOOLS``, re-importing ``tools.metrics`` under those values
     yields a registry whose tool-name set is stable across repeated
-    ``_list_tools()`` calls (R3.7), always contains the three default-on
-    readers (R3.5), and contains ``metrics_from_local_file`` iff the gate is
-    enabled (R18.1, R18.3).
+    ``_list_tools()`` calls, always contains the three default-on
+    readers, and contains ``metrics_from_local_file`` iff the gate is
+    enabled.
     """
     _import_metrics_tool_module()
 
@@ -768,7 +735,7 @@ def test_tool_registry_determinism(local_flag: str | None, umbrella_flag: str | 
     with _local_metrics_flag(env) as registry:
         names_first = set(registry)
 
-        # (1) Determinism (R3.7): a second introspection under the unchanged
+        # (1) Determinism: a second introspection under the unchanged
         # flag values returns the identical set of tool names.
         names_second = set(_registered_tools())
         assert names_first == names_second, (
@@ -776,14 +743,14 @@ def test_tool_registry_determinism(local_flag: str | None, umbrella_flag: str | 
             f"tool-name set; first={names_first ^ names_second} differed"
         )
 
-        # (2) Default-on presence (R3.5): the three readers are always present,
+        # (2) Default-on presence: the three readers are always present,
         # independent of the flags.
         for reader in _DEFAULT_ON_READERS:
             assert reader in names_first, (
                 f"default-on reader {reader!r} must always be registered, flags={env!r}"
             )
 
-        # (3) Gated presence (R18.1, R18.3): the local-file reader is present
+        # (3) Gated presence: the local-file reader is present
         # iff the gate is enabled per the is_enabled truth rule.
         expected_present = _gate_expected_present(env)
         assert (_LOCAL_FILE_TOOL in names_first) == expected_present, (

--- a/tests/test_metric_readers_tools.py
+++ b/tests/test_metric_readers_tools.py
@@ -1,0 +1,792 @@
+"""Success-path tests for the metric-reader MCP tool wrappers.
+
+The pure ``metric_readers`` package is exercised in isolation by its sibling
+test modules; this file pins down the *tool* surface in ``mcp/tools/metrics.py``
+— the thin ``@mcp.tool`` wrappers a Mission session actually calls. The first
+slice (task 8.4) covers the **success path** for every reader: each tool must
+return the Canonical_Metrics_Shape — a top-level ``metrics`` object mapping the
+chosen key to a single Numeric_Value, with every provenance field placed
+*outside* ``metrics`` — and each History_Bearing_Reader must reduce a known
+sequence to the right scalar under each Aggregation_Mode (``last``, ``first``,
+``min``, ``max``, ``mean``).
+
+The readers are exercised offline. ``metrics_cloudwatch_get`` runs against a
+patched ``boto3`` client (no live AWS); ``metrics_from_job_logs`` and
+``metrics_from_shared_storage_file`` run against patched retrieval seams
+(``cli_runner._run_cli`` / ``_read_shared_storage``) that hand back a known
+artifact, so no network, AWS, or job-log access is touched.
+
+Later tasks extend this file: 8.5 adds flag-gated registration tests, 8.6 the
+tool-registry determinism property, 8.7 the local-file confinement integration
+tests, and 8.8 the Observe_Phase merge-contract test. Shared helpers are kept
+at module scope so those slices can reuse them.
+
+Validates: Requirements 16.1, 16.2
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import importlib
+import json
+import os
+import sys
+from collections.abc import Iterator, Sequence
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+# ``mcp/run_mcp.py`` puts ``mcp/`` on ``sys.path`` at runtime; mirror that here
+# so the pure ``metric_readers`` package — and the ``tools.metrics`` wrappers
+# that sit beside it — import the same way they do in production, matching the
+# convention used by the sibling metric-reader tests.
+sys.path.insert(0, str(Path(__file__).parent.parent / "mcp"))
+
+from metric_readers.shape import is_numeric_value  # noqa: E402
+
+# Every Aggregation_Mode a History_Bearing_Reader must honour (R16.2).
+_MODES = ("last", "first", "min", "max", "mean")
+
+# A known sequence whose five reductions are all distinct, so a mode that is
+# silently ignored or swapped is caught: last=4, first=2, min=1, max=8,
+# mean=20/5=4.0. Integers keep ``mean`` exact for a clean equality assertion.
+_KNOWN_SEQUENCE = [2, 5, 1, 8, 4]
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _import_metrics_tool_module():
+    """Import ``tools.metrics`` or skip when its FastMCP/server deps are absent.
+
+    The pure ``metric_readers`` package needs nothing beyond the standard
+    library, but the tool wrappers pull in ``server`` (FastMCP) and ``audit``.
+    Skip rather than fail when that surface cannot be imported, so these tests
+    degrade gracefully in a minimal environment — mirroring the guard used by
+    ``tests/test_metric_readers_files.py``.
+    """
+    try:
+        import tools.metrics as metrics_module
+    except Exception as exc:  # noqa: BLE001 - any import-surface failure -> skip
+        pytest.skip(f"tools.metrics not importable in this environment: {exc}")
+    return metrics_module
+
+
+def _reference_reduce(values: Sequence[float], mode: str) -> float:
+    """Reduce ``values`` the obvious way for each mode.
+
+    A deliberately straightforward re-derivation of the Aggregation_Mode
+    contract, independent of the reader's own reducer, so a divergence points
+    at the tool under test rather than at clever test logic. ``values`` is
+    assumed already numeric (the test sequences are).
+    """
+    if mode == "last":
+        return values[-1]
+    if mode == "first":
+        return values[0]
+    if mode == "min":
+        return min(values)
+    if mode == "max":
+        return max(values)
+    # mode == "mean"
+    return sum(values) / len(values)
+
+
+def _assert_canonical_shape(
+    result: dict,
+    *,
+    expected_key: str,
+    expected_value: float,
+    provenance_keys: Sequence[str],
+) -> None:
+    """Assert ``result`` is the Canonical_Metrics_Shape carrying one numeric.
+
+    Pins down every clause of Requirement 1 that a success result must satisfy:
+    a top-level ``metrics`` object mapping exactly ``expected_key`` to a single
+    Numeric_Value equal to ``expected_value`` (R1.1), the value passing the
+    Numeric_Value guard (R1.2), no error-envelope ``code`` key, and every named
+    provenance field present at the top level but **never** inside ``metrics``
+    (R1.5).
+    """
+    # Not an error envelope.
+    assert "code" not in result, f"expected success shape, got envelope: {result!r}"
+
+    # Top-level metrics object mapping the key to the numeric value (R1.1).
+    assert "metrics" in result, f"missing top-level 'metrics': {result!r}"
+    metrics = result["metrics"]
+    assert isinstance(metrics, dict)
+    assert metrics == {expected_key: expected_value}, (
+        f"expected metrics {{{expected_key!r}: {expected_value!r}}}, got {metrics!r}"
+    )
+
+    # The emitted value is a real, finite number (R1.2).
+    assert is_numeric_value(metrics[expected_key])
+
+    # Provenance lives outside ``metrics`` (R1.5): present at the top level and
+    # absent from the metrics object, which carries only the numeric entry.
+    for prov_key in provenance_keys:
+        assert prov_key in result, f"missing provenance field {prov_key!r}: {result!r}"
+        assert prov_key not in metrics, f"provenance {prov_key!r} leaked into metrics"
+
+
+# ===========================================================================
+# CloudWatch reader — success path (single deterministic datapoint)
+# ===========================================================================
+
+
+def _cloudwatch_client_returning(datapoints: list[dict]) -> MagicMock:
+    """Build a mock boto3 CloudWatch client returning ``datapoints``.
+
+    The mock stands in for ``boto3.client("cloudwatch", ...)``; its
+    ``get_metric_statistics`` returns the supplied datapoints so no live AWS
+    call is made (R16.6).
+    """
+    client = MagicMock()
+    client.get_metric_statistics.return_value = {"Datapoints": datapoints}
+    return client
+
+
+def test_cloudwatch_get_success_returns_canonical_shape() -> None:
+    """The CloudWatch reader emits the most-recent datapoint as a canonical metric.
+
+    Validates: Requirements 16.1
+
+    With ``boto3`` patched to hand back two datapoints carrying distinct
+    timestamps, the tool must select the most recent one deterministically and
+    return its statistic value in the Canonical_Metrics_Shape under the metric
+    key (defaulting to the CloudWatch metric name), with the source / region /
+    statistic / timestamp provenance outside ``metrics``.
+    """
+    metrics_module = _import_metrics_tool_module()
+
+    older = {"Timestamp": datetime(2024, 1, 1, 0, 0, 0), "Average": 0.91}
+    newer = {"Timestamp": datetime(2024, 1, 1, 1, 0, 0), "Average": 0.42}
+    client = _cloudwatch_client_returning([older, newer])
+
+    with patch("boto3.client", return_value=client) as mock_client:
+        result = asyncio.run(
+            metrics_module.metrics_cloudwatch_get(
+                metric_name="GpuUtilization",
+                namespace="GCO/Training",
+                region="us-east-1",
+                dimensions={"JobName": "sft-run"},
+                statistic="Average",
+            )
+        )
+
+    # No live AWS: the region-scoped client was constructed and a read-only
+    # GetMetricStatistics was issued against the mock.
+    mock_client.assert_called_once()
+    assert mock_client.call_args.kwargs.get("region_name") == "us-east-1"
+    client.get_metric_statistics.assert_called_once()
+
+    # Most-recent datapoint (0.42 at 01:00) wins over the older (0.91 at 00:00).
+    _assert_canonical_shape(
+        result,
+        expected_key="GpuUtilization",
+        expected_value=0.42,
+        provenance_keys=("source", "region", "statistic", "datapoint_timestamp"),
+    )
+    assert result["region"] == "us-east-1"
+    assert result["statistic"] == "Average"
+
+
+def test_cloudwatch_get_success_honours_output_name() -> None:
+    """An explicit ``output_name`` becomes the metric key on the success path.
+
+    Validates: Requirements 16.1
+    """
+    metrics_module = _import_metrics_tool_module()
+
+    client = _cloudwatch_client_returning(
+        [{"Timestamp": datetime(2024, 6, 1, 12, 0, 0), "Sum": 1234}]
+    )
+
+    with patch("boto3.client", return_value=client):
+        result = asyncio.run(
+            metrics_module.metrics_cloudwatch_get(
+                metric_name="RequestCount",
+                namespace="GCO/Serving",
+                region="us-west-2",
+                statistic="Sum",
+                output_name="throughput",
+            )
+        )
+
+    _assert_canonical_shape(
+        result,
+        expected_key="throughput",
+        expected_value=1234,
+        provenance_keys=("source", "region", "statistic", "datapoint_timestamp"),
+    )
+
+
+# ===========================================================================
+# Job-log reader — success path + every Aggregation_Mode
+# ===========================================================================
+
+
+def _patch_job_logs(metrics_module, monkeypatch: pytest.MonkeyPatch, lines: list[str]) -> None:
+    """Patch the job-log retrieval seam to return ``lines`` as log text.
+
+    The tool fetches logs through ``cli_runner._run_cli("jobs", "logs", ...)``;
+    replacing that call with one that returns the joined lines exercises the
+    reader end-to-end without any job-log access.
+    """
+
+    def _fake_run_cli(*_args: object, **_kwargs: object) -> str:
+        return "\n".join(lines)
+
+    monkeypatch.setattr(metrics_module.cli_runner, "_run_cli", _fake_run_cli)
+
+
+@pytest.mark.parametrize("mode", _MODES)
+def test_job_logs_json_key_reduces_known_sequence(
+    mode: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The job-log reader reduces a known per-line sequence under each mode.
+
+    Validates: Requirements 16.1, 16.2
+
+    Each log line is a JSON object carrying one ``loss`` value from the known
+    sequence; the reader extracts the dot-path key, reduces under ``mode``, and
+    returns the reference reduction in the Canonical_Metrics_Shape (key defaults
+    to the JSON key's last segment), with aggregation/source provenance outside
+    ``metrics``.
+    """
+    metrics_module = _import_metrics_tool_module()
+    lines = [json.dumps({"loss": v}) for v in _KNOWN_SEQUENCE]
+    _patch_job_logs(metrics_module, monkeypatch, lines)
+
+    result = asyncio.run(
+        metrics_module.metrics_from_job_logs(
+            job_name="sft-run",
+            region="us-east-1",
+            json_key="loss",
+            aggregation=mode,
+        )
+    )
+
+    expected = _reference_reduce(_KNOWN_SEQUENCE, mode)
+    _assert_canonical_shape(
+        result,
+        expected_key="loss",
+        expected_value=expected,
+        provenance_keys=("source", "region", "aggregation", "match_count"),
+    )
+    assert result["aggregation"] == mode
+    assert result["match_count"] == len(_KNOWN_SEQUENCE)
+
+
+def test_job_logs_default_aggregation_is_last(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no aggregation supplied the job-log reader returns the most-recent match.
+
+    Validates: Requirements 16.1, 16.2
+    """
+    metrics_module = _import_metrics_tool_module()
+    lines = [json.dumps({"loss": v}) for v in _KNOWN_SEQUENCE]
+    _patch_job_logs(metrics_module, monkeypatch, lines)
+
+    result = asyncio.run(
+        metrics_module.metrics_from_job_logs(
+            job_name="sft-run",
+            region="us-east-1",
+            json_key="loss",
+        )
+    )
+
+    _assert_canonical_shape(
+        result,
+        expected_key="loss",
+        expected_value=_KNOWN_SEQUENCE[-1],
+        provenance_keys=("source", "region", "aggregation", "match_count"),
+    )
+    assert result["aggregation"] == "last"
+
+
+@pytest.mark.parametrize("mode", _MODES)
+def test_job_logs_regex_reduces_known_sequence(mode: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regex extraction's first capture group reduces under each mode.
+
+    Validates: Requirements 16.1, 16.2
+
+    The free-text lines print ``loss=<n>``; the reader captures the first group
+    per line, coerces to a number, and reduces under ``mode`` to the reference
+    scalar in the canonical shape (key defaults to ``value`` in regex mode).
+    """
+    metrics_module = _import_metrics_tool_module()
+    lines = [f"step done loss={v}" for v in _KNOWN_SEQUENCE]
+    _patch_job_logs(metrics_module, monkeypatch, lines)
+
+    result = asyncio.run(
+        metrics_module.metrics_from_job_logs(
+            job_name="sft-run",
+            region="us-east-1",
+            regex=r"loss=([0-9.]+)",
+            aggregation=mode,
+        )
+    )
+
+    expected = _reference_reduce(_KNOWN_SEQUENCE, mode)
+    _assert_canonical_shape(
+        result,
+        expected_key="value",
+        expected_value=expected,
+        provenance_keys=("source", "region", "aggregation", "match_count"),
+    )
+
+
+# ===========================================================================
+# Shared-storage file reader — success path + every Aggregation_Mode
+# ===========================================================================
+
+
+def _patch_shared_storage(metrics_module, monkeypatch: pytest.MonkeyPatch, content: bytes) -> None:
+    """Patch the shared-storage read seam to return ``content``.
+
+    The tool fetches the artifact via ``_read_shared_storage(path, region,
+    max_bytes)``; replacing it with one that returns known bytes exercises the
+    reader (format dispatch + reduction + shape building) without any storage
+    or network access.
+    """
+
+    def _fake_read(_path: str, _region: str, _max_bytes: int) -> bytes:
+        return content
+
+    monkeypatch.setattr(metrics_module, "_read_shared_storage", _fake_read)
+
+
+def test_shared_storage_single_value_returns_canonical_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single JSON scalar reads back as a canonical metric.
+
+    Validates: Requirements 16.1
+
+    The non-history success path: a plain ``json`` document whose field is one
+    number returns that number in the Canonical_Metrics_Shape with the
+    source / region / format / aggregation provenance outside ``metrics``.
+    """
+    metrics_module = _import_metrics_tool_module()
+    content = json.dumps({"loss": 0.125}).encode("utf-8")
+    _patch_shared_storage(metrics_module, monkeypatch, content)
+
+    result = asyncio.run(
+        metrics_module.metrics_from_shared_storage_file(
+            path="runs/metrics.json",
+            region="us-east-1",
+            field="loss",
+            format="json",
+        )
+    )
+
+    _assert_canonical_shape(
+        result,
+        expected_key="loss",
+        expected_value=0.125,
+        provenance_keys=("source", "region", "format", "aggregation"),
+    )
+    assert result["format"] == "json"
+
+
+@pytest.mark.parametrize("mode", _MODES)
+def test_shared_storage_hf_log_history_reduces_known_sequence(
+    mode: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A Hugging Face ``log_history`` reduces under each mode.
+
+    Validates: Requirements 16.1, 16.2
+
+    The ``hf_trainer_state`` format gathers one ``loss`` per ``log_history``
+    entry from the known sequence and reduces under ``mode`` to the reference
+    scalar in the canonical shape — the sequence-bearing success path for the
+    file reader.
+    """
+    metrics_module = _import_metrics_tool_module()
+    content = json.dumps({"log_history": [{"loss": v} for v in _KNOWN_SEQUENCE]}).encode("utf-8")
+    _patch_shared_storage(metrics_module, monkeypatch, content)
+
+    result = asyncio.run(
+        metrics_module.metrics_from_shared_storage_file(
+            path="runs/trainer_state.json",
+            region="us-east-1",
+            field="loss",
+            format="hf_trainer_state",
+            aggregation=mode,
+        )
+    )
+
+    expected = _reference_reduce(_KNOWN_SEQUENCE, mode)
+    _assert_canonical_shape(
+        result,
+        expected_key="loss",
+        expected_value=expected,
+        provenance_keys=("source", "region", "format", "aggregation"),
+    )
+    assert result["aggregation"] == mode
+
+
+@pytest.mark.parametrize("mode", _MODES)
+def test_shared_storage_jsonl_reduces_known_sequence(
+    mode: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A JSONL step-log stream reduces under each mode.
+
+    Validates: Requirements 16.1, 16.2
+
+    The ``jsonl`` format gathers the named field from each record of the known
+    sequence and reduces under ``mode`` to the reference scalar in the
+    canonical shape, covering a second sequence-bearing format.
+    """
+    metrics_module = _import_metrics_tool_module()
+    content = "\n".join(json.dumps({"loss": v}) for v in _KNOWN_SEQUENCE).encode("utf-8")
+    _patch_shared_storage(metrics_module, monkeypatch, content)
+
+    result = asyncio.run(
+        metrics_module.metrics_from_shared_storage_file(
+            path="runs/steps.jsonl",
+            region="us-east-1",
+            field="loss",
+            format="jsonl",
+            aggregation=mode,
+        )
+    )
+
+    expected = _reference_reduce(_KNOWN_SEQUENCE, mode)
+    _assert_canonical_shape(
+        result,
+        expected_key="loss",
+        expected_value=expected,
+        provenance_keys=("source", "region", "format", "aggregation"),
+    )
+
+
+# ===========================================================================
+# Flag-gated registration (task 8.5)
+# ===========================================================================
+#
+# The success-path slice above pins down what each reader *returns*. This slice
+# pins down which readers are *registered* on the shared FastMCP server as a
+# function of the gating flags. The contract:
+#
+#   * the three default-on readers (``metrics_cloudwatch_get``,
+#     ``metrics_from_job_logs``, ``metrics_from_shared_storage_file``) are
+#     always present, independent of any flag (R3.5);
+#   * ``metrics_from_local_file`` is default-off — absent when neither
+#     ``GCO_ENABLE_LOCAL_METRICS`` nor the umbrella ``GCO_ENABLE_ALL_TOOLS`` is
+#     set (R18.1), present when ``GCO_ENABLE_LOCAL_METRICS=true`` (R18.1) or the
+#     umbrella ``GCO_ENABLE_ALL_TOOLS=true`` is set with the local flag unset
+#     (R18.3);
+#   * when present, its description begins with the literal prefix
+#     ``"[gated by GCO_ENABLE_LOCAL_METRICS]"`` (R18.4) and it carries the
+#     ``safe`` Tool_Tag (R18.5 / R3.2).
+#
+# Registry introspection note: the server (``mcp/server.py``) wires the
+# BM25/Code-Mode catalog-replacement transforms, so the *public*
+# ``mcp.list_tools()`` only exposes ~5 synthetic tools. To assert *real*
+# registration we go through the underlying registry via the private
+# ``mcp._list_tools()`` — exactly as ``tests/test_mcp_server.py::
+# TestToolRegistration`` does.
+
+# The three readers that must always be registered regardless of any flag.
+_DEFAULT_ON_READERS = (
+    "metrics_cloudwatch_get",
+    "metrics_from_job_logs",
+    "metrics_from_shared_storage_file",
+)
+
+_LOCAL_FILE_TOOL = "metrics_from_local_file"
+_GATED_DOCSTRING_PREFIX = "[gated by GCO_ENABLE_LOCAL_METRICS]"
+
+
+def _registered_tools() -> dict:
+    """Return the real registry as a ``{name: Tool}`` map.
+
+    Uses the private ``mcp._list_tools()`` to bypass the BM25/Code-Mode
+    catalog-replacement transforms — the public ``list_tools()`` would only
+    ever show the handful of synthetic entry-point tools regardless of what is
+    registered. ``run_mcp`` imports the shared FastMCP singleton and fires
+    ``register_all_tools()`` (which imports ``tools.metrics``) at import time,
+    so the default-on readers are registered as a side effect of importing it.
+    """
+    import run_mcp
+
+    tools = asyncio.run(run_mcp.mcp._list_tools())
+    return {t.name: t for t in tools}
+
+
+@contextlib.contextmanager
+def _local_metrics_flag(env: dict[str, str | None]) -> Iterator[dict]:
+    """Re-import ``tools.metrics`` under ``env`` and yield the live registry.
+
+    ``metrics_from_local_file`` is registered by a module-level
+    ``if is_enabled("GCO_ENABLE_LOCAL_METRICS"):`` block, so toggling its
+    registration requires setting the relevant env vars and **re-importing**
+    ``tools.metrics`` so the gate is re-evaluated. ``env`` maps env-var names to
+    values (or ``None`` to unset). After the body runs, the gated tool is
+    force-unregistered from the shared FastMCP singleton and the environment is
+    restored, so a registration here never leaks into a sibling test's
+    tool-count / tool-name snapshot (the same teardown precedent used by the
+    destructive-gating and local-fs confinement tests).
+
+    Yields the ``{name: Tool}`` registry map captured *after* the re-import.
+    """
+    previous: dict[str, str | None] = {key: os.environ.get(key) for key in env}
+    for key, value in env.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+    # Re-import under the env so the gated decorator re-evaluates its flag.
+    if "tools.metrics" in sys.modules:
+        del sys.modules["tools.metrics"]
+    importlib.import_module("tools.metrics")
+
+    try:
+        yield _registered_tools()
+    finally:
+        # Drop the gated registration off the shared singleton so the canonical
+        # tool-name / tool-count snapshots in sibling tests stay clean.
+        with contextlib.suppress(Exception):
+            import server
+
+            server.mcp.local_provider.remove_tool(_LOCAL_FILE_TOOL)
+        # Restore the environment we mutated.
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def test_local_file_reader_absent_when_flag_unset() -> None:
+    """With the gate unset, ``metrics_from_local_file`` is not registered.
+
+    Validates: Requirements 18.1
+
+    With neither ``GCO_ENABLE_LOCAL_METRICS`` nor the umbrella
+    ``GCO_ENABLE_ALL_TOOLS`` set, the gated decorator never fires and the tool
+    is absent from the registry; the three default-on readers remain present.
+    """
+    _import_metrics_tool_module()
+    env = {"GCO_ENABLE_LOCAL_METRICS": None, "GCO_ENABLE_ALL_TOOLS": None}
+    with _local_metrics_flag(env) as registry:
+        assert _LOCAL_FILE_TOOL not in registry, (
+            "metrics_from_local_file must be absent when the gate is unset"
+        )
+        for reader in _DEFAULT_ON_READERS:
+            assert reader in registry, f"default-on reader {reader!r} must always register"
+
+
+def test_local_file_reader_present_when_local_flag_set() -> None:
+    """``GCO_ENABLE_LOCAL_METRICS=true`` registers ``metrics_from_local_file``.
+
+    Validates: Requirements 18.1
+
+    Setting the per-tool flag fires the gated decorator so the tool appears in
+    the registry; the default-on readers stay present alongside it.
+    """
+    _import_metrics_tool_module()
+    env = {"GCO_ENABLE_LOCAL_METRICS": "true", "GCO_ENABLE_ALL_TOOLS": None}
+    with _local_metrics_flag(env) as registry:
+        assert _LOCAL_FILE_TOOL in registry, (
+            "metrics_from_local_file must register when GCO_ENABLE_LOCAL_METRICS=true"
+        )
+        for reader in _DEFAULT_ON_READERS:
+            assert reader in registry, f"default-on reader {reader!r} must always register"
+
+
+def test_local_file_reader_present_under_umbrella_flag() -> None:
+    """The umbrella ``GCO_ENABLE_ALL_TOOLS=true`` also registers the gated reader.
+
+    Validates: Requirements 18.3
+
+    With the per-tool ``GCO_ENABLE_LOCAL_METRICS`` left unset, setting only the
+    umbrella ``GCO_ENABLE_ALL_TOOLS=true`` must still enable the tool, mirroring
+    the umbrella-override semantics every other per-tool flag inherits from
+    ``feature_flags.is_enabled``.
+    """
+    _import_metrics_tool_module()
+    env = {"GCO_ENABLE_LOCAL_METRICS": None, "GCO_ENABLE_ALL_TOOLS": "true"}
+    with _local_metrics_flag(env) as registry:
+        assert _LOCAL_FILE_TOOL in registry, (
+            "metrics_from_local_file must register under the umbrella "
+            "GCO_ENABLE_ALL_TOOLS=true with the per-tool flag unset"
+        )
+        for reader in _DEFAULT_ON_READERS:
+            assert reader in registry, f"default-on reader {reader!r} must always register"
+
+
+def test_local_file_reader_docstring_prefix_and_safe_tag() -> None:
+    """When registered, the gated reader is prefixed and carries the ``safe`` tag.
+
+    Validates: Requirements 18.4
+
+    With the gate on, the tool's description must begin with the literal prefix
+    ``"[gated by GCO_ENABLE_LOCAL_METRICS]"`` (R18.4) and its Tool_Tag set must
+    include ``safe`` (R18.5 / R3.2), marking it read-only like its siblings.
+    """
+    _import_metrics_tool_module()
+    env = {"GCO_ENABLE_LOCAL_METRICS": "true", "GCO_ENABLE_ALL_TOOLS": None}
+    with _local_metrics_flag(env) as registry:
+        tool = registry.get(_LOCAL_FILE_TOOL)
+        assert tool is not None, "metrics_from_local_file must register under the flag"
+
+        # The description begins with the literal gating prefix (R18.4).
+        assert tool.description is not None
+        assert tool.description.startswith(_GATED_DOCSTRING_PREFIX), (
+            f"description must begin with {_GATED_DOCSTRING_PREFIX!r}, "
+            f"got {tool.description[: len(_GATED_DOCSTRING_PREFIX)]!r}"
+        )
+
+        # It carries the read-only ``safe`` Tool_Tag (R18.5 / R3.2).
+        assert "safe" in tool.tags, f"expected 'safe' tag, got {tool.tags!r}"
+
+
+def test_default_on_readers_present_regardless_of_flag() -> None:
+    """The three default-on readers register whether the gate is on or off.
+
+    Validates: Requirements 3.5, 18.1
+
+    A default-registered Metric_Reader_Tool must appear in the registry
+    independent of any flag. Toggling ``GCO_ENABLE_LOCAL_METRICS`` only adds or
+    removes the gated local-file reader; it must never change the presence of
+    the three default-on readers.
+    """
+    _import_metrics_tool_module()
+
+    # Flag off: default-on readers present, gated reader absent.
+    with _local_metrics_flag(
+        {"GCO_ENABLE_LOCAL_METRICS": None, "GCO_ENABLE_ALL_TOOLS": None}
+    ) as registry_off:
+        for reader in _DEFAULT_ON_READERS:
+            assert reader in registry_off, (
+                f"default-on reader {reader!r} must be present with the gate off"
+            )
+        assert _LOCAL_FILE_TOOL not in registry_off
+
+    # Flag on: default-on readers still present, gated reader now present too.
+    with _local_metrics_flag(
+        {"GCO_ENABLE_LOCAL_METRICS": "true", "GCO_ENABLE_ALL_TOOLS": None}
+    ) as registry_on:
+        for reader in _DEFAULT_ON_READERS:
+            assert reader in registry_on, (
+                f"default-on reader {reader!r} must be present with the gate on"
+            )
+        assert _LOCAL_FILE_TOOL in registry_on
+
+
+# ===========================================================================
+# Tool-registry determinism (task 8.6)
+# ===========================================================================
+#
+# The flag-gated slice above pins down individual flag combinations with hand
+# written examples. This slice generalises that contract across the whole
+# Feature_Flag space with a property test: for *any* combination of the two
+# flags that govern the local-file reader, the registry must be a deterministic
+# function of those flags. Concretely, for each generated combination:
+#
+#   1. Determinism (R3.7) — re-running ``_list_tools()`` under the SAME flag
+#      values yields the IDENTICAL set of tool names. The Tool_Registry must
+#      not depend on call order, time, or any hidden state.
+#   2. Default-on presence (R3.5) — the three default-on readers are ALWAYS in
+#      the registry, independent of the flags.
+#   3. Gated presence (R18.1, R18.3) — ``metrics_from_local_file`` is present
+#      IFF the gate is enabled, i.e. ``GCO_ENABLE_LOCAL_METRICS=true`` OR the
+#      umbrella ``GCO_ENABLE_ALL_TOOLS=true`` — exactly the
+#      ``feature_flags.is_enabled`` truth rule.
+#
+# Each example flips env vars and re-imports ``tools.metrics`` (slow), so the
+# settings mirror the sibling metric-reader property tests: ``deadline=None``
+# and the ``too_slow``/``data_too_large`` health checks suppressed. The
+# ``_local_metrics_flag`` context manager (defined above for task 8.5) is used
+# as a context manager *inside* the test body so its force-unregister +
+# environ-restore teardown runs for EVERY example — no gated registration ever
+# leaks into a sibling test's tool-count / tool-name snapshot.
+
+# The flag values an example can draw for each gate. ``None`` means "unset";
+# the non-"true" string exercises the "set but not enabled" branch of the
+# ``is_enabled`` truth rule (only the literal "true", stripped/lowered, enables).
+_FLAG_VALUES = st.sampled_from([None, "true", "false"])
+
+
+def _gate_expected_present(env: dict[str, str | None]) -> bool:
+    """Re-derive ``is_enabled('GCO_ENABLE_LOCAL_METRICS')`` from ``env``.
+
+    An independent restatement of the ``feature_flags`` truth rule: the gate is
+    enabled iff the umbrella ``GCO_ENABLE_ALL_TOOLS`` OR the per-tool
+    ``GCO_ENABLE_LOCAL_METRICS`` is the literal ``"true"`` (case-insensitive,
+    stripped). Kept deliberately separate from the production helper so a
+    divergence points at the tool gating rather than at shared logic.
+    """
+
+    def _is_true(value: str | None) -> bool:
+        return value is not None and value.strip().lower() == "true"
+
+    return _is_true(env.get("GCO_ENABLE_ALL_TOOLS")) or _is_true(
+        env.get("GCO_ENABLE_LOCAL_METRICS")
+    )
+
+
+# Feature: mission-metric-reader-tools, Property 10: Tool-registry determinism
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
+)
+@given(local_flag=_FLAG_VALUES, umbrella_flag=_FLAG_VALUES)
+def test_tool_registry_determinism(local_flag: str | None, umbrella_flag: str | None) -> None:
+    """The Tool_Registry is a deterministic function of the gating flags.
+
+    Validates: Requirements 3.5, 3.7, 18.1, 18.3
+
+    For any combination of ``GCO_ENABLE_LOCAL_METRICS`` and the umbrella
+    ``GCO_ENABLE_ALL_TOOLS``, re-importing ``tools.metrics`` under those values
+    yields a registry whose tool-name set is stable across repeated
+    ``_list_tools()`` calls (R3.7), always contains the three default-on
+    readers (R3.5), and contains ``metrics_from_local_file`` iff the gate is
+    enabled (R18.1, R18.3).
+    """
+    _import_metrics_tool_module()
+
+    env = {
+        "GCO_ENABLE_LOCAL_METRICS": local_flag,
+        "GCO_ENABLE_ALL_TOOLS": umbrella_flag,
+    }
+
+    # The context manager re-imports under ``env`` and, on exit, force
+    # unregisters the gated tool and restores the environment — so this example
+    # cannot leak gated registration into the next example or a sibling test.
+    with _local_metrics_flag(env) as registry:
+        names_first = set(registry)
+
+        # (1) Determinism (R3.7): a second introspection under the unchanged
+        # flag values returns the identical set of tool names.
+        names_second = set(_registered_tools())
+        assert names_first == names_second, (
+            "repeated _list_tools() under fixed flags must return the identical "
+            f"tool-name set; first={names_first ^ names_second} differed"
+        )
+
+        # (2) Default-on presence (R3.5): the three readers are always present,
+        # independent of the flags.
+        for reader in _DEFAULT_ON_READERS:
+            assert reader in names_first, (
+                f"default-on reader {reader!r} must always be registered, flags={env!r}"
+            )
+
+        # (3) Gated presence (R18.1, R18.3): the local-file reader is present
+        # iff the gate is enabled per the is_enabled truth rule.
+        expected_present = _gate_expected_present(env)
+        assert (_LOCAL_FILE_TOOL in names_first) == expected_present, (
+            f"metrics_from_local_file presence ({_LOCAL_FILE_TOOL in names_first}) "
+            f"must equal gate-enabled ({expected_present}) for flags={env!r}"
+        )

--- a/tests/test_mission_metric_trend.py
+++ b/tests/test_mission_metric_trend.py
@@ -1,0 +1,335 @@
+"""Tests for the cumulative-metrics view and the ``metric_trend`` criterion.
+
+These exercise the engine capability that lets a Mission criterion observe how
+a metric moves *across iterations* — the history-aware counterpart to the
+point-in-time ``metric_threshold`` kind. Three layers are covered:
+
+* :meth:`MissionEngine._build_cumulative_observation` accumulating a
+  ``metric_history`` series (oldest→newest, numeric-only) the same way it
+  already accumulates ``tool_results``;
+* :meth:`MissionEngine._evaluate_metric_trend` deciding met / unmet /
+  inconclusive over that series per ``direction``, ``window``, and
+  ``min_points``;
+* :func:`mcp.mission.validation.validate_criteria` accepting a well-formed
+  ``metric_trend`` criterion and rejecting the malformed shapes.
+
+Pure unit tests: no live MCP server, no AWS, no LLM.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Match the import pattern used by every other Mission test module.
+sys.path.insert(0, str(Path(__file__).parent.parent / "mcp"))
+
+from mission import validation  # noqa: E402
+from mission.engine import MissionEngine  # noqa: E402
+from mission.validation import MissionValidationError  # noqa: E402
+
+
+def _session_with_metric_iterations(values: list[float | str], key: str = "loss") -> dict:
+    """Build a minimal session whose iterations each carry one ``metrics`` reading.
+
+    Each entry in ``values`` becomes one prior iteration whose Observation has
+    ``metrics = {key: value}``. Non-numeric entries are included deliberately so
+    tests can assert the accumulator skips them.
+    """
+    iterations = []
+    for i, value in enumerate(values):
+        iterations.append(
+            {
+                "iteration_index": i,
+                "observation": {"metrics": {key: value}, "tool_results": []},
+            }
+        )
+    return {"iterations": iterations}
+
+
+# ---------------------------------------------------------------------------
+# Cumulative metric_history accumulation
+# ---------------------------------------------------------------------------
+
+
+class TestCumulativeMetricHistory:
+    """The cumulative observation accumulates an oldest→newest numeric series."""
+
+    def test_history_orders_prior_then_current(self) -> None:
+        """Prior iterations come first; the current reading lands last."""
+        session = _session_with_metric_iterations([2.0, 1.5])
+        current = {"metrics": {"loss": 1.0}, "tool_results": []}
+
+        cumulative = MissionEngine._build_cumulative_observation(current, session)  # type: ignore[arg-type]
+
+        assert cumulative["metric_history"]["loss"] == [2.0, 1.5, 1.0]
+
+    def test_history_skips_non_numeric_and_bool(self) -> None:
+        """Strings, None, and bools never enter the numeric series."""
+        session = _session_with_metric_iterations([2.0, "n/a", True])
+        current = {"metrics": {"loss": 1.0, "flag": False}, "tool_results": []}
+
+        cumulative = MissionEngine._build_cumulative_observation(current, session)  # type: ignore[arg-type]
+
+        # Only the two real numbers survive; bool/str are filtered.
+        assert cumulative["metric_history"]["loss"] == [2.0, 1.0]
+        assert "flag" not in cumulative["metric_history"]
+
+    def test_per_iteration_metrics_stay_point_in_time(self) -> None:
+        """The cumulative view's ``metrics`` is still the current reading only."""
+        session = _session_with_metric_iterations([2.0, 1.5])
+        current = {"metrics": {"loss": 1.0}, "tool_results": []}
+
+        cumulative = MissionEngine._build_cumulative_observation(current, session)  # type: ignore[arg-type]
+
+        # metrics is point-in-time (current), metric_history is the series.
+        assert cumulative["metrics"] == {"loss": 1.0}
+        assert cumulative["metric_history"]["loss"][-1] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# metric_trend evaluator
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateMetricTrend:
+    """Direct exercises of the metric_trend evaluator branches."""
+
+    @staticmethod
+    def _obs(series: list[float], key: str = "loss") -> dict:
+        return {"metric_history": {key: series}}
+
+    def test_decreasing_met(self) -> None:
+        result = MissionEngine._evaluate_metric_trend(
+            {"metric": "metrics.loss", "direction": "decreasing"},  # type: ignore[arg-type]
+            self._obs([3.0, 2.0, 1.0]),
+        )
+        assert result[0] == "met"
+        assert result[1]["delta"] == -2.0
+
+    def test_decreasing_unmet_when_rising(self) -> None:
+        result = MissionEngine._evaluate_metric_trend(
+            {"metric": "metrics.loss", "direction": "decreasing"},  # type: ignore[arg-type]
+            self._obs([1.0, 2.0, 3.0]),
+        )
+        assert result[0] == "unmet"
+
+    def test_increasing_met(self) -> None:
+        result = MissionEngine._evaluate_metric_trend(
+            {"metric": "acc", "direction": "increasing"},  # type: ignore[arg-type]
+            self._obs([0.1, 0.5, 0.9], key="acc"),
+        )
+        assert result[0] == "met"
+
+    def test_non_increasing_allows_flat(self) -> None:
+        """A flat series satisfies ``non_increasing`` (last <= first)."""
+        result = MissionEngine._evaluate_metric_trend(
+            {"metric": "metrics.loss", "direction": "non_increasing"},  # type: ignore[arg-type]
+            self._obs([2.0, 2.0, 2.0]),
+        )
+        assert result[0] == "met"
+
+    def test_decreasing_unmet_on_flat(self) -> None:
+        """A flat series does NOT satisfy strict ``decreasing``."""
+        result = MissionEngine._evaluate_metric_trend(
+            {"metric": "metrics.loss", "direction": "decreasing"},  # type: ignore[arg-type]
+            self._obs([2.0, 2.0, 2.0]),
+        )
+        assert result[0] == "unmet"
+
+    def test_window_limits_to_recent_points(self) -> None:
+        """``window`` considers only the most-recent N readings.
+
+        The full series rises then falls; a window of 2 sees only the final
+        two points (5.0 → 1.0), so ``decreasing`` is met even though the
+        series as a whole started lower.
+        """
+        result = MissionEngine._evaluate_metric_trend(
+            {"metric": "metrics.loss", "direction": "decreasing", "window": 2},  # type: ignore[arg-type]
+            self._obs([1.0, 9.0, 5.0, 1.0]),
+        )
+        assert result[0] == "met"
+        assert result[1]["points"] == [5.0, 1.0]
+
+    def test_inconclusive_below_min_points(self) -> None:
+        """A single reading is inconclusive — a trend needs at least two points."""
+        result = MissionEngine._evaluate_metric_trend(
+            {"metric": "metrics.loss", "direction": "decreasing"},  # type: ignore[arg-type]
+            self._obs([1.0]),
+        )
+        assert result[0] == "inconclusive"
+        assert result[1]["reason"] == "insufficient_history"
+
+    def test_inconclusive_when_custom_min_points_unmet(self) -> None:
+        """An explicit ``min_points`` raises the bar for a decision."""
+        result = MissionEngine._evaluate_metric_trend(
+            {"metric": "metrics.loss", "direction": "decreasing", "min_points": 4},  # type: ignore[arg-type]
+            self._obs([3.0, 2.0, 1.0]),
+        )
+        assert result[0] == "inconclusive"
+        assert result[1]["required_points"] == 4
+
+    def test_inconclusive_when_history_missing(self) -> None:
+        """No metric_history map on the observation is inconclusive, not a crash."""
+        result = MissionEngine._evaluate_metric_trend(
+            {"metric": "metrics.loss", "direction": "decreasing"},  # type: ignore[arg-type]
+            {},
+        )
+        assert result[0] == "inconclusive"
+
+    def test_inconclusive_when_series_empty_for_key(self) -> None:
+        """A metric with no recorded history is inconclusive."""
+        result = MissionEngine._evaluate_metric_trend(
+            {"metric": "metrics.other", "direction": "decreasing"},  # type: ignore[arg-type]
+            self._obs([1.0, 2.0]),
+        )
+        assert result[0] == "inconclusive"
+
+    def test_bare_metric_name_resolves(self) -> None:
+        """A bare key (no ``metrics.`` prefix) addresses the same series."""
+        result = MissionEngine._evaluate_metric_trend(
+            {"metric": "loss", "direction": "decreasing"},  # type: ignore[arg-type]
+            self._obs([3.0, 1.0]),
+        )
+        assert result[0] == "met"
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidateMetricTrend:
+    """The validator accepts well-formed metric_trend and rejects bad shapes."""
+
+    def test_accepts_minimal(self) -> None:
+        criteria = [
+            {
+                "criterion_id": "loss_falling",
+                "kind": "metric_trend",
+                "required": True,
+                "metric": "metrics.loss",
+                "direction": "decreasing",
+            }
+        ]
+        out = validation.validate_criteria(criteria)
+        assert out[0]["kind"] == "metric_trend"
+        assert out[0]["direction"] == "decreasing"
+
+    def test_accepts_window_and_min_points(self) -> None:
+        criteria = [
+            {
+                "criterion_id": "loss_falling",
+                "kind": "metric_trend",
+                "required": True,
+                "metric": "metrics.loss",
+                "direction": "non_increasing",
+                "window": 5,
+                "min_points": 3,
+            }
+        ]
+        out = validation.validate_criteria(criteria)
+        assert out[0]["window"] == 5
+        assert out[0]["min_points"] == 3
+
+    def test_rejects_missing_metric(self) -> None:
+        criteria = [
+            {
+                "criterion_id": "bad",
+                "kind": "metric_trend",
+                "required": True,
+                "direction": "decreasing",
+            }
+        ]
+        with pytest.raises(MissionValidationError) as exc:
+            validation.validate_criteria(criteria)
+        assert exc.value.details["reason"] == "metric_missing_or_invalid"
+
+    def test_rejects_bad_direction(self) -> None:
+        criteria = [
+            {
+                "criterion_id": "bad",
+                "kind": "metric_trend",
+                "required": True,
+                "metric": "metrics.loss",
+                "direction": "sideways",
+            }
+        ]
+        with pytest.raises(MissionValidationError) as exc:
+            validation.validate_criteria(criteria)
+        assert exc.value.details["reason"] == "direction_invalid"
+
+    def test_rejects_non_positive_window(self) -> None:
+        criteria = [
+            {
+                "criterion_id": "bad",
+                "kind": "metric_trend",
+                "required": True,
+                "metric": "metrics.loss",
+                "direction": "decreasing",
+                "window": 0,
+            }
+        ]
+        with pytest.raises(MissionValidationError) as exc:
+            validation.validate_criteria(criteria)
+        assert exc.value.details["reason"] == "window_must_be_positive_int"
+
+    def test_rejects_non_positive_min_points(self) -> None:
+        criteria = [
+            {
+                "criterion_id": "bad",
+                "kind": "metric_trend",
+                "required": True,
+                "metric": "metrics.loss",
+                "direction": "decreasing",
+                "min_points": -1,
+            }
+        ]
+        with pytest.raises(MissionValidationError) as exc:
+            validation.validate_criteria(criteria)
+        assert exc.value.details["reason"] == "min_points_must_be_positive_int"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through the criterion dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestMetricTrendThroughDispatch:
+    """The evaluate dispatch routes metric_trend against the cumulative view."""
+
+    def test_dispatch_evaluates_trend_against_history(self) -> None:
+        """A full evaluate pass marks a falling-loss trend as met.
+
+        Drives the same path the engine uses: build the cumulative observation
+        from a session with prior readings, then evaluate the criterion through
+        the public dispatch helper so the routing (trend → cumulative_obs) is
+        exercised, not just the leaf evaluator.
+        """
+
+        async def _noop_dispatcher(tool_name, args, ctx):  # type: ignore[no-untyped-def]
+            return None
+
+        engine = MissionEngine(
+            backend=None,
+            tool_dispatcher=_noop_dispatcher,
+            sampling_callable=None,
+            sandbox_runner=None,
+        )
+        session = _session_with_metric_iterations([3.0, 2.0])
+        current = {"metrics": {"loss": 1.0}, "tool_results": []}
+        cumulative = engine._build_cumulative_observation(current, session)  # type: ignore[arg-type]
+
+        criterion = {
+            "criterion_id": "loss_falling",
+            "kind": "metric_trend",
+            "required": True,
+            "metric": "metrics.loss",
+            "direction": "decreasing",
+        }
+        result = engine._evaluate_one_criterion(criterion, current, cumulative, session)  # type: ignore[arg-type]
+
+        assert result["criterion_id"] == "loss_falling"
+        assert result["status"] == "met"


### PR DESCRIPTION
Add four read-only MCP tools that emit the canonical {"metrics": {"<key>": <number>}} shape the Mission Observe phase already merges, so a metric_threshold criterion can observe a training scalar (loss, accuracy, throughput, GPU utilization) with zero scripting.

Tools (mcp/tools/metrics.py), all carrying the `safe` tag:
  - metrics_cloudwatch_get          (default-on) — one GetMetricStatistics
    datapoint, region-scoped, most-recent selected deterministically
  - metrics_from_job_logs           (default-on) — scalar from a job's log
    tail by JSON key or regex, reduced via aggregation mode
  - metrics_from_shared_storage_file (default-on) — named field from a
    shared-storage file (json/csv/hf_trainer_state/jsonl/yaml/parquet/tfevents)
  - metrics_from_local_file         (gated, default-off) — same machinery
    confined to GCO_METRICS_LOCAL_ROOT, behind GCO_ENABLE_LOCAL_METRICS

Implementation is a pure, FastMCP-free package (mcp/metric_readers/: shape, aggregate, cloudwatch, logs, files, localfs) with thin @mcp.tool wrappers. The Mission engine is unchanged (Requirement 17); the Observe-phase merge is exercised against the engine as-is.

Every failure mode returns a structured {"code","details"} error envelope rather than raising, so a failed read merges as inconclusive and the loop keeps running. History-bearing sources reduce via last/first/min/max/mean.

Tests: 10 Hypothesis properties (>=100 iterations), mocked-CloudWatch unit tests, file-error-class tests, local-file confinement integration tests, flag-gated registration tests, and an Observe-phase merge-contract test against the real engine.

Docs: tool counts bumped to 95 default / 117 all-flags in mcp/README.md and mcp/tools/README.md; new operator section in docs/MISSION.md; HF Trainer example artifact + criteria file with examples/README.md entry.

<!--
Thanks for contributing to Global Capacity Orchestrator (GCO)! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [ ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
