### PR TITLE
feat(mission): add per-session allow-all-tools option

### DIFF
--- a/cli/commands/mission_cmd.py
+++ b/cli/commands/mission_cmd.py
@@ -189,8 +189,16 @@ def mission_cmd() -> None:
 @click.option(
     "--tool-allowlist",
     multiple=True,
-    required=True,
-    help="Tool name to allowlist; pass multiple times for multiple tools.",
+    help="Tool name to allowlist; pass multiple times. Optional with --allow-all-tools.",
+)
+@click.option(
+    "--allow-all-tools",
+    is_flag=True,
+    help=(
+        "Resolve the session's tool allowlist to every registered MCP tool "
+        "(minus the mission_* control tools). Makes --tool-allowlist optional; "
+        "mutually exclusive with it."
+    ),
 )
 @click.option(
     "--cadence",
@@ -268,6 +276,7 @@ def mission_start(
     max_iterations: int,
     max_wall_clock: int,
     tool_allowlist: tuple[str, ...],
+    allow_all_tools: bool,
     cadence: str,
     cadence_n: int | None,
     cadence_t: int | None,
@@ -351,17 +360,25 @@ def mission_start(
     if cadence_event is not None:
         cadence_dict["event_name"] = cadence_event
 
-    # Validate inputs. The CLI has no live FastMCP tool registry, so the
-    # tool-allowlist validator is skipped and the budget validator gets
-    # an empty tag map — meaning a CLI-started session with a cost-
-    # incurring tool will only be caught at iterate time when the engine
-    # routes through the real tool dispatcher. The MCP tool surface
+    # Resolve the effective allowlist before any persistence. The explicit
+    # path keeps the thin CLI behaviour (no live-registry per-name check); the
+    # all-tools path resolves from the on-demand registry. A rejection here
+    # emits a structured envelope and exits before any session is built.
+    allowlist_resolved = _resolve_cli_allowlist(
+        allow_all_tools=allow_all_tools, tool_allowlist=tool_allowlist
+    )
+
+    # Validate inputs. The CLI has no live FastMCP tool registry on the
+    # explicit path, so the tool-allowlist validator is skipped and the
+    # budget validator gets an empty tag map — meaning a CLI-started session
+    # with a cost-incurring tool will only be caught at iterate time when the
+    # engine routes through the real tool dispatcher. The MCP tool surface
     # performs the full validation; the CLI is intentionally a thin
     # smoke-test path.
     try:
         directive_clean = mission_validation.validate_directive(directive)
         criteria_clean = mission_validation.validate_criteria(criteria)
-        budget_clean = mission_validation.validate_budget(budget, list(tool_allowlist), {})
+        budget_clean = mission_validation.validate_budget(budget, allowlist_resolved, {})
         cadence_clean = mission_validation.validate_cadence(cadence_dict)
     except MissionValidationError as exc:
         _emit_error(exc.code, exc.details)
@@ -389,7 +406,7 @@ def mission_start(
         "directive_text": directive_clean,
         "criteria": criteria_clean,
         "budget": budget_clean,
-        "tool_allowlist": list(tool_allowlist),
+        "tool_allowlist": allowlist_resolved,
         "checkpoint_cadence": cadence_clean,
         "stagnation_threshold": stagnation_threshold,
         "use_sampling": use_sampling_resolved,
@@ -523,6 +540,61 @@ def _ensure_tool_registry() -> None:
     from tools import register_all_tools  # noqa: PLC0415
 
     register_all_tools()
+
+
+def _resolve_registered_tools_for_cli() -> tuple[dict[str, Any], set[str]]:
+    """Register every MCP tool on demand and snapshot the live registry.
+
+    Returns a ``(name -> Tool, control-tool names)`` pair. The control set is
+    derived from the ``"mission"`` tag, so it auto-adapts if a tenth
+    session-management tool is ever added. Calls the idempotent
+    :func:`_ensure_tool_registry` first, then lists tools through
+    ``mcp._list_tools()`` — the same low-level path the engine factory uses.
+    Returns ``({}, set())`` only when the registry genuinely holds no tools,
+    which the resolver then rejects as ``allow_all_tools_empty_registry``.
+    """
+    _ensure_tool_registry()
+    from server import mcp  # noqa: PLC0415 — lazy
+
+    async def _list() -> list[Any]:
+        return list(await mcp._list_tools())
+
+    tools = asyncio.run(_list())
+    registered = {t.name: t for t in tools}
+    control = {t.name for t in tools if "mission" in (getattr(t, "tags", None) or set())}
+    return registered, control
+
+
+def _resolve_cli_allowlist(*, allow_all_tools: bool, tool_allowlist: tuple[str, ...]) -> list[str]:
+    """Resolve a subcommand's effective tool allowlist or exit with code 1.
+
+    The all-tools branch populates the registry on demand and resolves the
+    effective list from it. The explicit branch preserves the thin CLI path
+    (no per-name registry check) but enforces at-least-one, emitting the
+    existing ``empty`` rejection when no name is supplied. On any
+    :class:`MissionValidationError` the structured envelope is emitted and the
+    process exits 1 — before the caller builds or persists a session.
+    """
+    from mission import validation as mission_validation  # noqa: PLC0415
+    from mission.validation import MissionValidationError  # noqa: PLC0415
+
+    if allow_all_tools:
+        registered_tools, control_tools = _resolve_registered_tools_for_cli()
+        try:
+            resolved: list[str] = mission_validation.resolve_effective_allowlist(
+                allow_all_tools=True,
+                explicit_allowlist=list(tool_allowlist),
+                registered_tools=registered_tools,
+                control_tools=control_tools,
+            )
+        except MissionValidationError as exc:
+            _emit_error(exc.code, exc.details)
+            sys.exit(1)
+        return resolved
+    if not tool_allowlist:
+        _emit_error("validation_error", {"field": "tool_allowlist", "reason": "empty"})
+        sys.exit(1)
+    return list(tool_allowlist)
 
 
 # ---------------------------------------------------------------------------
@@ -1174,8 +1246,16 @@ def mission_scaffold_criteria_cmd(
 @click.option(
     "--tool-allowlist",
     multiple=True,
-    required=True,
-    help="Tool name to allowlist; pass multiple times for multiple tools.",
+    help="Tool name to allowlist; pass multiple times. Optional with --allow-all-tools.",
+)
+@click.option(
+    "--allow-all-tools",
+    is_flag=True,
+    help=(
+        "Resolve the session's tool allowlist to every registered MCP tool "
+        "(minus the mission_* control tools). Makes --tool-allowlist optional; "
+        "mutually exclusive with it."
+    ),
 )
 @click.option(
     "--max-iterations",
@@ -1260,6 +1340,7 @@ def mission_scaffold_criteria_cmd(
 def mission_run_cmd(
     directive: str,
     tool_allowlist: tuple[str, ...],
+    allow_all_tools: bool,
     max_iterations: int,
     max_wall_clock: int,
     max_criteria: int,
@@ -1316,6 +1397,16 @@ def mission_run_cmd(
             {"field": "retries", "reason": "must_be_non_negative_int"},
         )
         sys.exit(1)
+
+    # Resolve the effective allowlist up front, before scaffolding or any
+    # persistence. A mutual-exclusivity or empty-registry rejection exits here
+    # with no sampling spend, no criteria file write, and no state write. The
+    # scaffolder below still consults the explicit ``tool_allowlist`` (empty
+    # under --allow-all-tools, which routes it to the directive-only
+    # deterministic path); ``allowlist_resolved`` fills the persisted session.
+    allowlist_resolved = _resolve_cli_allowlist(
+        allow_all_tools=allow_all_tools, tool_allowlist=tool_allowlist
+    )
 
     # ---- Step 1: scaffold criteria. -------------------------------------
     # Resolve the sampling state once; reuse it for both the scaffold
@@ -1376,7 +1467,7 @@ def mission_run_cmd(
     try:
         directive_clean = mission_validation.validate_directive(directive)
         criteria_clean = mission_validation.validate_criteria(criteria)
-        budget_clean = mission_validation.validate_budget(budget, list(tool_allowlist), {})
+        budget_clean = mission_validation.validate_budget(budget, allowlist_resolved, {})
         cadence_clean = mission_validation.validate_cadence(cadence_dict)
     except MissionValidationError as exc:
         _emit_error(exc.code, exc.details)
@@ -1397,7 +1488,7 @@ def mission_run_cmd(
         "directive_text": directive_clean,
         "criteria": criteria_clean,
         "budget": budget_clean,
-        "tool_allowlist": list(tool_allowlist),
+        "tool_allowlist": allowlist_resolved,
         "checkpoint_cadence": cadence_clean,
         "stagnation_threshold": stagnation_threshold,
         "use_sampling": use_sampling_resolved,

--- a/docs/MISSION.md
+++ b/docs/MISSION.md
@@ -24,6 +24,10 @@ Mission is GCO's goal-directed iteration loop. The operator declares a directive
 - [Quickstart](#quickstart)
 - [One-Command Run](#one-command-run)
 - [The No-AWS Smoke Test](#the-no-aws-smoke-test)
+- [Tool Allowlist](#tool-allowlist)
+  - [`--allow-all-tools` / `allow_all_tools`](#--allow-all-tools--allow_all_tools)
+  - [Distinct from `GCO_ENABLE_ALL_TOOLS`](#distinct-from-gco_enable_all_tools)
+  - [Risk-tier scope](#risk-tier-scope)
 - [Sampling](#sampling)
 - [Scripted Strategies](#scripted-strategies)
 - [Loop Limits](#loop-limits)
@@ -581,7 +585,8 @@ Useful options:
 | Flag | Default | Purpose |
 |------|---------|---------|
 | `--directive TEXT` | required | Natural-language goal description. |
-| `--tool-allowlist NAME` | required, repeatable | One per allowlisted tool. The first allowlisted tool also seeds the deterministic strategy when sampling is off. |
+| `--tool-allowlist NAME` | repeatable | One per allowlisted tool. The first allowlisted tool also seeds the deterministic strategy when sampling is off. Required unless `--allow-all-tools` is set; mutually exclusive with it. |
+| `--allow-all-tools` | off | Resolve the allowlist to every registered tool (minus the `mission_*` control tools). Makes `--tool-allowlist` optional; mutually exclusive with it. See [Tool Allowlist](#tool-allowlist). |
 | `--max-iterations N` | `5` | Hard cap on the iteration count. Pass `-1` to opt out. |
 | `--max-wall-clock SECONDS` | `300` | Hard cap on wall-clock seconds. Pass `-1` to opt out. |
 | `--use-sampling` / `--no-sampling` | auto-detect | Force the sampling path on/off for both the scaffolder and the loop's Strategy_Revision sampler. Default precedence: MCP host capability → Bedrock cred probe → off. |
@@ -629,6 +634,80 @@ gco mission start --run \
 ```
 
 The session terminates on `max_iterations` if the predicate is not satisfied within the iteration budget. The Final_Report streams to stdout as JSON. The same flow runs in CI as `tests/test_mission_no_aws.py` — `boto3.Session` is patched to raise on any client construction so the test fails loudly if a Mission code path tries to reach AWS.
+
+## Tool Allowlist
+
+Every Mission session carries a **tool allowlist** — the set of tool names the loop may invoke during its Execute phase and inside scripted strategies. By default you spell that list out tool-by-tool: `--tool-allowlist NAME` (repeatable) on the CLI, or the `tool_allowlist` array on the `mission_start` MCP tool. The allowlist is resolved and persisted on the session at start time, so the iteration loop, the script sandbox, the strategy-revision sampling prompt, and the Final_Report all see exactly the same concrete list.
+
+### `--allow-all-tools` / `allow_all_tools`
+
+Enumerating every tool name is tedious when you simply want the loop to reach for whatever the server exposes. Both surfaces accept an all-tools option that resolves the session's allowlist to **every currently-registered tool** (minus the nine `mission_*` control tools — see [Risk-tier scope](#risk-tier-scope)) without naming each one:
+
+| Surface | Input | Default |
+|---------|-------|---------|
+| `gco mission start` / `gco mission run` | `--allow-all-tools` (boolean flag) | disabled |
+| `mission_start` MCP tool | `allow_all_tools: bool` parameter | `false` |
+
+When the option is set, the effective allowlist is **resolved once at session-start time** to the concrete list of tool names registered with the MCP server at that moment, and that enumerated list is persisted on the session exactly as if you had typed every name. The persisted list does not change if the registered set changes later in the session.
+
+On the CLI, `--allow-all-tools` makes `--tool-allowlist` **optional** — you can omit it entirely:
+
+```bash
+export GCO_ENABLE_MISSION=true
+
+# Start a session against every registered tool, no per-tool enumeration:
+gco mission start \
+  --directive "Investigate why the us-east-1 queue is backing up." \
+  --criteria-file criteria.json \
+  --max-iterations 10 --max-wall-clock 3600 \
+  --allow-all-tools
+
+# Same for the one-command run. With no explicit allowlist, the criteria
+# scaffolder falls back to its directive-only path, then the session's
+# allowlist is filled from the registry:
+gco mission run \
+  --directive "Find documentation about inference endpoints." \
+  --max-iterations 5 --max-wall-clock 300 \
+  --allow-all-tools
+```
+
+The MCP equivalent passes `allow_all_tools: true` and omits `tool_allowlist`:
+
+```jsonc
+{
+  "directive": "Investigate why the us-east-1 queue is backing up.",
+  "criteria": [ /* ... */ ],
+  "budget": {"max_iterations": 10, "max_wall_clock_seconds": 3600},
+  "allow_all_tools": true
+}
+```
+
+**Interaction with `--tool-allowlist` (mutually exclusive).** The all-tools option and an explicit allowlist are mutually exclusive. If you set `--allow-all-tools` (or `allow_all_tools: true`) **and** also supply a non-empty `--tool-allowlist` / `tool_allowlist`, the request is rejected with a `validation_error` whose `details.reason` is `allow_all_and_explicit_allowlist_mutually_exclusive`, and no session is persisted. Supply one or the other, never both.
+
+**Empty registry.** If the all-tools option is set but nothing resolvable is registered (the registry is empty, or only the `mission_*` control tools are registered), the request is rejected with `validation_error` / `allow_all_tools_empty_registry`, and no session is persisted — you never start a session that can invoke no tools.
+
+| `details.reason` | When |
+|------------------|------|
+| `allow_all_and_explicit_allowlist_mutually_exclusive` | `--allow-all-tools` set **and** a non-empty `--tool-allowlist` supplied. |
+| `allow_all_tools_empty_registry` | `--allow-all-tools` set but the resolved set (registered tools minus the `mission_*` control tools) is empty. |
+| `empty` | Neither option set nor any `--tool-allowlist` supplied (the existing empty-allowlist error). |
+
+### Distinct from `GCO_ENABLE_ALL_TOOLS`
+
+The per-session all-tools option is **not** the same thing as the `GCO_ENABLE_ALL_TOOLS` environment variable, even though both mention "all tools". They operate at different layers and never substitute for one another:
+
+| Mechanism | Layer | Controls |
+|-----------|-------|----------|
+| `GCO_ENABLE_ALL_TOOLS` (environment variable) | server startup / **registration** | *which tools get registered* with the MCP server. |
+| `--allow-all-tools` / `allow_all_tools` (per-session option) | a single Mission session | *which already-registered tools that one session may call*. |
+
+The per-session option resolves its allowlist **from whatever is registered** — it never widens reach beyond the registered set. An operator who has not enabled the destructive, infrastructure, or cost-incurring feature flags will never see those tools registered, so they cannot enter a session's resolved allowlist. Setting `GCO_ENABLE_ALL_TOOLS=true` widens what `--allow-all-tools` resolves to *only* by virtue of registering more tools in the first place. See [Feature Flags](../mcp/README.md#feature-flags) for the registration-layer flags.
+
+### Risk-tier scope
+
+Every MCP tool carries a risk-tier tag (`safe`, `low-risk`, `destructive`, `infrastructure`, `cost-incurring`, `data-upload`, `image`). The all-tools option resolves to **all registered tools regardless of risk tier** — it does not stop at read-only `safe` tools. The blast-radius control is the **registration layer**, not this option: a destructive, infrastructure, or cost-incurring tool enters scope only if its gating feature flag was set when the server registered tools, in which case you have already opted into exposing it. Concretely, registering those higher-risk tools via their feature flags (including the `GCO_ENABLE_ALL_TOOLS` umbrella) brings them into scope of the all-tools expansion.
+
+The **only** names excluded from the expansion are the nine `mission_*` control tools (`mission_start`, `mission_status`, `mission_iterate`, `mission_checkpoint`, `mission_complete`, `mission_abort`, `mission_resume`, `mission_history`, `mission_list`), so a Mission session can never recursively invoke the session-management tools that drive it. If you want a session bounded to read-only tools only, use an explicit `--tool-allowlist` of `safe`-tagged tools instead of `--allow-all-tools`.
 
 ## Sampling
 
@@ -843,7 +922,7 @@ All `gco mission` subcommands require `GCO_ENABLE_MISSION=true`. Without the fla
 | `gco mission history <id> [--format full\|summary]` | Print the iteration history. |
 | `gco mission list [--status STATUS]` | List known sessions, optionally filtered by status. |
 
-`gco mission start --help` prints the full option list — directive text, criteria file path, the iteration and wall-clock caps (each accepting `-1` to opt out), the tool allowlist, cadence parameters, stagnation threshold, sampling toggles, and the scripted-strategy opt-in.
+`gco mission start --help` prints the full option list — directive text, criteria file path, the iteration and wall-clock caps (each accepting `-1` to opt out), the tool allowlist, cadence parameters, stagnation threshold, sampling toggles, and the scripted-strategy opt-in. The `--tool-allowlist` option (repeatable) is required unless `--allow-all-tools` is set; the two are mutually exclusive. `--allow-all-tools` (default disabled) resolves the session's allowlist to every registered tool and is available on both `start` and `run` — see [Tool Allowlist](#tool-allowlist).
 
 ## MCP Tool Reference
 
@@ -860,6 +939,8 @@ The MCP surface mirrors the CLI. All gated tools require `GCO_ENABLE_MISSION` (o
 | `mission_resume` | Transition `paused → running`. |
 | `mission_history` | Return iteration history (`full` or `summary` format). |
 | `mission_list` | List known sessions. |
+
+`mission_start` accepts an `allow_all_tools` boolean parameter (default `false`). When `true`, the session's `tool_allowlist` is resolved to every registered tool (minus the `mission_*` control tools) and `tool_allowlist` may be omitted; supplying both a non-empty `tool_allowlist` and `allow_all_tools: true` is rejected as mutually exclusive. See [Tool Allowlist](#tool-allowlist) for the full semantics, the empty-registry error, and the distinction from `GCO_ENABLE_ALL_TOOLS`.
 
 Resource templates expose session state: `mission://sessions/{session_id}` returns the live session JSON; `mission://sessions/{session_id}/report` returns the Final_Report (only after the session terminates); `mission://sessions/{session_id}/audit-replay` reconstructs the in-process audit history described in [Audit Replay](#audit-replay). The four self-indexing resources documented in [MCP Self-Indexing Resources](#mcp-self-indexing-resources) are also reachable as tools through the Resources As Tools transform.
 

--- a/mcp/mission/validation.py
+++ b/mcp/mission/validation.py
@@ -33,7 +33,7 @@ Design notes:
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Collection, Mapping, Sequence
 from typing import Any, Final, cast
 
 from . import predicate
@@ -587,6 +587,85 @@ def validate_tool_allowlist(
             raise MissionValidationError("validation_error", details=details)
         normalized.append(name)
     return normalized
+
+
+# The nine session-management tool names. They are excluded from an
+# all-tools expansion so a session can never resolve an allowlist that lets
+# it recursively invoke the tools that start, drive, and tear down sessions.
+# This constant is the default exclusion set for
+# :func:`resolve_effective_allowlist`; callers holding a live tag map may pass
+# their own equivalent set instead.
+MISSION_CONTROL_TOOLS: frozenset[str] = frozenset(
+    {
+        "mission_start",
+        "mission_status",
+        "mission_iterate",
+        "mission_checkpoint",
+        "mission_complete",
+        "mission_abort",
+        "mission_resume",
+        "mission_history",
+        "mission_list",
+    }
+)
+"""The nine control-tool names excluded from an all-tools expansion."""
+
+
+def resolve_effective_allowlist(
+    *,
+    allow_all_tools: bool,
+    explicit_allowlist: list[str] | None,
+    registered_tools: dict[str, Any],
+    control_tools: Collection[str] = MISSION_CONTROL_TOOLS,
+    flag_lookup: dict[str, str] | None = None,
+) -> list[str]:
+    """Resolve a session's effective tool allowlist.
+
+    Pure: no I/O, no clocks, no environment lookups. The caller passes the
+    currently-registered tool names (``registered_tools`` — only the dict keys
+    are read) and the set of control-tool names to exclude from an all-tools
+    expansion (``control_tools``, defaulting to :data:`MISSION_CONTROL_TOOLS`).
+
+    Behaviour:
+
+    * When ``allow_all_tools`` is True and ``explicit_allowlist`` is non-empty,
+      the two inputs conflict, so the function raises
+      :class:`MissionValidationError` with
+      ``details.reason == "allow_all_and_explicit_allowlist_mutually_exclusive"``.
+    * When ``allow_all_tools`` is True and no explicit list is supplied, the
+      candidate is ``sorted(set(registered_tools) - set(control_tools))``. An
+      empty candidate (nothing registered, or only control tools registered)
+      raises ``details.reason == "allow_all_tools_empty_registry"``. Otherwise
+      the candidate is passed through :func:`validate_tool_allowlist` so the
+      resolved list satisfies every invariant an operator-supplied list would.
+    * When ``allow_all_tools`` is False, the call delegates to
+      :func:`validate_tool_allowlist` over ``explicit_allowlist or []``,
+      preserving its existing ``empty`` rejection on an empty/absent list.
+
+    Returns the normalized allowlist. The all-tools path returns a sorted,
+    duplicate-free list; the explicit path returns
+    :func:`validate_tool_allowlist`'s order-preserving output unchanged.
+    """
+    if allow_all_tools:
+        if explicit_allowlist:
+            raise MissionValidationError(
+                "validation_error",
+                details={
+                    "field": "tool_allowlist",
+                    "reason": "allow_all_and_explicit_allowlist_mutually_exclusive",
+                },
+            )
+        candidate = sorted(set(registered_tools) - set(control_tools))
+        if not candidate:
+            raise MissionValidationError(
+                "validation_error",
+                details={
+                    "field": "tool_allowlist",
+                    "reason": "allow_all_tools_empty_registry",
+                },
+            )
+        return validate_tool_allowlist(candidate, registered_tools)
+    return validate_tool_allowlist(explicit_allowlist or [], registered_tools, flag_lookup)
 
 
 # ---------------------------------------------------------------------------

--- a/mcp/tools/mission.py
+++ b/mcp/tools/mission.py
@@ -149,12 +149,13 @@ if is_enabled(FLAG_MISSION):
         directive: str,
         criteria: list[dict[str, Any]],
         budget: dict[str, Any],
-        tool_allowlist: list[str],
+        tool_allowlist: list[str] | None = None,
         checkpoint_cadence: dict[str, Any] | None = None,
         stagnation_threshold: int = 3,
         use_sampling: bool | None = None,
         allow_scripted_strategies: bool = False,
         sampling_model_preferences: dict[str, Any] | None = None,
+        allow_all_tools: bool = False,
     ) -> str:
         """[gated by GCO_ENABLE_MISSION] Start a new Mission session.
 
@@ -166,6 +167,7 @@ if is_enabled(FLAG_MISSION):
                 ``max_wall_clock_seconds``. Cost guardrails live
                 out-of-band via AWS Budgets and Cost Anomaly Detection.
             tool_allowlist: List of tool names the session may invoke.
+                Optional; omit it when ``allow_all_tools`` is set.
             checkpoint_cadence: Optional cadence dict (default
                 ``{"kind": "every_iteration"}``).
             stagnation_threshold: Iterations of no progress before
@@ -176,6 +178,11 @@ if is_enabled(FLAG_MISSION):
                 scripted strategies (validated via the sandbox AST).
             sampling_model_preferences: Optional FastMCP
                 ``ModelPreferences`` payload forwarded to MCP sampling.
+            allow_all_tools: When True (default ``False``), resolve the
+                session's allowlist to every currently-registered tool
+                minus the ``mission_*`` control tools, instead of an
+                explicit ``tool_allowlist``. Mutually exclusive with a
+                non-empty ``tool_allowlist``.
 
         Returns a JSON string with the new ``session_id`` and the
         resolved sampling state, or an error envelope.
@@ -185,8 +192,12 @@ if is_enabled(FLAG_MISSION):
             criteria_clean = mission_validation.validate_criteria(criteria)
             registered_tools = await _registered_tools_dict()
             registered_tags = await _registered_tool_tags()
-            allowlist_clean = mission_validation.validate_tool_allowlist(
-                tool_allowlist, registered_tools=registered_tools
+            control_tools = {n for n, tags in registered_tags.items() if "mission" in tags}
+            allowlist_clean = mission_validation.resolve_effective_allowlist(
+                allow_all_tools=allow_all_tools,
+                explicit_allowlist=tool_allowlist,
+                registered_tools=registered_tools,
+                control_tools=control_tools,
             )
             budget_clean = mission_validation.validate_budget(
                 budget, allowlist_clean, registered_tags

--- a/tests/test_mission_allow_all_tools_cli.py
+++ b/tests/test_mission_allow_all_tools_cli.py
@@ -1,0 +1,502 @@
+"""CLI tests for the ``--allow-all-tools`` flag on ``gco mission``.
+
+Drives the ``start`` and ``run`` subcommands through Click's
+``CliRunner`` against a ``FilesystemBackend`` rooted at ``tmp_path``,
+mirroring the harness in ``test_mission_cli.py``: every test points the
+module-level backend cache at the per-test temp directory so sessions
+written by one test never leak into another, and the gating env var is
+set per-test so the command group's gate does not block the subcommand
+under test.
+
+The all-tools branch reaches into the live MCP tool registry to resolve
+the effective allowlist. To keep these tests fast and deterministic the
+registry-resolution helper is patched to return a known, small registry
+(or an empty one), so the resolved set is predictable and no real tool
+registration happens during the test.
+
+Cases:
+
+* ``start --allow-all-tools`` with no ``--tool-allowlist`` succeeds and
+  persists the resolved set; same for ``run`` (asserting the
+  directive-only criteria fallback when the explicit list is empty).
+* ``--allow-all-tools`` together with ``--tool-allowlist`` emits the
+  mutual-exclusivity envelope, exits 1, and persists no session.
+* ``--allow-all-tools`` against an empty registry emits
+  ``allow_all_tools_empty_registry``, exits 1, and writes no session
+  file or other state.
+* The explicit-list path without the flag is unchanged.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+# The Mission package lives under ``mcp/mission`` and is imported as
+# ``mission.*``. Mirror the path-injection pattern used throughout the
+# rest of the ``test_mission_*`` files so the imports below resolve
+# regardless of how pytest is invoked.
+sys.path.insert(0, str(Path(__file__).parent.parent / "mcp"))
+
+from cli.main import cli  # noqa: E402
+
+# The command-group package re-exports the ``mission`` Click group under
+# the name ``mission_cmd``, which shadows the submodule attribute. Reach
+# the real module object through importlib so the registry-resolution
+# helper can be patched on it.
+mission_cmd_mod = importlib.import_module("cli.commands.mission_cmd")
+
+# ---------------------------------------------------------------------------
+# Shared fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_backend(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point the Mission backend cache at a per-test temp directory.
+
+    ``mission.state.get_backend()`` memoises the resolved backend in a
+    module-level ``_BACKEND_INSTANCE`` so concurrent calls share state.
+    Without overriding the cache every CLI test would write to
+    ``~/.gco/missions/`` on the developer's machine.
+    """
+    from mission import state as mission_state  # noqa: PLC0415
+    from mission.state import FilesystemBackend  # noqa: PLC0415
+
+    backend = FilesystemBackend(root=tmp_path)
+    monkeypatch.setattr(mission_state, "_BACKEND_INSTANCE", backend)
+    yield tmp_path
+    monkeypatch.setattr(mission_state, "_BACKEND_INSTANCE", None)
+
+
+def _enable_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Enable the Mission gate and clear the umbrella env var.
+
+    The command group's gate accepts either flag; clearing the umbrella
+    keeps the test focused on the per-tool flag and avoids cross-test
+    interference from a developer machine that has the umbrella set.
+    """
+    monkeypatch.setenv("GCO_ENABLE_MISSION", "true")
+    monkeypatch.delenv("GCO_ENABLE_ALL_TOOLS", raising=False)
+
+
+def _patch_registry(
+    monkeypatch: pytest.MonkeyPatch,
+    registered: dict[str, Any],
+    control: set[str],
+) -> None:
+    """Replace the CLI registry-resolution helper with a fixed snapshot.
+
+    Returns ``(registered, control)`` verbatim so the all-tools branch
+    resolves a predictable effective list without registering any real
+    tools or walking the live FastMCP instance.
+    """
+    monkeypatch.setattr(
+        mission_cmd_mod,
+        "_resolve_registered_tools_for_cli",
+        lambda: (registered, control),
+    )
+
+
+def _forbid_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the registry-resolution helper fail if it is ever called.
+
+    The explicit-list path must never reach into the registry, so a
+    test of that path patches the helper to raise: a clean run proves
+    the registry was left untouched.
+    """
+
+    def _boom() -> Any:
+        raise AssertionError("registry resolution should not run on the explicit path")
+
+    monkeypatch.setattr(mission_cmd_mod, "_resolve_registered_tools_for_cli", _boom)
+
+
+def _fake_registry() -> tuple[dict[str, Any], set[str]]:
+    """A small registry with two ordinary tools and one control tool.
+
+    The resolver reads only the dict keys, so the values can be any
+    placeholder object. The control set names the one tool that must be
+    filtered out of the all-tools expansion, leaving a stable resolved
+    list of ``["find_examples", "list_jobs"]``.
+    """
+    registered: dict[str, Any] = {
+        "list_jobs": object(),
+        "find_examples": object(),
+        "mission_start": object(),
+    }
+    control = {"mission_start"}
+    return registered, control
+
+
+_RESOLVED_SET = ["find_examples", "list_jobs"]
+
+
+def _session_files(root: Path) -> list[Path]:
+    """Return persisted session JSON files under ``root``.
+
+    Excludes the ``*.report.json`` Final_Report sidecar so the count
+    reflects only sessions that were actually saved.
+    """
+    return [p for p in root.glob("mission-*.json") if not p.name.endswith(".report.json")]
+
+
+def _load_only_session(root: Path) -> dict[str, Any]:
+    """Load the single persisted session under ``root`` as a dict."""
+    files = _session_files(root)
+    assert len(files) == 1, f"expected exactly one session file, found {files}"
+    return json.loads(files[0].read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# start --allow-all-tools
+# ---------------------------------------------------------------------------
+
+
+class TestMissionStartAllowAllTools:
+    """``gco mission start --allow-all-tools`` behaviour."""
+
+    def test_start_allow_all_tools_without_explicit_list_persists_resolved_set(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        isolated_backend: Path,
+    ) -> None:
+        """``start --allow-all-tools`` with no explicit list saves the resolved set."""
+        _enable_flag(monkeypatch)
+        _patch_registry(monkeypatch, *_fake_registry())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "mission",
+                "start",
+                "--directive",
+                "Stabilize the widget pipeline configuration.",
+                "--max-iterations",
+                "5",
+                "--max-wall-clock",
+                "60",
+                "--allow-all-tools",
+                "--with-defaults",
+            ],
+        )
+
+        assert result.exit_code == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "pending"
+
+        session = _load_only_session(isolated_backend)
+        # The resolved allowlist is the registry minus the control tool,
+        # sorted for a stable persisted order.
+        assert session["tool_allowlist"] == _RESOLVED_SET
+
+    def test_start_allow_all_tools_with_explicit_list_is_rejected(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        isolated_backend: Path,
+    ) -> None:
+        """Combining the flag with an explicit list rejects and saves nothing."""
+        _enable_flag(monkeypatch)
+        _patch_registry(monkeypatch, *_fake_registry())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "mission",
+                "start",
+                "--directive",
+                "Stabilize the widget pipeline configuration.",
+                "--max-iterations",
+                "5",
+                "--max-wall-clock",
+                "60",
+                "--allow-all-tools",
+                "--tool-allowlist",
+                "find_examples",
+                "--with-defaults",
+            ],
+        )
+
+        assert result.exit_code == 1
+        envelope = json.loads(result.stderr)
+        assert envelope["code"] == "validation_error"
+        assert envelope["details"]["field"] == "tool_allowlist"
+        assert (
+            envelope["details"]["reason"] == "allow_all_and_explicit_allowlist_mutually_exclusive"
+        )
+        # No session was persisted before the rejection.
+        assert _session_files(isolated_backend) == []
+
+    def test_start_allow_all_tools_empty_registry_is_rejected(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        isolated_backend: Path,
+    ) -> None:
+        """An empty registry rejects with no session or other state written."""
+        _enable_flag(monkeypatch)
+        _patch_registry(monkeypatch, {}, set())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "mission",
+                "start",
+                "--directive",
+                "Stabilize the widget pipeline configuration.",
+                "--max-iterations",
+                "5",
+                "--max-wall-clock",
+                "60",
+                "--allow-all-tools",
+                "--with-defaults",
+            ],
+        )
+
+        assert result.exit_code == 1
+        envelope = json.loads(result.stderr)
+        assert envelope["code"] == "validation_error"
+        assert envelope["details"]["field"] == "tool_allowlist"
+        assert envelope["details"]["reason"] == "allow_all_tools_empty_registry"
+        # No session file and no report sidecar exist under the root.
+        assert list(isolated_backend.glob("mission-*.json")) == []
+
+
+# ---------------------------------------------------------------------------
+# run --allow-all-tools
+# ---------------------------------------------------------------------------
+
+
+class TestMissionRunAllowAllTools:
+    """``gco mission run --allow-all-tools`` behaviour."""
+
+    def test_run_allow_all_tools_without_explicit_list_persists_resolved_set(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        isolated_backend: Path,
+    ) -> None:
+        """``run --allow-all-tools`` saves the resolved set and scaffolds from the directive only.
+
+        With no explicit list the criteria scaffolder receives an empty
+        allowlist and falls back to its directive-only deterministic
+        path (a single placeholder predicate rather than any per-tool
+        criterion). Resolution then fills the persisted allowlist from
+        the patched registry. ``--no-sampling`` keeps the scaffolder on
+        the deterministic path and ``--dry-run`` keeps the loop off the
+        live tool dispatcher.
+        """
+        _enable_flag(monkeypatch)
+        _patch_registry(monkeypatch, *_fake_registry())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "mission",
+                "run",
+                "--directive",
+                "Stabilize the widget pipeline configuration.",
+                "--max-iterations",
+                "1",
+                "--max-wall-clock",
+                "60",
+                "--allow-all-tools",
+                "--no-sampling",
+                "--dry-run",
+            ],
+        )
+
+        assert result.exit_code == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+
+        session = _load_only_session(isolated_backend)
+        assert session["tool_allowlist"] == _RESOLVED_SET
+
+        # The directive matched no keyword template, so the empty-allowlist
+        # scaffolder produced a single directive-only placeholder predicate
+        # and no per-tool ``tool_call_succeeded`` criteria.
+        criteria = session["criteria"]
+        assert len(criteria) == 1
+        assert criteria[0]["kind"] == "predicate"
+        assert all(c["kind"] != "tool_call_succeeded" for c in criteria)
+
+    def test_run_allow_all_tools_with_explicit_list_is_rejected(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        isolated_backend: Path,
+    ) -> None:
+        """Combining the flag with an explicit list rejects before any side effect."""
+        _enable_flag(monkeypatch)
+        _patch_registry(monkeypatch, *_fake_registry())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "mission",
+                "run",
+                "--directive",
+                "Stabilize the widget pipeline configuration.",
+                "--max-iterations",
+                "1",
+                "--allow-all-tools",
+                "--tool-allowlist",
+                "find_examples",
+                "--no-sampling",
+                "--dry-run",
+            ],
+        )
+
+        assert result.exit_code == 1
+        envelope = json.loads(result.stderr)
+        assert envelope["code"] == "validation_error"
+        assert (
+            envelope["details"]["reason"] == "allow_all_and_explicit_allowlist_mutually_exclusive"
+        )
+        # The rejection happens up front: no session and no report sidecar.
+        assert list(isolated_backend.glob("mission-*.json")) == []
+
+    def test_run_allow_all_tools_empty_registry_is_rejected(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        isolated_backend: Path,
+    ) -> None:
+        """An empty registry rejects up front with no state written."""
+        _enable_flag(monkeypatch)
+        _patch_registry(monkeypatch, {}, set())
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "mission",
+                "run",
+                "--directive",
+                "Stabilize the widget pipeline configuration.",
+                "--max-iterations",
+                "1",
+                "--allow-all-tools",
+                "--no-sampling",
+                "--dry-run",
+            ],
+        )
+
+        assert result.exit_code == 1
+        envelope = json.loads(result.stderr)
+        assert envelope["code"] == "validation_error"
+        assert envelope["details"]["reason"] == "allow_all_tools_empty_registry"
+        # Resolution runs before scaffolding and persistence, so nothing
+        # at all is written under the root.
+        assert list(isolated_backend.glob("mission-*.json")) == []
+
+
+# ---------------------------------------------------------------------------
+# Explicit-list path without the flag — unchanged behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestMissionExplicitListUnchanged:
+    """The explicit-list path without ``--allow-all-tools`` is unaffected."""
+
+    def test_start_explicit_list_without_flag_persists_and_skips_registry(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        isolated_backend: Path,
+    ) -> None:
+        """An explicit list without the flag persists verbatim and never touches the registry."""
+        _enable_flag(monkeypatch)
+        # The explicit path must not reach into the registry at all.
+        _forbid_registry(monkeypatch)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "mission",
+                "start",
+                "--directive",
+                "Stabilize the widget pipeline configuration.",
+                "--max-iterations",
+                "5",
+                "--max-wall-clock",
+                "60",
+                "--tool-allowlist",
+                "find_examples",
+                "--with-defaults",
+            ],
+        )
+
+        assert result.exit_code == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+        session = _load_only_session(isolated_backend)
+        assert session["tool_allowlist"] == ["find_examples"]
+
+    def test_start_without_flag_and_without_list_is_rejected_empty(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        isolated_backend: Path,
+    ) -> None:
+        """No flag and no explicit list rejects with the existing empty reason."""
+        _enable_flag(monkeypatch)
+        _forbid_registry(monkeypatch)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "mission",
+                "start",
+                "--directive",
+                "Stabilize the widget pipeline configuration.",
+                "--max-iterations",
+                "5",
+                "--max-wall-clock",
+                "60",
+                "--with-defaults",
+            ],
+        )
+
+        assert result.exit_code == 1
+        envelope = json.loads(result.stderr)
+        assert envelope["code"] == "validation_error"
+        assert envelope["details"]["field"] == "tool_allowlist"
+        assert envelope["details"]["reason"] == "empty"
+        assert _session_files(isolated_backend) == []
+
+    def test_run_explicit_list_without_flag_persists_and_skips_registry(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        isolated_backend: Path,
+    ) -> None:
+        """``run`` with an explicit list and no flag persists it and skips the registry."""
+        _enable_flag(monkeypatch)
+        _forbid_registry(monkeypatch)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "mission",
+                "run",
+                "--directive",
+                "Stabilize the widget pipeline configuration.",
+                "--max-iterations",
+                "1",
+                "--max-wall-clock",
+                "60",
+                "--tool-allowlist",
+                "find_examples",
+                "--no-sampling",
+                "--dry-run",
+            ],
+        )
+
+        assert result.exit_code == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+        session = _load_only_session(isolated_backend)
+        assert session["tool_allowlist"] == ["find_examples"]

--- a/tests/test_mission_allow_all_tools_doc_hygiene.py
+++ b/tests/test_mission_allow_all_tools_doc_hygiene.py
@@ -1,0 +1,115 @@
+"""Doc-hygiene guard for the allow-all-tools feature files.
+
+The allow-all-tools resolver, its MCP-tool and CLI call sites, and its
+test modules are shipped, standalone code. They should read as such:
+their comments and docstrings explain behaviour in plain terms, not by
+pointing at an internal planning artifact the repository does not
+contain. References like ``R4.1``, ``Validates: Requirements 1.3``,
+``Property 7``, or "the design's resolver table" are scaffolding from the
+authoring process — useful while building, noise (and dangling pointers)
+once merged.
+
+This test scans the feature's touched source files plus its own test
+modules and fails if any such reference survives, listing every
+offending line so the fix is mechanical. It deliberately excludes itself
+from the scan so the pattern catalogue below does not trip the very
+check it defines.
+
+The three touched source files are pre-existing, shared modules: the
+guard scans them so this feature's additions stay breadcrumb-free, and
+they carry no such references today. Documentation files (docs/MISSION.md)
+are intentionally out of scope — operator-facing prose may legitimately
+describe the feature and reference requirements.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_THIS_FILE = Path(__file__).resolve()
+
+# The feature's files: the three touched source modules and the feature
+# test modules. Documentation files (docs/MISSION.md) and example
+# artifacts are intentionally out of scope — those legitimately describe
+# the feature and may reference requirements in operator-facing prose.
+_FEATURE_PATHS: tuple[Path, ...] = (
+    _REPO_ROOT / "mcp" / "mission" / "validation.py",
+    _REPO_ROOT / "mcp" / "tools" / "mission.py",
+    _REPO_ROOT / "cli" / "commands" / "mission_cmd.py",
+    _REPO_ROOT / "tests",
+)
+
+# Only this feature's test modules under ``tests/`` are in scope; the
+# rest of the suite is unrelated.
+_TEST_PREFIX = "test_mission_allow_all_tools_"
+
+
+def _iter_feature_files() -> list[Path]:
+    """Collect the Python files this guard scans, excluding itself."""
+    tests_dir = _REPO_ROOT / "tests"
+    files: list[Path] = []
+    for base in _FEATURE_PATHS:
+        if base.is_file():
+            files.append(base)
+            continue
+        for path in sorted(base.rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            if path.resolve() == _THIS_FILE:
+                continue
+            # Under ``tests/`` only this feature's own modules are in
+            # scope, at any depth — unrelated shared helpers such as
+            # ``tests/strategies/`` belong to other features and are
+            # left out so this guard never trips on their content.
+            if base == tests_dir and not path.name.startswith(_TEST_PREFIX):
+                continue
+            files.append(path)
+    return files
+
+
+# Each pattern names a class of authoring-scaffolding reference that must
+# not survive into shipped code. The label is shown in the failure report
+# so a contributor knows what to rewrite.
+_FORBIDDEN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    # Requirement IDs like R4.1, R10.5.
+    ("requirement-id", re.compile(r"\bR\d+\.\d+\b")),
+    # The "Validates: Requirements ..." docstring annotation.
+    ("validates-annotation", re.compile(r"Validates:\s*Requirement", re.IGNORECASE)),
+    # The "# Feature: mission-allow-all-tools, Property N" tag.
+    ("feature-property-tag", re.compile(r"Feature:\s*mission-allow-all-tools")),
+    # Bare "Property N" property-numbering references.
+    ("property-number", re.compile(r"\bProperty\s+\d+\b")),
+    # "Requirement 4" / "Requirements 1.3" prose references.
+    ("requirement-word", re.compile(r"\bRequirements?\s+\d", re.IGNORECASE)),
+    # Numbered task references pointing at the implementation plan.
+    ("task-number", re.compile(r"\btask\s+\d+(?:\.\d+)?\b", re.IGNORECASE)),
+    # Pointers at planning documents the repository does not ship.
+    ("planning-doc", re.compile(r"\b(?:requirements|design|tasks)\.md\b", re.IGNORECASE)),
+    # "the design" / "design's" / "the spec" prose pointers.
+    ("spec-prose", re.compile(r"\bthe design\b|\bdesign's\b|\bthe spec\b", re.IGNORECASE)),
+)
+
+
+def test_feature_files_have_no_spec_internal_references() -> None:
+    """No allow-all-tools file may reference the authoring spec artifacts.
+
+    Scans every touched source and feature test file line by line for the
+    scaffolding patterns above and fails with a complete, grouped list of
+    offences so they can be rewritten in one pass.
+    """
+    violations: list[str] = []
+
+    for path in _iter_feature_files():
+        rel = path.relative_to(_REPO_ROOT)
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for label, pattern in _FORBIDDEN_PATTERNS:
+                if pattern.search(line):
+                    violations.append(f"{rel}:{lineno} [{label}] {line.strip()}")
+
+    assert not violations, (
+        "Spec-internal references must not appear in shipped feature files. "
+        f"Found {len(violations)}:\n" + "\n".join(violations)
+    )

--- a/tests/test_mission_allow_all_tools_integration.py
+++ b/tests/test_mission_allow_all_tools_integration.py
@@ -1,0 +1,457 @@
+"""Integration checks that an all-tools-resolved session behaves like an explicit one.
+
+When an operator asks a session to reach every registered tool, that request
+is expanded once, at session-start time, into a concrete enumerated list of
+tool names with the session-management control tools removed. The expanded
+list is stored on the session exactly as if the operator had typed each name
+by hand. Nothing downstream is told how the list came to be — it is a plain
+list of strings either way.
+
+This module exercises the unchanged iteration engine against such a session
+and confirms the Execute phase gates tool calls the same way it would for a
+hand-typed list: a name that is on the list dispatches and records a normal
+result, while a name that is off the list (including a control tool that the
+expansion deliberately dropped) is recorded as skipped without ever reaching
+the dispatcher. The same strategy run against a session whose list was typed
+out explicitly produces byte-identical call records, which is the fidelity
+guarantee under test.
+
+The module is organised so later fidelity checks can append cleanly: the
+registry fixture, the all-tools resolution helper, the session builder, and
+the single-iteration driver are all shared module-level helpers.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Mirror the import pattern every other Mission test uses: ``mcp/run_mcp.py``
+# adds ``mcp/`` to ``sys.path`` at runtime, but pytest has to do it itself
+# before the imports below resolve.
+sys.path.insert(0, str(Path(__file__).parent.parent / "mcp"))
+
+from mission import (
+    SCHEMA_VERSION,  # noqa: E402
+    validation,  # noqa: E402
+)
+from mission.engine import MissionEngine  # noqa: E402
+from mission.sampling import SamplingUsed, _render_tool_allowlist  # noqa: E402
+from mission.state import FilesystemBackend  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Shared fixtures, helpers, and constants
+# ---------------------------------------------------------------------------
+
+# A name that is registered but is a session-management control tool, so the
+# all-tools expansion drops it from the resolved list. Reusing it as a call
+# target proves the dropped name is gated exactly like any other off-list name.
+_CONTROL_TOOL = "mission_status"
+
+# Three ordinary tools the expansion keeps. One of them is the allowlisted
+# call target exercised below.
+_ALLOWED_TOOLS: tuple[str, ...] = ("find_docs", "find_examples", "list_jobs")
+
+# The allowlisted tool the driver dispatches. Picked from the kept set above.
+_DISPATCHED_TOOL = "find_examples"
+
+
+def _registry_with_control_tool() -> dict[str, Any]:
+    """Build a registered-tools mapping that includes one control tool.
+
+    Only the keys of this mapping are read by the resolver, so the values are
+    simple placeholders. The control tool is present in the registry but is
+    expected to be excluded from the resolved list.
+    """
+    registry: dict[str, Any] = {name: object() for name in _ALLOWED_TOOLS}
+    registry[_CONTROL_TOOL] = object()
+    return registry
+
+
+def _resolve_all_tools_allowlist() -> list[str]:
+    """Resolve a session allowlist the way the all-tools path produces it.
+
+    Expands a registry to every registered name minus the control tools,
+    yielding a concrete, sorted, duplicate-free enumerated list that is
+    indistinguishable from one an operator could have typed.
+    """
+    return validation.resolve_effective_allowlist(
+        allow_all_tools=True,
+        explicit_allowlist=None,
+        registered_tools=_registry_with_control_tool(),
+    )
+
+
+def _make_session(
+    *,
+    session_id: str,
+    tool_allowlist: list[str],
+) -> dict[str, Any]:
+    """Build a running session that is poised to consult the sampler.
+
+    The session carries a synthetic prior iteration whose verdict is
+    ``adjust`` and turns sampling on, so the next Propose phase adopts a
+    sampler-supplied strategy. Built by hand because the engine consumes the
+    typed fields directly and the allowlist provenance is the only thing that
+    differs between the cases under test.
+    """
+    return {
+        "version": SCHEMA_VERSION,
+        "session_id": session_id,
+        "directive_text": "Exercise Execute-phase gating against the session allowlist.",
+        "criteria": [
+            {
+                "criterion_id": "unreachable",
+                "kind": "metric_threshold",
+                "required": True,
+                "metric": "metrics.val_loss",
+                "op": "<=",
+                "target": -1.0,
+            }
+        ],
+        "budget": {"max_iterations": 10, "max_wall_clock_seconds": 600},
+        "tool_allowlist": tool_allowlist,
+        "checkpoint_cadence": {"kind": "every_iteration"},
+        "stagnation_threshold": 100,
+        "use_sampling": True,
+        "allow_scripted_strategies": False,
+        "status": "running",
+        "created_at": "2025-01-01T00:00:00Z",
+        "started_at": "2025-01-01T00:00:00+00:00",
+        "iterations": [
+            {
+                "iteration_index": 0,
+                "started_at": "2025-01-01T00:00:00+00:00",
+                "ended_at": "2025-01-01T00:00:01+00:00",
+                "phases": [],
+                "strategy": {"tool_calls": []},
+                "observation": {
+                    "tool_results": [],
+                    "metrics": {},
+                    "events": [],
+                    "phase_started_at": "2025-01-01T00:00:00+00:00",
+                    "phase_ended_at": "2025-01-01T00:00:01+00:00",
+                },
+                "criteria_evaluation": [],
+                "verdict": "adjust",
+                "verdict_reason": "heuristic_unproductive",
+                "checkpoint_evaluated": True,
+            }
+        ],
+        "no_progress_counter": 0,
+    }
+
+
+def _sampler_returning(strategy: dict[str, Any]) -> Any:
+    """Build a sampling callable that always proposes ``strategy``.
+
+    The returned strategy is delivered as an accepted sampler output so the
+    engine adopts it verbatim for the Execute phase.
+    """
+
+    async def sampling_callable(*, session: dict, ctx: Any) -> SamplingUsed:
+        del session, ctx
+        return SamplingUsed(
+            output_text="{}",
+            parsed={"revision_rationale": "r", "next_strategy": strategy},
+            backend_name="mcp",
+            model_id="test-model",
+        )
+
+    return sampling_callable
+
+
+async def _run_one_iteration(
+    backend: FilesystemBackend,
+    session: dict[str, Any],
+    strategy: dict[str, Any],
+) -> tuple[dict[str, Any], list[tuple[str, dict[str, Any]]]]:
+    """Persist ``session``, run one iteration with ``strategy``, return results.
+
+    Returns the iteration record and the list of ``(tool_name, args)`` pairs
+    the dispatcher actually received, so callers can assert both the recorded
+    call outcomes and which calls reached dispatch.
+    """
+    backend.save_session(session)
+    dispatched: list[tuple[str, dict[str, Any]]] = []
+
+    async def dispatcher(tool_name: str, args: dict, ctx: Any) -> dict[str, Any]:
+        del ctx
+        dispatched.append((tool_name, dict(args)))
+        return {"ok": True}
+
+    engine = MissionEngine(
+        backend=backend,
+        tool_dispatcher=dispatcher,
+        sampling_callable=_sampler_returning(strategy),
+        sandbox_runner=None,
+    )
+    record = await engine.run_iteration(session["session_id"])
+    return record, dispatched
+
+
+def _call_outcomes(record: dict[str, Any]) -> list[tuple[str, str]]:
+    """Extract ``(tool_name, status)`` pairs from an iteration's executed calls."""
+    calls = record["strategy"]["tool_calls"]
+    return [(call["tool_name"], call["status"]) for call in calls]
+
+
+# A strategy that names one allowlisted tool and one off-list control tool, in
+# that order, so the Execute phase must dispatch the first and gate the second.
+_MIXED_STRATEGY: dict[str, Any] = {
+    "tool_calls": [
+        {"tool_name": _DISPATCHED_TOOL, "args": {"query": "x"}},
+        {"tool_name": _CONTROL_TOOL, "args": {}},
+    ],
+    "rationale": "one allowlisted call followed by one off-list call",
+}
+
+
+# ---------------------------------------------------------------------------
+# Execute-phase gating fidelity
+# ---------------------------------------------------------------------------
+
+
+async def test_all_tools_session_gates_execute_phase_like_an_explicit_list(
+    tmp_path: Path,
+) -> None:
+    """An all-tools-resolved session gates tool calls identically to a typed list.
+
+    Two sessions are run through the unchanged engine with the same proposed
+    strategy. The first session's allowlist was produced by the all-tools
+    expansion; the second's was typed out explicitly to the same names. In
+    both, the allowlisted tool dispatches and records ``ok`` while the off-list
+    control tool is recorded ``skipped_not_allowed`` without reaching the
+    dispatcher. The two sessions yield identical call outcomes, proving the
+    gate does not care how the allowlist was produced.
+    """
+    resolved_allowlist = _resolve_all_tools_allowlist()
+
+    # The expansion keeps the ordinary tools and drops the control tool.
+    assert resolved_allowlist == sorted(_ALLOWED_TOOLS)
+    assert _CONTROL_TOOL not in resolved_allowlist
+
+    # All-tools-resolved session.
+    all_tools_backend = FilesystemBackend(root=tmp_path / "all_tools")
+    all_tools_session = _make_session(
+        session_id="sess-all-tools",
+        tool_allowlist=list(resolved_allowlist),
+    )
+    all_tools_record, all_tools_dispatched = await _run_one_iteration(
+        all_tools_backend, all_tools_session, _MIXED_STRATEGY
+    )
+
+    # Explicit-list session with the same names typed out by hand.
+    explicit_backend = FilesystemBackend(root=tmp_path / "explicit")
+    explicit_session = _make_session(
+        session_id="sess-explicit",
+        tool_allowlist=sorted(_ALLOWED_TOOLS),
+    )
+    explicit_record, explicit_dispatched = await _run_one_iteration(
+        explicit_backend, explicit_session, _MIXED_STRATEGY
+    )
+
+    # The allowlisted call dispatched; the off-list control call never did.
+    expected_dispatched = [(_DISPATCHED_TOOL, {"query": "x"})]
+    assert all_tools_dispatched == expected_dispatched
+    assert explicit_dispatched == expected_dispatched
+
+    # The recorded outcomes show the allowlisted call succeeding and the
+    # off-list control call being gated out.
+    expected_outcomes = [(_DISPATCHED_TOOL, "ok"), (_CONTROL_TOOL, "skipped_not_allowed")]
+    assert _call_outcomes(all_tools_record) == expected_outcomes
+
+    # The explicit-list session produces identical outcomes — gating is
+    # independent of how the allowlist was produced.
+    assert _call_outcomes(explicit_record) == _call_outcomes(all_tools_record)
+
+
+# ---------------------------------------------------------------------------
+# Final_Report snapshot fidelity
+# ---------------------------------------------------------------------------
+
+# Driver-loop safety bound. A session capped at a couple of iterations reaches
+# a terminal verdict well under this many turns; the bound turns a regression
+# in cap detection into a clean failure rather than an infinite loop.
+_REPORT_DRIVER_LOOP_BOUND = 20
+
+
+def _make_terminal_session(
+    *,
+    session_id: str,
+    tool_allowlist: list[str],
+) -> dict[str, Any]:
+    """Build a pending session that the engine drives to a terminal verdict.
+
+    The lone criterion targets an unreachable validation-loss value, so the
+    completion branch never fires and the run exits through the iteration cap
+    instead. Sampling is off, so the Propose phase falls back to invoking the
+    first allowlisted tool — which is why the allowlist must be non-empty and
+    enumerated, exactly what the all-tools expansion produces.
+    """
+    return {
+        "version": SCHEMA_VERSION,
+        "session_id": session_id,
+        "directive_text": "Drive to a terminal verdict so the report snapshots the allowlist.",
+        "criteria": [
+            {
+                "criterion_id": "unreachable_loss_target",
+                "kind": "metric_threshold",
+                "required": True,
+                "metric": "metrics.val_loss",
+                "op": "<=",
+                "target": -1.0,
+            }
+        ],
+        "budget": {"max_iterations": 2, "max_wall_clock_seconds": 600},
+        "tool_allowlist": tool_allowlist,
+        "checkpoint_cadence": {"kind": "every_iteration"},
+        "stagnation_threshold": 100,
+        "use_sampling": False,
+        "allow_scripted_strategies": False,
+        "status": "pending",
+        "created_at": "2025-01-01T00:00:00Z",
+        "iterations": [],
+        "no_progress_counter": 0,
+    }
+
+
+def _unmet_metric_dispatcher() -> Any:
+    """Return an async dispatcher that always reports an unmet ``val_loss``.
+
+    The constant positive value keeps the criterion ``unmet`` on every
+    iteration, so the run can only end via the iteration cap. The tool name
+    and args are ignored — the engine already gated the call against the
+    allowlist before this callable runs.
+    """
+
+    async def dispatcher(tool_name: str, args: dict, ctx: Any) -> dict[str, Any]:
+        del tool_name, args, ctx
+        return {"metrics": {"val_loss": 0.5}}
+
+    return dispatcher
+
+
+async def _drive_to_terminal_verdict(
+    backend: FilesystemBackend,
+    session: dict[str, Any],
+) -> dict[str, Any]:
+    """Persist ``session``, run iterations until a terminal verdict, return it.
+
+    Returns the reloaded session once the engine has written the durable exit
+    artifact, so a caller can read back the persisted report.
+    """
+    backend.save_session(session)
+    engine = MissionEngine(
+        backend=backend,
+        tool_dispatcher=_unmet_metric_dispatcher(),
+        sampling_callable=None,
+        sandbox_runner=None,
+    )
+
+    for _ in range(_REPORT_DRIVER_LOOP_BOUND):
+        record = await engine.run_iteration(session["session_id"])
+        if record["verdict"] in ("complete", "terminate"):
+            break
+    else:  # pragma: no cover - safety bound
+        raise AssertionError(
+            "session did not reach a terminal verdict within the driver loop bound"
+        )
+
+    persisted = backend.load_session(session["session_id"])
+    assert persisted is not None
+    return persisted
+
+
+async def test_all_tools_session_report_snapshots_the_persisted_allowlist(
+    tmp_path: Path,
+) -> None:
+    """The exit report snapshots an all-tools session's allowlist verbatim.
+
+    A session whose allowlist came from the all-tools expansion is driven to a
+    terminal verdict through the unchanged engine and report writer. The report
+    written at termination carries a ``tool_allowlist`` that is byte-for-byte
+    the concrete enumerated list persisted on the session — the expanded names
+    with the control tool removed — so an operator auditing the report sees
+    exactly which tools were in scope, regardless of how the list was produced.
+    """
+    resolved_allowlist = _resolve_all_tools_allowlist()
+
+    # The expansion keeps the ordinary tools and drops the control tool.
+    assert resolved_allowlist == sorted(_ALLOWED_TOOLS)
+    assert _CONTROL_TOOL not in resolved_allowlist
+
+    backend = FilesystemBackend(root=tmp_path / "report")
+    session = _make_terminal_session(
+        session_id="sess-report-all-tools",
+        tool_allowlist=list(resolved_allowlist),
+    )
+    persisted = await _drive_to_terminal_verdict(backend, session)
+
+    # The run ended on the iteration cap, and the durable report landed.
+    assert persisted["final_verdict"] == "terminate"
+    report_path = Path(persisted["final_report_path"])
+    assert report_path.exists()
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+
+    # The report snapshots exactly the persisted resolved allowlist.
+    assert report["tool_allowlist"] == list(resolved_allowlist)
+    assert report["tool_allowlist"] == persisted["tool_allowlist"]
+
+
+# ---------------------------------------------------------------------------
+# Strategy_Revision sampling-prompt fidelity
+# ---------------------------------------------------------------------------
+
+# A docstring for each kept tool, so the rendered prompt can be checked for the
+# name/docstring pairing the advisory model relies on. Keyed by tool name.
+_TOOL_DOCSTRINGS: dict[str, str] = {
+    "find_docs": "Search the documentation catalog.",
+    "find_examples": "Search the example catalog.",
+    "list_jobs": "List the jobs currently known to the orchestrator.",
+}
+
+
+def test_all_tools_session_sampling_prompt_pairs_names_with_docstrings(
+    tmp_path: Path,
+) -> None:
+    """An all-tools session renders each tool with its docstring like a typed list.
+
+    The advisory prompt builder pairs every name on a session's allowlist with
+    that tool's docstring. This drives the builder with an allowlist produced by
+    the all-tools expansion and again with the same names typed out by hand, and
+    confirms both render the identical set of name/docstring entries: every kept
+    tool appears exactly once with its own docstring, the dropped control tool
+    appears nowhere, and the two renderings match entry-for-entry. The prompt
+    builder cannot tell how the list was produced.
+    """
+    del tmp_path  # The prompt builder is pure; no backend is needed here.
+
+    resolved_allowlist = _resolve_all_tools_allowlist()
+
+    # The expansion keeps the ordinary tools and drops the control tool.
+    assert resolved_allowlist == sorted(_ALLOWED_TOOLS)
+    assert _CONTROL_TOOL not in resolved_allowlist
+
+    # Render the allowlist that came from the all-tools expansion.
+    all_tools_rendered = _render_tool_allowlist(resolved_allowlist, _TOOL_DOCSTRINGS)
+
+    # Render the same names typed out explicitly by hand.
+    explicit_rendered = _render_tool_allowlist(sorted(_ALLOWED_TOOLS), _TOOL_DOCSTRINGS)
+
+    # Every kept tool renders exactly once, paired with its own docstring.
+    expected_entries = [
+        {"tool_name": name, "docstring": _TOOL_DOCSTRINGS[name]} for name in sorted(_ALLOWED_TOOLS)
+    ]
+    assert all_tools_rendered == expected_entries
+
+    # The dropped control tool never surfaces in the rendered prompt.
+    rendered_names = [entry["tool_name"] for entry in all_tools_rendered]
+    assert _CONTROL_TOOL not in rendered_names
+
+    # The explicit-list rendering is identical — name/docstring pairing does not
+    # depend on how the allowlist was produced.
+    assert all_tools_rendered == explicit_rendered

--- a/tests/test_mission_allow_all_tools_mcp.py
+++ b/tests/test_mission_allow_all_tools_mcp.py
@@ -1,0 +1,438 @@
+"""MCP-tool tests for the ``mission_start`` all-tools resolution path.
+
+These tests round-trip ``mission_start`` through the FastMCP in-process
+``Client`` and assert how the new ``allow_all_tools`` boolean parameter
+shapes the persisted session's ``tool_allowlist``. The handler reads the
+live tool registry via two module-level helpers
+(``_registered_tools_dict`` and ``_registered_tool_tags``); most cases
+here patch those helpers with a small, deterministic in-memory registry
+so the resolved list can be asserted exactly. The registration-separation
+cases deliberately use the real registry to prove that starting a session
+neither adds nor removes registered tools.
+
+Isolation mirrors ``tests/test_mission_mcp_tools.py``: the autouse fixture
+strips every ``mission_*`` registration before and after each test and
+re-imports the gated modules under no flags so neighbouring test files
+start from a clean registry. The ``isolated_backend`` fixture roots the
+Mission state backend under ``tmp_path`` so persisted sessions never leak
+between cases.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# Ensure mcp/ is importable, mirroring every other test module.
+sys.path.insert(0, str(Path(__file__).parent.parent / "mcp"))
+
+import mission.state as mission_state  # noqa: E402
+import run_mcp  # noqa: E402
+from mission.state import FilesystemBackend  # noqa: E402
+
+# Canonical roster of the nine session-management tools.
+_MISSION_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "mission_start",
+        "mission_status",
+        "mission_iterate",
+        "mission_checkpoint",
+        "mission_complete",
+        "mission_abort",
+        "mission_resume",
+        "mission_history",
+        "mission_list",
+    }
+)
+
+_MISSION_RESOURCE_TEMPLATES: tuple[str, ...] = (
+    "mission://sessions/{session_id}",
+    "mission://sessions/{session_id}/report",
+    "mission://sessions/{session_id}/audit-replay",
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry / reload plumbing (mirrors tests/test_mission_mcp_tools.py)
+# ---------------------------------------------------------------------------
+
+
+async def _list_tool_names_async() -> set[str]:
+    """Snapshot every registered tool name from inside a running event loop."""
+    tools = await run_mcp.mcp._list_tools()
+    return {t.name for t in tools}
+
+
+def _force_unregister_mission_tools() -> None:
+    """Strip every ``mission_*`` tool and resource template from the singleton."""
+    for name in _MISSION_TOOL_NAMES:
+        with contextlib.suppress(Exception):
+            run_mcp.mcp.local_provider.remove_tool(name)
+    for uri in _MISSION_RESOURCE_TEMPLATES:
+        with contextlib.suppress(Exception):
+            run_mcp.mcp.local_provider.remove_template(uri)
+
+
+def _drop_mission_module_caches() -> None:
+    """Drop ``tools.mission`` / ``resources.mission`` from every import cache."""
+    for parent_name, child in (("tools", "mission"), ("resources", "mission")):
+        sys.modules.pop(f"{parent_name}.{child}", None)
+        parent = sys.modules.get(parent_name)
+        if parent is not None and hasattr(parent, child):
+            delattr(parent, child)
+
+
+def _reload_run_mcp_fresh() -> None:
+    """Reload ``run_mcp`` after dropping caches so gated bodies re-evaluate."""
+    _drop_mission_module_caches()
+    importlib.reload(run_mcp)
+
+
+def _restore_mission_modules_unregistered() -> None:
+    """Re-import the gated modules under no flags so registrations are no-ops."""
+    flag_env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("GCO_ENABLE_MISSION", "GCO_ENABLE_ALL_TOOLS")
+    }
+    _drop_mission_module_caches()
+    with patch.dict(os.environ, flag_env, clear=True):
+        import resources  # noqa: F401
+        import tools  # noqa: F401
+
+        importlib.import_module("tools.mission")
+        importlib.import_module("resources.mission")
+    _force_unregister_mission_tools()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_mission_tools():
+    """Reset the live mcp singleton before and after every test."""
+    _force_unregister_mission_tools()
+    yield
+    _force_unregister_mission_tools()
+    _restore_mission_modules_unregistered()
+
+
+@pytest.fixture
+def isolated_backend(tmp_path):
+    """Root the Mission state backend at a per-test tmp filesystem instance."""
+    previous = mission_state._BACKEND_INSTANCE
+    mission_state._BACKEND_INSTANCE = FilesystemBackend(root=tmp_path / "missions")
+    yield mission_state._BACKEND_INSTANCE
+    mission_state._BACKEND_INSTANCE = previous
+
+
+# ---------------------------------------------------------------------------
+# Controlled-registry helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeTool:
+    """Minimal stand-in for a FastMCP Tool: a name, a tag set, a description."""
+
+    def __init__(self, name: str, tags: set[str]) -> None:
+        self.name = name
+        self.tags = set(tags)
+        self.description = f"{name} description."
+
+
+@contextlib.contextmanager
+def _patched_registry(tools_by_tag: dict[str, set[str]]):
+    """Patch the handler's registry helpers with a deterministic in-memory set.
+
+    ``tools_by_tag`` maps each tool name to its tag set. Control tools are
+    those carrying the ``"mission"`` tag, exactly as the live handler
+    derives them. Both async helpers are replaced for the duration of the
+    block so the resolver sees only this registry.
+    """
+    mission_mod = importlib.import_module("tools.mission")
+    tools_dict = {name: _FakeTool(name, tags) for name, tags in tools_by_tag.items()}
+    tags_dict = {name: set(tags) for name, tags in tools_by_tag.items()}
+    with (
+        patch.object(mission_mod, "_registered_tools_dict", AsyncMock(return_value=tools_dict)),
+        patch.object(mission_mod, "_registered_tool_tags", AsyncMock(return_value=tags_dict)),
+    ):
+        yield
+
+
+def _expected_resolution(tools_by_tag: dict[str, set[str]]) -> list[str]:
+    """Return the sorted non-control names for a controlled registry."""
+    control = {name for name, tags in tools_by_tag.items() if "mission" in tags}
+    return sorted(set(tools_by_tag) - control)
+
+
+def _base_start_kwargs() -> dict[str, Any]:
+    """Return a minimal valid ``mission_start`` payload without an allowlist.
+
+    The allowlist is intentionally omitted so each test supplies whatever
+    combination of ``allow_all_tools`` / ``tool_allowlist`` it exercises.
+    The criteria and budget are independent of the allowlist path.
+    """
+    return {
+        "directive": "Drive validation loss below 0.1.",
+        "criteria": [
+            {
+                "criterion_id": "loss",
+                "kind": "metric_threshold",
+                "required": True,
+                "metric": "val_loss",
+                "op": "<",
+                "target": 0.1,
+            }
+        ],
+        "budget": {"max_iterations": 10, "max_wall_clock_seconds": 3600},
+    }
+
+
+def _payload(result: Any) -> dict[str, Any]:
+    """Decode the JSON body FastMCP returns on the first content block."""
+    return json.loads(result.content[0].text)  # type: ignore[no-any-return]
+
+
+# A registry that carries two control tools, two read-only tools, and one
+# non-``safe`` (destructive/infrastructure) tool. Used to prove the
+# expansion spans every tier while still dropping the control tools.
+_MIXED_REGISTRY: dict[str, set[str]] = {
+    "mission_start": {"low-risk", "mission"},
+    "mission_iterate": {"low-risk", "mission"},
+    "list_jobs": {"safe"},
+    "cost_summary": {"safe"},
+    "deploy_stack": {"destructive", "infrastructure"},
+}
+
+
+class TestMissionStartAllowAllTools:
+    """``allow_all_tools`` resolution behaviour on the ``mission_start`` tool."""
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"GCO_ENABLE_MISSION": "true"})
+    async def test_allow_all_persists_registered_minus_control(self, isolated_backend):
+        """Setting the flag persists the sorted registered set minus control tools.
+
+        The mixed registry includes control tools and a destructive,
+        non-read-only tool; the persisted allowlist must list every
+        non-control name regardless of tier and must omit the control
+        tools entirely.
+        """
+        _reload_run_mcp_fresh()
+        from fastmcp import Client
+
+        expected = _expected_resolution(_MIXED_REGISTRY)
+        with _patched_registry(_MIXED_REGISTRY):
+            async with Client(run_mcp.mcp) as client:
+                result = await client.call_tool(
+                    "mission_start",
+                    {**_base_start_kwargs(), "allow_all_tools": True},
+                )
+
+        payload = _payload(result)
+        session_id = payload["session_id"]
+        persisted = isolated_backend.load_session(session_id)["tool_allowlist"]
+
+        assert persisted == expected
+        assert persisted == ["cost_summary", "deploy_stack", "list_jobs"]
+        # The destructive, non-read-only tool is in scope (tier-agnostic).
+        assert "deploy_stack" in persisted
+        # No control tool leaks into the resolved allowlist.
+        assert not (set(persisted) & {"mission_start", "mission_iterate"})
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"GCO_ENABLE_MISSION": "true"})
+    async def test_allow_all_with_explicit_list_is_rejected(self, isolated_backend):
+        """The flag combined with a non-empty explicit list is mutually exclusive.
+
+        The tool returns the mutual-exclusivity envelope and persists no
+        session.
+        """
+        _reload_run_mcp_fresh()
+        from fastmcp import Client
+
+        with _patched_registry(_MIXED_REGISTRY):
+            async with Client(run_mcp.mcp) as client:
+                result = await client.call_tool(
+                    "mission_start",
+                    {
+                        **_base_start_kwargs(),
+                        "allow_all_tools": True,
+                        "tool_allowlist": ["list_jobs"],
+                    },
+                )
+
+        payload = _payload(result)
+        assert payload["code"] == "validation_error"
+        assert payload["details"]["field"] == "tool_allowlist"
+        assert payload["details"]["reason"] == "allow_all_and_explicit_allowlist_mutually_exclusive"
+        # Nothing was persisted before the rejection.
+        assert isolated_backend.list_sessions() == []
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"GCO_ENABLE_MISSION": "true"})
+    async def test_omitting_flag_uses_explicit_path_unchanged(self, isolated_backend):
+        """Omitting the flag behaves as disabled and keeps the explicit list verbatim.
+
+        With no ``allow_all_tools`` argument and an explicit single-tool
+        list, the persisted allowlist is exactly that list, order
+        preserved.
+        """
+        _reload_run_mcp_fresh()
+        from fastmcp import Client
+
+        with _patched_registry(_MIXED_REGISTRY):
+            async with Client(run_mcp.mcp) as client:
+                result = await client.call_tool(
+                    "mission_start",
+                    {**_base_start_kwargs(), "tool_allowlist": ["list_jobs"]},
+                )
+
+        payload = _payload(result)
+        session_id = payload["session_id"]
+        persisted = isolated_backend.load_session(session_id)["tool_allowlist"]
+        assert persisted == ["list_jobs"]
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"GCO_ENABLE_MISSION": "true"})
+    async def test_empty_resolution_registry_is_rejected(self, isolated_backend):
+        """A registry of only control tools resolves to nothing and is rejected.
+
+        When the flag is set but the registered set minus the control
+        tools is empty, the tool returns the empty-registry envelope and
+        persists no session.
+        """
+        _reload_run_mcp_fresh()
+        from fastmcp import Client
+
+        control_only = {
+            "mission_start": {"low-risk", "mission"},
+            "mission_status": {"safe", "mission"},
+        }
+        with _patched_registry(control_only):
+            async with Client(run_mcp.mcp) as client:
+                result = await client.call_tool(
+                    "mission_start",
+                    {**_base_start_kwargs(), "allow_all_tools": True},
+                )
+
+        payload = _payload(result)
+        assert payload["code"] == "validation_error"
+        assert payload["details"]["field"] == "tool_allowlist"
+        assert payload["details"]["reason"] == "allow_all_tools_empty_registry"
+        assert isolated_backend.list_sessions() == []
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"GCO_ENABLE_MISSION": "true"})
+    async def test_resolution_is_snapshotted_once_at_start(self, isolated_backend):
+        """The resolved list is frozen at start and ignores later registry changes.
+
+        Resolve against one registry, persist, then swap in a larger
+        registry. Reloading the session still returns the original
+        resolution, proving a concrete list was stored rather than a
+        live-evaluated sentinel.
+        """
+        _reload_run_mcp_fresh()
+        from fastmcp import Client
+
+        first_registry = {
+            "mission_start": {"low-risk", "mission"},
+            "alpha_tool": {"safe"},
+            "beta_tool": {"low-risk"},
+        }
+        expected_first = _expected_resolution(first_registry)
+        assert expected_first == ["alpha_tool", "beta_tool"]
+
+        with _patched_registry(first_registry):
+            async with Client(run_mcp.mcp) as client:
+                start = await client.call_tool(
+                    "mission_start",
+                    {**_base_start_kwargs(), "allow_all_tools": True},
+                )
+        session_id = _payload(start)["session_id"]
+        assert isolated_backend.load_session(session_id)["tool_allowlist"] == expected_first
+
+        # Swap in a wider registry; a plain reload must not re-resolve.
+        second_registry = {
+            **first_registry,
+            "gamma_tool": {"safe"},
+            "delta_tool": {"destructive"},
+        }
+        with _patched_registry(second_registry):
+            async with Client(run_mcp.mcp) as client:
+                status = await client.call_tool("mission_status", {"session_id": session_id})
+
+        reloaded = _payload(status)["tool_allowlist"]
+        assert reloaded == expected_first
+        assert isolated_backend.load_session(session_id)["tool_allowlist"] == expected_first
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"GCO_ENABLE_MISSION": "true"})
+    async def test_starting_session_does_not_change_registration(self, isolated_backend):
+        """Starting an all-tools session leaves the registered tool set untouched.
+
+        The per-session option resolves from whatever is registered; it
+        never registers or unregisters tools. The live registry snapshot
+        is identical before and after the call.
+        """
+        _reload_run_mcp_fresh()
+        from fastmcp import Client
+
+        before = await _list_tool_names_async()
+        async with Client(run_mcp.mcp) as client:
+            await client.call_tool(
+                "mission_start",
+                {**_base_start_kwargs(), "allow_all_tools": True},
+            )
+        after = await _list_tool_names_async()
+
+        assert before == after, f"registration changed: {sorted(before ^ after)}"
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"GCO_ENABLE_MISSION": "true"})
+    async def test_more_registered_tools_widens_resolution(self, isolated_backend):
+        """Registering more tools widens the resolved allowlist by exactly those tools.
+
+        A narrow registry resolves to a small set; a superset registry
+        resolves to a strictly larger set whose extra members are precisely
+        the newly-registered non-control tools.
+        """
+        _reload_run_mcp_fresh()
+        from fastmcp import Client
+
+        narrow = {
+            "mission_start": {"low-risk", "mission"},
+            "alpha_tool": {"safe"},
+        }
+        wide = {
+            **narrow,
+            "omega_tool": {"safe"},
+            "deploy_stack": {"destructive"},
+        }
+
+        with _patched_registry(narrow):
+            async with Client(run_mcp.mcp) as client:
+                narrow_start = await client.call_tool(
+                    "mission_start",
+                    {**_base_start_kwargs(), "allow_all_tools": True},
+                )
+        narrow_id = _payload(narrow_start)["session_id"]
+        narrow_list = isolated_backend.load_session(narrow_id)["tool_allowlist"]
+
+        with _patched_registry(wide):
+            async with Client(run_mcp.mcp) as client:
+                wide_start = await client.call_tool(
+                    "mission_start",
+                    {**_base_start_kwargs(), "allow_all_tools": True},
+                )
+        wide_id = _payload(wide_start)["session_id"]
+        wide_list = isolated_backend.load_session(wide_id)["tool_allowlist"]
+
+        assert set(narrow_list) == {"alpha_tool"}
+        assert set(wide_list) > set(narrow_list)
+        assert set(wide_list) - set(narrow_list) == {"omega_tool", "deploy_stack"}

--- a/tests/test_mission_allow_all_tools_validation.py
+++ b/tests/test_mission_allow_all_tools_validation.py
@@ -1,0 +1,558 @@
+"""Property-based checks for the Mission all-tools allowlist resolver.
+
+When a session asks for every registered tool, the resolver expands that
+request to the concrete set of currently-registered tool names with the
+session-management control tools removed. The expansion is a pure set
+operation: it reads only the keys of the registered-tools mapping, subtracts
+the control names it is handed, and hands the survivors through the same
+allowlist validator an operator-typed list would pass through.
+
+The check below pins the central expansion invariant: the resolved list is
+exactly the registered names minus the control names, sorted and free of
+duplicates, a subset of what was registered, disjoint from the control set,
+and stable under a second pass of the allowlist validator. Each generated
+registry carries the full vocabulary of classification tags (``safe``,
+``low-risk``, ``destructive``, ``infrastructure``, ``cost-incurring``,
+``data-upload``, ``image``) so the check also confirms a tool is never
+dropped on account of its tag — only control membership decides exclusion.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
+
+# Mirror the import pattern the other Mission tests use: ``mcp/run_mcp.py``
+# adds ``mcp/`` to ``sys.path`` at runtime, but pytest has to do it itself
+# before the import below resolves.
+sys.path.insert(0, str(Path(__file__).parent.parent / "mcp"))
+
+from mission import validation  # noqa: E402
+
+# The full tag vocabulary applied to MCP tools. Every generated registry
+# carries one tool of each tag so the expansion is exercised against the
+# whole classification space on every example.
+_TAGS: tuple[str, ...] = (
+    "safe",
+    "low-risk",
+    "destructive",
+    "infrastructure",
+    "cost-incurring",
+    "data-upload",
+    "image",
+)
+
+# Tool names: non-empty, printable, whitespace-free ASCII so every name is a
+# valid allowlist entry that the underlying validator accepts.
+_TOOL_NAME = st.text(
+    alphabet=st.characters(min_codepoint=33, max_codepoint=126, blacklist_categories=("Cs",)),
+    min_size=1,
+    max_size=12,
+)
+
+
+def _tag_tool_name(tag: str) -> str:
+    """A stable per-tag tool name, distinct from generated arbitrary names."""
+    return f"__tagged__{tag}"
+
+
+@st.composite
+def _registry_and_control(draw):  # type: ignore[no-untyped-def]
+    """Build a registered-tools mapping and an overlapping control set.
+
+    The registry always contains one tool of every classification tag, plus
+    an arbitrary number of additional tools each tagged with an arbitrary
+    value. The control set mixes names drawn from the registry with invented
+    names that are not registered, giving arbitrary overlap. Examples whose
+    registered-minus-control set would be empty are discarded so the resolver
+    takes its non-empty expansion path.
+    """
+    registered: dict[str, set[str]] = {}
+
+    # Arbitrary extra tools with arbitrary tags.
+    extra_names = draw(st.lists(_TOOL_NAME, max_size=12, unique=True))
+    for name in extra_names:
+        registered[name] = {draw(st.sampled_from(_TAGS))}
+
+    # Guarantee one tool of every tag. Applied last so a name clash with an
+    # arbitrary tool can never drop a tag from the registry.
+    for tag in _TAGS:
+        registered[_tag_tool_name(tag)] = {tag}
+
+    registered_names = list(registered)
+
+    # Control set with arbitrary overlap: some names lifted from the registry
+    # (so they will be excluded) and some invented names that are absent from
+    # it (so they exercise the "control name not even registered" case).
+    overlap = draw(st.lists(st.sampled_from(registered_names), max_size=len(registered_names)))
+    outsiders = draw(st.lists(_TOOL_NAME, max_size=8))
+    control = set(overlap) | set(outsiders)
+
+    # Keep only registries where at least one non-control tool survives.
+    assume(sorted(set(registered) - control))
+    return registered, control
+
+
+@settings(
+    max_examples=200,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much],
+)
+@given(data=_registry_and_control())
+def test_all_tools_resolution_is_registered_set_minus_control_tools(
+    data: tuple[dict[str, set[str]], set[str]],
+) -> None:
+    """Expanding to all tools yields exactly the registry minus the control set.
+
+    The resolved list must equal ``sorted(set(registered) - control)`` exactly:
+    duplicate-free, a subset of the registered names, disjoint from the control
+    names, and unchanged when re-run through the allowlist validator. A tool of
+    every classification tag survives the expansion unless it is a control
+    name, confirming the tag itself never causes a drop.
+    """
+    registered, control = data
+
+    result = validation.resolve_effective_allowlist(
+        allow_all_tools=True,
+        explicit_allowlist=None,
+        registered_tools=registered,
+        control_tools=control,
+    )
+
+    expected = sorted(set(registered) - control)
+
+    # Exact equality is the core invariant.
+    assert result == expected
+
+    # No duplicates survive the expansion.
+    assert len(result) == len(set(result))
+
+    # Every resolved name was registered; none came from outside the registry.
+    assert set(result) <= set(registered)
+
+    # No control name leaks into the resolved list.
+    assert set(result).isdisjoint(control)
+
+    # The resolved list satisfies every invariant an operator-typed list would:
+    # re-running the registry validator returns it unchanged.
+    assert validation.validate_tool_allowlist(result, registered) == result
+
+    # Tag-agnosticism: a tool of each tag is retained unless it is a control
+    # name, regardless of which tag it carries.
+    for tag in _TAGS:
+        tagged = _tag_tool_name(tag)
+        if tagged not in control:
+            assert tagged in result
+
+
+@settings(
+    max_examples=200,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much],
+)
+@given(
+    registered=st.dictionaries(_TOOL_NAME, st.sets(st.sampled_from(_TAGS)), max_size=12),
+    explicit=st.lists(_TOOL_NAME, min_size=1, max_size=12),
+)
+def test_all_tools_with_an_explicit_list_is_rejected_as_mutually_exclusive(
+    registered: dict[str, set[str]],
+    explicit: list[str],
+) -> None:
+    """Asking for all tools while also naming tools is a contradiction.
+
+    When the all-tools expansion is requested at the same time as a non-empty
+    explicit list of tool names, the two inputs disagree about what the
+    session may reach. The resolver refuses to guess: it raises a validation
+    error tagged ``allow_all_and_explicit_allowlist_mutually_exclusive`` and
+    returns nothing, so no allowlist — and therefore no session — can be built
+    from the conflicting request. The registered set is irrelevant to this
+    decision; the conflict is detected before any expansion happens.
+    """
+    with pytest.raises(validation.MissionValidationError) as exc_info:
+        validation.resolve_effective_allowlist(
+            allow_all_tools=True,
+            explicit_allowlist=explicit,
+            registered_tools=registered,
+        )
+
+    error = exc_info.value
+    assert error.code == "validation_error"
+    assert error.details is not None
+    assert error.details["reason"] == "allow_all_and_explicit_allowlist_mutually_exclusive"
+
+
+# The three distinct, stable reason tokens the resolver attaches when it
+# refuses an allowlist request. They are deliberately different strings so an
+# operator can tell the three rejection conditions apart from the token alone.
+_EMPTY_REGISTRY_REASON = "allow_all_tools_empty_registry"
+_EMPTY_LIST_REASON = "empty"
+_MUTUALLY_EXCLUSIVE_REASON = "allow_all_and_explicit_allowlist_mutually_exclusive"
+
+
+@st.composite
+def _rejection_case(draw):  # type: ignore[no-untyped-def]
+    """Draw one rejection scenario plus the reason token it should produce.
+
+    The resolver refuses an allowlist request under three separate conditions,
+    and this strategy spreads its examples evenly across all three:
+
+    * Empty expansion — all-tools is requested with no explicit list, but the
+      registered names minus the control names come out empty. This covers
+      both an empty registry and a registry whose every name is a control
+      name. The expected token is ``allow_all_tools_empty_registry``.
+    * Empty explicit list — all-tools is not requested and the explicit list is
+      missing (``None``) or empty (``[]``). The expected token is ``empty``.
+    * Conflicting request — all-tools is requested together with a non-empty
+      explicit list. The expected token is
+      ``allow_all_and_explicit_allowlist_mutually_exclusive``.
+
+    Returns a ``(kwargs, expected_reason)`` pair: the keyword arguments to hand
+    the resolver and the single reason token that call must raise with.
+    """
+    which = draw(st.sampled_from(("empty_expansion", "empty_list", "conflict")))
+
+    if which == "empty_expansion":
+        # Control names are arbitrary; the registry holds only a subset of
+        # them, so registered-minus-control is always empty (the ``S ⊆ C`` and
+        # ``S empty`` cases both fall out of this construction). The explicit
+        # list stays falsy so the conflict branch is not taken instead.
+        control_names = draw(st.lists(_TOOL_NAME, max_size=8, unique=True))
+        reg_keys = (
+            draw(st.lists(st.sampled_from(control_names), unique=True)) if control_names else []
+        )
+        registered = {name: {draw(st.sampled_from(_TAGS))} for name in reg_keys}
+        kwargs = {
+            "allow_all_tools": True,
+            "explicit_allowlist": draw(st.sampled_from([None, []])),
+            "registered_tools": registered,
+            "control_tools": set(control_names),
+        }
+        return kwargs, _EMPTY_REGISTRY_REASON
+
+    if which == "empty_list":
+        registered = draw(st.dictionaries(_TOOL_NAME, st.sets(st.sampled_from(_TAGS)), max_size=12))
+        kwargs = {
+            "allow_all_tools": False,
+            "explicit_allowlist": draw(st.sampled_from([None, []])),
+            "registered_tools": registered,
+        }
+        return kwargs, _EMPTY_LIST_REASON
+
+    # which == "conflict"
+    registered = draw(st.dictionaries(_TOOL_NAME, st.sets(st.sampled_from(_TAGS)), max_size=12))
+    explicit = draw(st.lists(_TOOL_NAME, min_size=1, max_size=12))
+    kwargs = {
+        "allow_all_tools": True,
+        "explicit_allowlist": explicit,
+        "registered_tools": registered,
+    }
+    return kwargs, _MUTUALLY_EXCLUSIVE_REASON
+
+
+@settings(
+    max_examples=200,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much],
+)
+@given(case=_rejection_case())
+def test_each_rejection_condition_carries_its_own_distinct_reason(
+    case: tuple[dict, str],
+) -> None:
+    """Every rejection condition reports its own reason and never another's.
+
+    The resolver has three separate ways to refuse a request — an empty
+    all-tools expansion, an empty explicit list, and an all-tools request that
+    also names tools. Each one must raise a validation error whose ``reason``
+    is its own dedicated token, and the three tokens must stay distinct so no
+    single input could be read as two different failures at once. For every
+    generated scenario the raised reason equals the token that scenario should
+    produce and matches neither of the other two.
+    """
+    kwargs, expected_reason = case
+
+    # The three tokens are genuinely different strings, so matching one rules
+    # out the other two by construction.
+    all_reasons = {
+        _EMPTY_REGISTRY_REASON,
+        _EMPTY_LIST_REASON,
+        _MUTUALLY_EXCLUSIVE_REASON,
+    }
+    assert len(all_reasons) == 3
+
+    with pytest.raises(validation.MissionValidationError) as exc_info:
+        validation.resolve_effective_allowlist(**kwargs)
+
+    error = exc_info.value
+    assert error.code == "validation_error"
+    assert error.details is not None
+    assert error.details["field"] == "tool_allowlist"
+
+    reason = error.details["reason"]
+
+    # The scenario maps to exactly its own reason ...
+    assert reason == expected_reason
+    # ... and never collides with either of the other two classes.
+    assert reason not in (all_reasons - {expected_reason})
+
+
+@st.composite
+def _explicit_list_inputs(draw):  # type: ignore[no-untyped-def]
+    """Draw a registry, a non-empty explicit list, and a flag-lookup mapping.
+
+    The all-tools switch is left off here, so the resolver should behave as a
+    transparent pass-through to the underlying allowlist validator. To make
+    that pass-through meaningful the inputs are constructed to land on both
+    sides of the validator's decision:
+
+    * The registry holds an arbitrary set of tool names (each carries an
+      arbitrary classification tag; only the names are read).
+    * The explicit list mixes names lifted from the registry (which the
+      validator accepts) with invented names absent from it (which the
+      validator rejects as not-registered), and may repeat a name so the
+      duplicate-name rejection is reached too. It is never empty.
+    * The flag-lookup is ``None``, an empty mapping, or a mapping that favours
+      the not-registered names so the rejection's ``flag`` annotation is
+      populated on at least some examples.
+    """
+    registered_names = draw(st.lists(_TOOL_NAME, max_size=10, unique=True))
+    registered = {name: {draw(st.sampled_from(_TAGS))} for name in registered_names}
+
+    # Invented names deliberately kept out of the registry so the explicit list
+    # can drive the not-registered rejection. Drop any accidental overlap.
+    raw_outsiders = draw(st.lists(_TOOL_NAME, max_size=6, unique=True))
+    outsiders = [name for name in raw_outsiders if name not in registered]
+
+    pool = registered_names + outsiders
+    if pool:
+        # Sampling with repeats lets a name appear twice, reaching the
+        # duplicate-name rejection as well as the registered/not-registered mix.
+        explicit = draw(st.lists(st.sampled_from(pool), min_size=1, max_size=10))
+    else:
+        explicit = draw(st.lists(_TOOL_NAME, min_size=1, max_size=10))
+
+    # flag_lookup is dict[str, str] | None. Bias the keys toward names that may
+    # be missing from the registry so the validator's flag annotation fires.
+    flag_candidates = registered_names + outsiders + explicit
+    if flag_candidates and draw(st.booleans()):
+        keys = draw(st.lists(st.sampled_from(flag_candidates), max_size=8, unique=True))
+        flag_lookup: dict[str, str] | None = {name: f"GCO_ENABLE_{name}" for name in keys}
+    else:
+        flag_lookup = draw(st.sampled_from([None, {}]))
+
+    return registered, explicit, flag_lookup
+
+
+def _capture_outcome(call):  # type: ignore[no-untyped-def]
+    """Run ``call`` and capture either its return value or its error signature.
+
+    Returns ``("returned", value)`` when the call produces a value, or
+    ``("raised", code, details)`` when it raises a validation error. Two calls
+    can then be compared for an identical outcome whether they return a list or
+    reject with an error — a raised error is compared by its code and its full
+    structured details, not by object identity.
+    """
+    try:
+        return ("returned", call())
+    except validation.MissionValidationError as exc:
+        return ("raised", exc.code, exc.details)
+
+
+@settings(
+    max_examples=200,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much],
+)
+@given(inputs=_explicit_list_inputs())
+def test_not_all_tools_branch_matches_the_underlying_allowlist_validator(
+    inputs: tuple[dict[str, set[str]], list[str], dict[str, str] | None],
+) -> None:
+    """With all-tools off, resolution is the plain allowlist validator verbatim.
+
+    When the all-tools switch is off and an explicit list is supplied, the
+    resolver must neither add to nor subtract from what the underlying
+    allowlist validator already does: for the same registry, explicit list, and
+    flag-lookup, the resolver returns the identical normalized list the
+    validator returns, and when the validator rejects the list the resolver
+    raises the identical error — same code and same structured details. The two
+    outcomes are captured and compared so both the accepting and the rejecting
+    paths are pinned to the validator's behaviour exactly.
+    """
+    registered, explicit, flag_lookup = inputs
+
+    via_resolver = _capture_outcome(
+        lambda: validation.resolve_effective_allowlist(
+            allow_all_tools=False,
+            explicit_allowlist=explicit,
+            registered_tools=registered,
+            flag_lookup=flag_lookup,
+        )
+    )
+    via_validator = _capture_outcome(
+        lambda: validation.validate_tool_allowlist(explicit, registered, flag_lookup)
+    )
+
+    assert via_resolver == via_validator
+
+
+# ---------------------------------------------------------------------------
+# Concrete example checks
+#
+# The property checks above sweep the resolver across a wide input space. The
+# deterministic examples below pin a handful of fixed, hand-picked scenarios so
+# the exact returned list and the exact rejection signatures are nailed down in
+# isolation, independent of any generated data.
+# ---------------------------------------------------------------------------
+
+
+def test_known_registry_with_a_control_tool_resolves_to_sorted_survivors() -> None:
+    """A fixed registry containing one control name resolves to the rest, sorted.
+
+    Five tools are registered, one of which is a control name handed in as the
+    excluded set. The expansion drops that one control name and returns the
+    four survivors in sorted order, free of duplicates and with the control
+    name absent.
+    """
+    registered = {
+        "list_jobs": {"safe"},
+        "find_docs": {"safe"},
+        "cost_summary": {"cost-incurring"},
+        "find_examples": {"low-risk"},
+        "mission_status": {"safe"},
+    }
+    control = {"mission_status"}
+
+    result = validation.resolve_effective_allowlist(
+        allow_all_tools=True,
+        explicit_allowlist=None,
+        registered_tools=registered,
+        control_tools=control,
+    )
+
+    assert result == ["cost_summary", "find_docs", "find_examples", "list_jobs"]
+    assert "mission_status" not in result
+    assert len(result) == len(set(result))
+
+
+def test_empty_registry_is_rejected_as_empty_registry() -> None:
+    """Asking for all tools when nothing is registered is refused.
+
+    With an empty registry there is nothing to expand to, so the resolver
+    refuses the request with the empty-registry reason and never returns a
+    list.
+    """
+    with pytest.raises(validation.MissionValidationError) as exc_info:
+        validation.resolve_effective_allowlist(
+            allow_all_tools=True,
+            explicit_allowlist=None,
+            registered_tools={},
+        )
+
+    error = exc_info.value
+    assert error.code == "validation_error"
+    assert error.details is not None
+    assert error.details["field"] == "tool_allowlist"
+    assert error.details["reason"] == _EMPTY_REGISTRY_REASON
+
+
+def test_registry_of_only_control_tools_is_rejected_as_empty_registry() -> None:
+    """A registry holding nothing but control names also resolves to empty.
+
+    When every registered name is a control name, subtracting the control set
+    leaves nothing to allow, so the resolver raises the same empty-registry
+    reason it raises for a genuinely empty registry.
+    """
+    registered = {
+        "mission_start": {"safe"},
+        "mission_status": {"safe"},
+        "mission_iterate": {"safe"},
+    }
+    control = {"mission_start", "mission_status", "mission_iterate"}
+
+    with pytest.raises(validation.MissionValidationError) as exc_info:
+        validation.resolve_effective_allowlist(
+            allow_all_tools=True,
+            explicit_allowlist=None,
+            registered_tools=registered,
+            control_tools=control,
+        )
+
+    error = exc_info.value
+    assert error.code == "validation_error"
+    assert error.details is not None
+    assert error.details["reason"] == _EMPTY_REGISTRY_REASON
+
+
+def test_all_tools_with_an_explicit_list_is_rejected_as_mutually_exclusive_example() -> None:
+    """Naming tools while also asking for all of them is a fixed contradiction.
+
+    A concrete registry paired with a concrete non-empty explicit list is
+    refused with the mutual-exclusivity reason; the registry contents are
+    irrelevant because the conflict is detected before any expansion.
+    """
+    registered = {"list_jobs": {"safe"}, "find_docs": {"safe"}}
+
+    with pytest.raises(validation.MissionValidationError) as exc_info:
+        validation.resolve_effective_allowlist(
+            allow_all_tools=True,
+            explicit_allowlist=["list_jobs"],
+            registered_tools=registered,
+        )
+
+    error = exc_info.value
+    assert error.code == "validation_error"
+    assert error.details is not None
+    assert error.details["reason"] == _MUTUALLY_EXCLUSIVE_REASON
+
+
+def test_not_all_tools_with_empty_list_is_rejected_as_empty() -> None:
+    """With all-tools off and no names supplied, the empty reason is raised.
+
+    The explicit path is taken and an empty list has nothing to allow, so the
+    resolver delegates to the underlying validator's existing empty rejection.
+    """
+    with pytest.raises(validation.MissionValidationError) as exc_info:
+        validation.resolve_effective_allowlist(
+            allow_all_tools=False,
+            explicit_allowlist=[],
+            registered_tools={"list_jobs": {"safe"}},
+        )
+
+    error = exc_info.value
+    assert error.code == "validation_error"
+    assert error.details is not None
+    assert error.details["field"] == "tool_allowlist"
+    assert error.details["reason"] == _EMPTY_LIST_REASON
+
+
+def test_default_control_set_excludes_the_nine_session_management_names() -> None:
+    """Omitting the control set falls back to the built-in nine-name exclusion.
+
+    The resolver is called without an explicit control set, so it uses its
+    default. A registry that contains all nine built-in session-management
+    names alongside three ordinary tools resolves to exactly the three ordinary
+    tools, sorted; none of the nine built-in names survive.
+    """
+    ordinary = {
+        "list_jobs": {"safe"},
+        "find_docs": {"safe"},
+        "cost_summary": {"cost-incurring"},
+    }
+    registered = {name: {"safe"} for name in validation.MISSION_CONTROL_TOOLS}
+    registered.update(ordinary)
+
+    result = validation.resolve_effective_allowlist(
+        allow_all_tools=True,
+        explicit_allowlist=None,
+        registered_tools=registered,
+    )
+
+    assert result == ["cost_summary", "find_docs", "list_jobs"]
+    assert set(result).isdisjoint(validation.MISSION_CONTROL_TOOLS)
+    # All nine built-in control names are kept out of the resolved list.
+    assert len(validation.MISSION_CONTROL_TOOLS) == 9
+    for control_name in validation.MISSION_CONTROL_TOOLS:
+        assert control_name not in result


### PR DESCRIPTION
Add an option that resolves a Mission session's tool allowlist to every currently-registered MCP tool (minus the nine mission_* control tools) instead of requiring each tool name to be enumerated. It surfaces as the allow_all_tools parameter on the mission_start MCP tool and as --allow-all-tools on the gco mission start / run CLI subcommands.

The allowlist is resolved once at session-start time to a concrete, enumerated list and persisted exactly as an operator-typed list would be, so the engine, sandbox, sampling prompt, and final report all consume it unchanged. The option is mutually exclusive with an explicit allowlist and rejects an empty registry before any session is persisted.

- Add resolve_effective_allowlist and MISSION_CONTROL_TOOLS to the pure validation seam, in front of the unchanged validate_tool_allowlist
- Wire the resolver into the mission_start MCP tool and the CLI start/run subcommands, making --tool-allowlist optional
- Document both surfaces, the mutual-exclusivity rule, the distinction from GCO_ENABLE_ALL_TOOLS, and the risk-tier scope in docs/MISSION.md
- Cover the resolver with Hypothesis property tests plus MCP, CLI, and unchanged-consumer fidelity tests, and add a doc-hygiene guard

<!--
Thanks for contributing to Global Capacity Orchestrator (GCO)! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [ ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
