### PR TITLE
chore(eks): upgrade EKS/Kubernetes to v1.36

### DIFF
--- a/.github/scripts/lib_dependency_scan.sh
+++ b/.github/scripts/lib_dependency_scan.sh
@@ -221,10 +221,10 @@ except ImportError:
 
 # extract_k8s_version [cdk_json_path]
 #
-# Reads the kubernetes_version from cdk.json. Falls back to "1.35".
+# Reads the kubernetes_version from cdk.json. Falls back to "1.36".
 extract_k8s_version() {
   local cdk="${1:-cdk.json}"
-  python3 -c "import json; print(json.load(open('$cdk'))['context']['kubernetes_version'])" 2>/dev/null || echo "1.35"
+  python3 -c "import json; print(json.load(open('$cdk'))['context']['kubernetes_version'])" 2>/dev/null || echo "1.36"
 }
 
 # extract_dockerfile_pins <dockerfile>
@@ -244,7 +244,7 @@ extract_k8s_version() {
 #     NODE_MAJOR|24
 #     NPM_VERSION|11.14.1
 #     CDK_VERSION|2.1120.0
-#     KUBECTL_VERSION|v1.35.4
+#     KUBECTL_VERSION|v1.36.1
 #     AWSCLI_VERSION|2.34.42
 #     DOCKER_VERSION|29.4.2
 extract_dockerfile_pins() {

--- a/.github/workflows/deps-scan.yml
+++ b/.github/workflows/deps-scan.yml
@@ -48,7 +48,7 @@ permissions:
 
 env:
   HELM_VERSION: "v4.2.0"
-  KUBECTL_VERSION: "v1.35.5"
+  KUBECTL_VERSION: "v1.36.1"
 
 jobs:
   deps-scan:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -390,7 +390,7 @@ jobs:
       - name: Verify helm + kubectl binaries
         # This is a Lambda container, not a server. The meaningful check is
         # that the image's helm and kubectl binaries are invocable at the
-        # pinned versions from the Dockerfile (helm v4.2.0, kubectl v1.35.5).
+        # pinned versions from the Dockerfile (helm v4.2.0, kubectl v1.36.1).
         run: |
           docker run --rm --entrypoint helm helm-installer:ci version --short
           docker run --rm --entrypoint kubectl helm-installer:ci version --client=true
@@ -552,8 +552,8 @@ jobs:
       - name: Create kind cluster (no default CNI)
         uses: helm/kind-action@v1.14.0
         with:
-          version: "v0.31.0"
-          node_image: "kindest/node:v1.35.0"
+          version: "v0.32.0"
+          node_image: "kindest/node:v1.36.1"
           cluster_name: "gco-ci"
           config: ".github/kind/kind-calico.yaml"
           # Default CNI is disabled in the kind config so Calico can take

--- a/.trivyignore
+++ b/.trivyignore
@@ -30,12 +30,11 @@
 #
 # Two binaries in the helm-installer Lambda container still match these
 # CVEs and keep these entries alive:
-#   - kubectl v1.35.5 pinned in Dockerfile. Built with Go 1.25.9 per
+#   - kubectl v1.36.1 pinned in Dockerfile. Built with Go 1.26.2 per
 #     `go version kubectl` and build-image/cross/VERSION on the
-#     v1.35.5 tag. v1.36.1 (the current latest k8s patch release,
-#     2026-05-12) is built with Go 1.26.2 — still on the wrong side
-#     of the fix line, so a minor bump does not clear these. Awaiting
-#     a kubectl release rebuilt with Go ≥ 1.25.10 / ≥ 1.26.3.
+#     v1.36.1 tag — still on the wrong side of the fix line, so the
+#     1.35.5 → 1.36.1 bump on this branch does not clear these.
+#     Awaiting a kubectl release rebuilt with Go ≥ 1.25.10 / ≥ 1.26.3.
 #   - aws-lambda-rie bundled in public.ecr.aws/lambda/python:3.14. Latest
 #     RIE release is v1.35 (2026-03-30, Go 1.26.2). AWS-controlled, no
 #     user-serviceable bump path — clears when AWS rebuilds the Lambda
@@ -65,9 +64,8 @@ CVE-2026-42499 exp:2026-08-22
 #   Go 1.26.3 per https://nvd.nist.gov/vuln/detail/CVE-2026-39826.
 #
 # These ride on:
-#   - kubectl v1.35.5 (built with Go 1.25.9): trips all four entries.
-#     v1.36.1 (current latest, 2026-05-12) is built with Go 1.26.2,
-#     which is still vulnerable to all four — kubectl needs a release
+#   - kubectl v1.36.1 (built with Go 1.26.2): trips all four entries.
+#     Go 1.26.2 is still vulnerable to all four — kubectl needs a release
 #     rebuilt with Go ≥ 1.25.10 / ≥ 1.26.3 before this clears.
 #   - aws-lambda-rie bundled in `public.ecr.aws/lambda/python:3.14`:
 #     trips the three Go-stdlib entries. AWS-controlled, no

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -654,7 +654,7 @@ EKS addon versions are checked by `deps-scan` when AWS credentials are configure
 
 ```bash
 # Check latest versions for all addons used by GCO
-K8S_VERSION="1.35"  # Match your configured Kubernetes version
+K8S_VERSION="1.36"  # Match your configured Kubernetes version
 
 for addon in metrics-server aws-efs-csi-driver amazon-cloudwatch-observability aws-fsx-csi-driver; do
   echo "=== $addon ==="

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -136,7 +136,7 @@ RUN npm install -g "aws-cdk@${CDK_VERSION}" \
 # allows ±1 minor, so this pin can lag or lead the cluster by one.
 # kubectl publishes both linux/amd64 and linux/arm64 binaries, so we
 # pass ${TARGETARCH} straight through.
-ARG KUBECTL_VERSION=v1.35.5
+ARG KUBECTL_VERSION=v1.36.1
 ARG TARGETARCH
 RUN curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
     && chmod +x kubectl \

--- a/cdk.json
+++ b/cdk.json
@@ -41,7 +41,7 @@
     "_comment_eks": "EKS cluster version and access posture. GCO runs EKS Auto Mode (https://docs.aws.amazon.com/eks/latest/userguide/automode.html), so node provisioning is managed by AWS — GPU/inference/EFA/Neuron compute is steered via the Karpenter NodePool manifests in lambda/kubectl-applier-simple/manifests/ (40-* through 44-*).",
 
     "_comment_kubernetes_version": "EKS minor version. kubectl in Dockerfile.dev should track this within the ±1 minor skew policy (https://kubernetes.io/releases/version-skew-policy/).",
-    "kubernetes_version": "1.35",
+    "kubernetes_version": "1.36",
 
     "_comment_eks_cluster": "endpoint_access controls who can reach the EKS API server. PRIVATE = inside the VPC only (production posture). Set to PUBLIC_AND_PRIVATE for kubectl access from the internet during dev. See docs/CUSTOMIZATION.md (EKS Endpoint Access).",
     "eks_cluster": {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -60,7 +60,7 @@ Each region contains:
 
 **EKS Auto Mode Cluster**
 
-- Kubernetes 1.35
+- Kubernetes 1.36
 - Managed control plane
 - Control plane logging enabled (API, Audit, Authenticator, Controller Manager, Scheduler)
 - Auto-scaling compute via nodepools:

--- a/gco/config/config_loader.py
+++ b/gco/config/config_loader.py
@@ -444,7 +444,7 @@ class ConfigLoader:
 
     def get_kubernetes_version(self) -> str:
         """Get Kubernetes version from configuration"""
-        return self.app.node.try_get_context("kubernetes_version") or "1.35"
+        return self.app.node.try_get_context("kubernetes_version") or "1.36"
 
     def get_resource_thresholds(self) -> ResourceThresholds:
         """Get resource thresholds configuration"""

--- a/lambda/helm-installer/Dockerfile
+++ b/lambda/helm-installer/Dockerfile
@@ -19,7 +19,7 @@ RUN dnf install -y tar gzip && \
     dnf clean all
 
 # Install kubectl for cluster connectivity verification
-RUN curl -LO "https://dl.k8s.io/release/v1.35.5/bin/linux/amd64/kubectl" && \
+RUN curl -LO "https://dl.k8s.io/release/v1.36.1/bin/linux/amd64/kubectl" && \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/kubectl
 

--- a/lambda/helm-installer/README.md
+++ b/lambda/helm-installer/README.md
@@ -73,4 +73,4 @@ Runs as a container Lambda (see `Dockerfile`). The image includes `helm` and `ku
 ## Dependencies
 
 - `boto3`, `pyyaml`, `urllib3` (see `requirements.txt`)
-- Helm v4.2.0, kubectl v1.35.5 (installed in Docker image)
+- Helm v4.2.0, kubectl v1.36.1 (installed in Docker image)

--- a/lambda/kubectl-applier-simple/requirements.txt
+++ b/lambda/kubectl-applier-simple/requirements.txt
@@ -1,4 +1,4 @@
 boto3==1.43.18
-kubernetes==35.0.0
+kubernetes==36.0.2
 PyYAML==6.0.3
 urllib3==2.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "requests==2.34.2",
     "pyyaml==6.0.3",
     "constructs==10.6.0",
-    "kubernetes==35.0.0",
+    "kubernetes==36.0.2",
     "fastapi==0.136.3",
     "uvicorn==0.48.0",
     "pydantic==2.13.4",
@@ -79,7 +79,7 @@ diagrams = [
 ]
 inference-monitor = [
     "boto3==1.43.18",
-    "kubernetes==35.0.0",
+    "kubernetes==36.0.2",
     "pyyaml==6.0.3",
 ]
 mcp = [

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -237,7 +237,7 @@ jsonschema-specifications==2025.9.1
     #   openapi-schema-validator
 keyring==25.7.0
     # via py-key-value-aio
-kubernetes==35.0.0
+kubernetes==36.0.2
     # via
     #   gco-cli
     #   gco-cli (pyproject.toml)

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -6,6 +6,12 @@
 #
 aiofile==3.9.0
     # via py-key-value-aio
+aiohappyeyeballs==2.6.2
+    # via aiohttp
+aiohttp==3.14.0
+    # via kubernetes
+aiosignal==1.4.0
+    # via aiohttp
 annotated-doc==0.0.4
     # via
     #   fastapi
@@ -22,6 +28,7 @@ anyio==4.13.0
     #   watchfiles
 attrs==25.4.0
     # via
+    #   aiohttp
     #   cattrs
     #   cyclopts
     #   hypothesis
@@ -155,6 +162,10 @@ filelock==3.29.0
     # via
     #   python-discovery
     #   virtualenv
+frozenlist==1.8.0
+    # via
+    #   aiohttp
+    #   aiosignal
 greenlet==3.5.0
     # via playwright
 griffelib==2.0.2
@@ -185,6 +196,7 @@ idna==3.15
     #   email-validator
     #   httpx
     #   requests
+    #   yarl
 importlib-metadata==8.7.1
     # via opentelemetry-api
 importlib-resources==7.1.0
@@ -263,6 +275,10 @@ moto==5.1.22
     # via
     #   gco-cli
     #   gco-cli (pyproject.toml)
+multidict==6.7.1
+    # via
+    #   aiohttp
+    #   yarl
 mypy==1.19.1
     # via
     #   gco-cli
@@ -325,6 +341,10 @@ prometheus-client==0.25.0
     #   gco-cli
     #   gco-cli (pyproject.toml)
     #   pydocket
+propcache==0.5.2
+    # via
+    #   aiohttp
+    #   yarl
 psutil==7.2.2
     # via pytest-xdist
 publication==0.0.3
@@ -588,6 +608,8 @@ yamllint==1.38.0
     # via
     #   gco-cli
     #   gco-cli (pyproject.toml)
+yarl==1.24.2
+    # via aiohttp
 zipp==3.23.1
     # via importlib-metadata
 

--- a/tests/BATS/test_dependency_scan.bats
+++ b/tests/BATS/test_dependency_scan.bats
@@ -583,14 +583,14 @@ EOF
 @test "extract_k8s_version: reads version from cdk.json" {
     run extract_k8s_version "cdk.json"
     [ "$status" -eq 0 ]
-    # Should be a version like 1.35
+    # Should be a version like 1.36
     [[ "$output" =~ ^[0-9]+\.[0-9]+$ ]]
 }
 
-@test "extract_k8s_version: falls back to 1.35 for missing file" {
+@test "extract_k8s_version: falls back to 1.36 for missing file" {
     run extract_k8s_version "/nonexistent/cdk.json"
     [ "$status" -eq 0 ]
-    [ "$output" = "1.35" ]
+    [ "$output" = "1.36" ]
 }
 
 # ── extract_direct_python_deps ──────────────────────────────────────────────

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,7 +169,7 @@ def sample_cluster_config(sample_thresholds):
     return ClusterConfig(
         region="us-east-1",
         cluster_name="gco-us-east-1",
-        kubernetes_version="1.35",
+        kubernetes_version="1.36",
         addons=["metrics-server"],
         resource_thresholds=sample_thresholds,
     )
@@ -354,7 +354,7 @@ def valid_cdk_context():
             "monitoring": "us-east-2",
             "regional": ["us-east-1", "us-west-2"],
         },
-        "kubernetes_version": "1.35",
+        "kubernetes_version": "1.36",
         "resource_thresholds": {"cpu_threshold": 80, "memory_threshold": 85, "gpu_threshold": 90},
         "global_accelerator": {
             "name": "gco-accelerator",

--- a/tests/test_analytics_cluster_shared_configmap_property.py
+++ b/tests/test_analytics_cluster_shared_configmap_property.py
@@ -81,7 +81,7 @@ class _RegionalMockConfig(MockConfigLoader):
         return ClusterConfig(
             region=region,
             cluster_name=f"gco-test-{region}",
-            kubernetes_version="1.35",
+            kubernetes_version="1.36",
             addons=["metrics-server"],
             resource_thresholds=self.get_resource_thresholds(),
         )

--- a/tests/test_cdk_stacks.py
+++ b/tests/test_cdk_stacks.py
@@ -36,7 +36,7 @@ class MockConfigLoader:
         return "us-east-2"
 
     def get_kubernetes_version(self):
-        return "1.35"
+        return "1.36"
 
     def get_tags(self):
         return {"Environment": "test", "Project": "gco"}
@@ -52,7 +52,7 @@ class MockConfigLoader:
         return ClusterConfig(
             region=region,
             cluster_name=f"gco-test-{region}",
-            kubernetes_version="1.35",
+            kubernetes_version="1.36",
             addons=["metrics-server"],
             resource_thresholds=self.get_resource_thresholds(),
         )
@@ -353,7 +353,7 @@ class TestConfigIntegration:
 
         assert config.get_project_name() == "gco-test"
         assert config.get_regions() == ["us-east-1"]
-        assert config.get_kubernetes_version() == "1.35"
+        assert config.get_kubernetes_version() == "1.36"
         assert isinstance(config.get_tags(), dict)
         assert config.get_resource_thresholds() is not None
         assert config.get_cluster_config("us-east-1") is not None

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -44,7 +44,7 @@ def valid_context():
             "monitoring": "us-east-2",
             "regional": ["us-east-1", "us-west-2"],
         },
-        "kubernetes_version": "1.35",
+        "kubernetes_version": "1.36",
         "resource_thresholds": {"cpu_threshold": 80, "memory_threshold": 85, "gpu_threshold": 90},
         "global_accelerator": {
             "name": "gco-accelerator",
@@ -257,7 +257,7 @@ class TestConfigLoaderGetters:
 
         assert cluster_config.region == "us-east-1"
         assert cluster_config.cluster_name == "gco-us-east-1"
-        assert cluster_config.kubernetes_version == "1.35"
+        assert cluster_config.kubernetes_version == "1.36"
 
     def test_get_tags(self, valid_context):
         """Test getting tags."""
@@ -301,7 +301,7 @@ class TestDefaultValues:
         """Test default Kubernetes version."""
         app = MockApp({})
         config = ConfigLoader(app)
-        assert config.get_kubernetes_version() == "1.35"
+        assert config.get_kubernetes_version() == "1.36"
 
     def test_default_resource_thresholds(self):
         """Test default resource thresholds."""

--- a/tests/test_config_loader_validation.py
+++ b/tests/test_config_loader_validation.py
@@ -45,7 +45,7 @@ class TestConfigLoaderValidation:
             context={
                 "project_name": "test",
                 "deployment_regions": {"regional": []},
-                "kubernetes_version": "1.35",
+                "kubernetes_version": "1.36",
                 "resource_thresholds": {
                     "cpu_threshold": 80,
                     "memory_threshold": 85,
@@ -108,7 +108,7 @@ class TestConfigLoaderValidation:
             context={
                 "project_name": "test",
                 "deployment_regions": {"regional": regions},
-                "kubernetes_version": "1.35",
+                "kubernetes_version": "1.36",
                 "resource_thresholds": {
                     "cpu_threshold": 80,
                     "memory_threshold": 85,
@@ -157,7 +157,7 @@ class TestConfigLoaderValidation:
             context={
                 "project_name": "test",
                 "deployment_regions": {"regional": ["invalid-region"]},
-                "kubernetes_version": "1.35",
+                "kubernetes_version": "1.36",
                 "resource_thresholds": {
                     "cpu_threshold": 80,
                     "memory_threshold": 85,
@@ -206,7 +206,7 @@ class TestConfigLoaderValidation:
             context={
                 "project_name": "test",
                 "deployment_regions": {"regional": ["us-east-1", "us-east-1"]},
-                "kubernetes_version": "1.35",
+                "kubernetes_version": "1.36",
                 "resource_thresholds": {
                     "cpu_threshold": 80,
                     "memory_threshold": 85,
@@ -255,7 +255,7 @@ class TestConfigLoaderValidation:
             context={
                 "project_name": "test",
                 "deployment_regions": {"regional": ["us-east-1"]},
-                "kubernetes_version": "1.35",
+                "kubernetes_version": "1.36",
                 "resource_thresholds": {
                     "cpu_threshold": 150,
                     "memory_threshold": 85,
@@ -304,7 +304,7 @@ class TestConfigLoaderValidation:
             context={
                 "project_name": "test",
                 "deployment_regions": {"regional": ["us-east-1"]},
-                "kubernetes_version": "1.35",
+                "kubernetes_version": "1.36",
                 "resource_thresholds": {
                     "cpu_threshold": 80,
                     "memory_threshold": 85,
@@ -352,7 +352,7 @@ class TestConfigLoaderValidation:
             context={
                 "project_name": "test",
                 "deployment_regions": {"regional": ["us-east-1"]},
-                "kubernetes_version": "1.35",
+                "kubernetes_version": "1.36",
                 "resource_thresholds": {
                     "cpu_threshold": 80,
                     "memory_threshold": 85,
@@ -401,7 +401,7 @@ class TestConfigLoaderValidation:
             context={
                 "project_name": "test",
                 "deployment_regions": {"regional": ["us-east-1"]},
-                "kubernetes_version": "1.35",
+                "kubernetes_version": "1.36",
                 "resource_thresholds": {
                     "cpu_threshold": 80,
                     "memory_threshold": 85,
@@ -452,7 +452,7 @@ class TestConfigLoaderValidation:
             context={
                 "project_name": "test",
                 "deployment_regions": {"regional": ["us-east-1"]},
-                "kubernetes_version": "1.35",
+                "kubernetes_version": "1.36",
                 "resource_thresholds": {
                     "cpu_threshold": 80,
                     "memory_threshold": 85,
@@ -501,7 +501,7 @@ class TestConfigLoaderValidation:
             context={
                 "project_name": "test",
                 "deployment_regions": {"regional": ["us-east-1"]},
-                "kubernetes_version": "1.35",
+                "kubernetes_version": "1.36",
                 "resource_thresholds": {
                     "cpu_threshold": 80,
                     "memory_threshold": 85,
@@ -550,7 +550,7 @@ class TestConfigLoaderValidation:
             context={
                 "project_name": "test",
                 "deployment_regions": {"regional": ["us-east-1"]},
-                "kubernetes_version": "1.35",
+                "kubernetes_version": "1.36",
                 "resource_thresholds": {
                     "cpu_threshold": 80,
                     "memory_threshold": 85,

--- a/tests/test_deployment_regions.py
+++ b/tests/test_deployment_regions.py
@@ -35,7 +35,7 @@ def base_context():
     """Create base configuration context without deployment_regions."""
     return {
         "project_name": "gco",
-        "kubernetes_version": "1.35",
+        "kubernetes_version": "1.36",
         "resource_thresholds": {"cpu_threshold": 80, "memory_threshold": 85, "gpu_threshold": 90},
         "global_accelerator": {
             "name": "gco-accelerator",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1262,7 +1262,7 @@ class TestDependencyVersionConsistency:
         assert kubectl_match, "Could not find kubectl version in helm-installer Dockerfile"
         kubectl_version = kubectl_match.group(1)
 
-        # kubectl version should start with the EKS version (e.g., 1.35.x matches 1.35)
+        # kubectl version should start with the EKS version (e.g., 1.36.x matches 1.36)
         assert kubectl_version.startswith(eks_version), (
             f"kubectl version {kubectl_version} in helm-installer Dockerfile "
             f"doesn't match EKS version {eks_version} in cdk.json"
@@ -1289,7 +1289,7 @@ class TestDependencyVersionConsistency:
         assert k8s_version, "kubernetes not found in pyproject.toml dependencies"
 
         # kubernetes Python client major version maps to K8s minor version
-        # e.g., kubernetes==35.0.0 supports K8s 1.35
+        # e.g., kubernetes==36.0.0 supports K8s 1.36
         k8s_client_major = int(k8s_version.split(".")[0])
         assert k8s_client_major == eks_minor, (
             f"kubernetes Python client {k8s_version} (major={k8s_client_major}) "

--- a/tests/test_models_extended.py
+++ b/tests/test_models_extended.py
@@ -556,7 +556,7 @@ class TestClusterConfigValidation:
         config = ClusterConfig(
             region="us-east-1",
             cluster_name="test-cluster",
-            kubernetes_version="1.35",
+            kubernetes_version="1.36",
             addons=["metrics-server"],
             resource_thresholds=valid_thresholds,
         )
@@ -571,7 +571,7 @@ class TestClusterConfigValidation:
             ClusterConfig(
                 region="",
                 cluster_name="test-cluster",
-                kubernetes_version="1.35",
+                kubernetes_version="1.36",
                 addons=["metrics-server"],
                 resource_thresholds=valid_thresholds,
             )
@@ -584,7 +584,7 @@ class TestClusterConfigValidation:
             ClusterConfig(
                 region="us-east-1",
                 cluster_name="",
-                kubernetes_version="1.35",
+                kubernetes_version="1.36",
                 addons=["metrics-server"],
                 resource_thresholds=valid_thresholds,
             )

--- a/tests/test_regional_stack.py
+++ b/tests/test_regional_stack.py
@@ -40,7 +40,7 @@ class MockConfigLoader:
         return "us-east-2"
 
     def get_kubernetes_version(self):
-        return "1.35"
+        return "1.36"
 
     def get_tags(self):
         return {"Environment": "test", "Project": "gco"}
@@ -56,7 +56,7 @@ class MockConfigLoader:
         return ClusterConfig(
             region=region,
             cluster_name=f"gco-test-{region}",
-            kubernetes_version="1.35",
+            kubernetes_version="1.36",
             addons=["metrics-server"],
             resource_thresholds=self.get_resource_thresholds(),
         )
@@ -443,7 +443,7 @@ class TestConfigLoaderDefaults:
         """Test default Kubernetes version."""
         app = cdk.App()
         config = MockConfigLoader(app)
-        assert config.get_kubernetes_version() == "1.35"
+        assert config.get_kubernetes_version() == "1.36"
 
     def test_get_fsx_lustre_config_disabled(self):
         """Test FSx config when disabled."""
@@ -516,14 +516,14 @@ class TestClusterConfigModel:
         config = ClusterConfig(
             region="us-east-1",
             cluster_name="test-cluster",
-            kubernetes_version="1.35",
+            kubernetes_version="1.36",
             addons=["metrics-server"],
             resource_thresholds=thresholds,
         )
 
         assert config.region == "us-east-1"
         assert config.cluster_name == "test-cluster"
-        assert config.kubernetes_version == "1.35"
+        assert config.kubernetes_version == "1.36"
 
 
 class TestResourceThresholdsModel:


### PR DESCRIPTION
Bump the EKS cluster version from 1.35 to 1.36 and move the version-pinned toolchain in lockstep to satisfy the version-consistency guards:

- cdk.json + config_loader default: kubernetes_version 1.36
- kubectl v1.35.5 -> v1.36.1 (Dockerfile.dev, helm-installer Dockerfile, deps-scan.yml KUBECTL_VERSION, integration-tests comments)
- kubernetes Python client 35.0.0 -> 36.0.2 (pyproject.toml, lambda requirements, requirements-lock.txt)
- kind node image v1.35.0 -> v1.36.1 and kind-action v0.31.0 -> v0.32.0
- dependency-scan fallback default + BATS expectation -> 1.36
- refresh .trivyignore notes to reflect the v1.36.1 pin (CVEs still ride on Go 1.26.2, suppressions remain valid)
- docs (ARCHITECTURE.md, CONTRIBUTING.md, helm-installer README) and test fixtures updated to 1.36

Verified: cdk synth emits "Version": "1.36"; 634 tests pass (config, stacks, integration, network-policy, doc-hygiene) plus the BATS dependency-scan suite. Audited 1.36 breaking changes (gitRepo volumes, strict CIDR validation, externalIPs) — none affect this codebase.

<!--
Thanks for contributing to Global Capacity Orchestrator (GCO)! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [ ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
