### PR TITLE
feat(ga): make Global Accelerator client affinity configurable

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -50,13 +50,14 @@
 
     "_comment_networking": "Networking, security, and ingress",
 
-    "_comment_global_accelerator": "AWS Global Accelerator front door. health_check_grace_period: seconds before a new endpoint starts being probed. health_check_interval: seconds between probes. health_check_timeout: seconds to wait per probe. health_check_path: HTTP path probed on each regional ALB. See https://docs.aws.amazon.com/global-accelerator/latest/dg/about-endpoint-groups-health-check-options.html.",
+    "_comment_global_accelerator": "AWS Global Accelerator front door. health_check_grace_period: seconds before a new endpoint starts being probed. health_check_interval: seconds between probes. health_check_timeout: seconds to wait per probe. health_check_path: HTTP path probed on each regional ALB. client_affinity: 'NONE' (default, spreads connections across endpoints) or 'SOURCE_IP' (pins a client IP to the same endpoint). See https://docs.aws.amazon.com/global-accelerator/latest/dg/about-endpoint-groups-health-check-options.html and https://docs.aws.amazon.com/global-accelerator/latest/dg/about-listeners.html#about-listeners-client-affinity.",
     "global_accelerator": {
       "name": "gco-accelerator",
       "health_check_grace_period": 30,
       "health_check_interval": 30,
       "health_check_timeout": 5,
-      "health_check_path": "/api/v1/health"
+      "health_check_path": "/api/v1/health",
+      "client_affinity": "NONE"
     },
 
     "_comment_alb_config": "Internal ALB target-group health checks for the manifest-processor service. health_check_interval / health_check_timeout in seconds. healthy_threshold / unhealthy_threshold are the consecutive-probe counts before a target flips state. See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html.",

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -470,7 +470,8 @@ Global Accelerator uses HTTP health checks to determine if a region is healthy. 
 ```json
 "global_accelerator": {
   "health_check_path": "/api/v1/health",
-  "health_check_interval": 30
+  "health_check_interval": 30,
+  "client_affinity": "NONE"
 }
 ```
 
@@ -480,10 +481,20 @@ Global Accelerator uses HTTP health checks to determine if a region is healthy. 
 | `health_check_interval` | `30` | Seconds between health checks |
 | `health_check_grace_period` | `30` | Seconds to wait before first health check |
 | `health_check_timeout` | `5` | Seconds before a health check times out |
+| `client_affinity` | `NONE` | Listener client affinity. `NONE` spreads connections across endpoints for even load distribution; `SOURCE_IP` pins each client IP to the same endpoint for session stickiness |
 
 The `/api/v1/health` endpoint returns 200 when the cluster is within resource thresholds and 503 when overloaded. This enables intelligent routing — GA automatically routes traffic away from overloaded regions.
 
 The health check path must be listed in `UNAUTHENTICATED_PATHS` in `gco/services/auth_middleware.py` so GA can reach it without the secret header. A CI test (`tests/test_health_check_coverage.py`) validates this automatically.
+
+#### Client Affinity
+
+Global Accelerator listeners support two client-affinity modes, controlled by the `client_affinity` knob under `global_accelerator` in `cdk.json`:
+
+- `NONE` (default): GA may route each new connection to any healthy endpoint. This maximizes even load distribution across regions and is the right choice for stateless request/response traffic.
+- `SOURCE_IP`: GA pins connections from the same source IP to the same endpoint group for as long as it stays healthy. Use this when a workload keeps per-client state on a single region (for example, sticky sessions). Note that affinity is broken when an endpoint becomes unhealthy or the endpoint set changes.
+
+The value is validated at synth time — anything other than `NONE` or `SOURCE_IP` raises a `ConfigValidationError`. See the [AWS Global Accelerator client affinity docs](https://docs.aws.amazon.com/global-accelerator/latest/dg/about-listeners.html#about-listeners-client-affinity) for details.
 
 #### Inference Health Watchdog
 

--- a/gco/config/config_loader.py
+++ b/gco/config/config_loader.py
@@ -200,8 +200,7 @@ class ConfigLoader:
             value = ga_config["client_affinity"]
             if not isinstance(value, str) or value.upper() not in allowed_affinity:
                 raise ConfigValidationError(
-                    "client_affinity must be one of "
-                    f"{sorted(allowed_affinity)}, got {value!r}"
+                    f"client_affinity must be one of {sorted(allowed_affinity)}, got {value!r}"
                 )
 
     def _validate_alb_config(self) -> None:

--- a/gco/config/config_loader.py
+++ b/gco/config/config_loader.py
@@ -193,6 +193,17 @@ class ConfigLoader:
         if not ga_config["health_check_path"].startswith("/"):
             raise ConfigValidationError("health_check_path must start with '/'")
 
+        # Validate optional client affinity. Omitting the key is allowed and
+        # defaults to "NONE" in get_global_accelerator_config().
+        if "client_affinity" in ga_config:
+            allowed_affinity = {"NONE", "SOURCE_IP"}
+            value = ga_config["client_affinity"]
+            if not isinstance(value, str) or value.upper() not in allowed_affinity:
+                raise ConfigValidationError(
+                    "client_affinity must be one of "
+                    f"{sorted(allowed_affinity)}, got {value!r}"
+                )
+
     def _validate_alb_config(self) -> None:
         """Validate ALB configuration"""
         alb_config = self.app.node.try_get_context("alb_config")
@@ -485,6 +496,7 @@ class ConfigLoader:
             "health_check_interval": 30,
             "health_check_timeout": 5,
             "health_check_path": "/api/v1/health",
+            "client_affinity": "NONE",
         }
 
     def get_alb_config(self) -> dict[str, Any]:

--- a/gco/stacks/global_stack.py
+++ b/gco/stacks/global_stack.py
@@ -214,7 +214,9 @@ class GCOGlobalStack(Stack):
         # Use Fn.select and Fn.split to extract the ID at deploy time
         self.accelerator_id = Fn.select(1, Fn.split("/", self.accelerator.accelerator_arn))
 
-        # Create listener for both HTTP (80) and HTTPS (443) traffic
+        # Create listener for both HTTP (80) and HTTPS (443) traffic.
+        # Client affinity controls whether GA pins a client to the same
+        # endpoint across connections (see ``_resolve_client_affinity``).
         self.listener = self.accelerator.add_listener(
             "GCOListener",
             port_ranges=[
@@ -222,7 +224,7 @@ class GCOGlobalStack(Stack):
                 ga.PortRange(from_port=443, to_port=443),
             ],
             protocol=ga.ConnectionProtocol.TCP,
-            client_affinity=ga.ClientAffinity.NONE,
+            client_affinity=self._resolve_client_affinity(ga_config),
         )
 
         # Create endpoint groups for each configured region
@@ -234,6 +236,30 @@ class GCOGlobalStack(Stack):
 
         # Apply cdk-nag suppressions
         self._apply_nag_suppressions()
+
+    @staticmethod
+    def _resolve_client_affinity(ga_config: dict[str, Any]) -> ga.ClientAffinity:
+        """Map the ``client_affinity`` cdk.json knob to a CDK enum.
+
+        Global Accelerator supports two client-affinity modes:
+
+        - ``NONE`` (default): each new connection may be routed to any
+          healthy endpoint, maximising even load distribution.
+        - ``SOURCE_IP``: connections from the same source IP are pinned to
+          the same endpoint, which is useful for workloads that keep
+          per-client state on a single region.
+
+        The value is validated up front by
+        ``ConfigLoader._validate_global_accelerator_config`` so an unknown
+        string never reaches this point; the fallback to ``NONE`` keeps the
+        stack synthesizable even when the key is omitted entirely.
+        """
+        affinity = str(ga_config.get("client_affinity", "NONE")).upper()
+        mapping = {
+            "NONE": ga.ClientAffinity.NONE,
+            "SOURCE_IP": ga.ClientAffinity.SOURCE_IP,
+        }
+        return mapping.get(affinity, ga.ClientAffinity.NONE)
 
     def _create_outputs(self) -> None:
         """Create CloudFormation outputs for cross-stack references."""

--- a/tests/test_cdk_stacks.py
+++ b/tests/test_cdk_stacks.py
@@ -141,6 +141,63 @@ class TestGlobalStackSynth:
         template = assertions.Template.from_stack(stack)
         template.resource_count_is("AWS::GlobalAccelerator::Listener", 1)
 
+    def test_listener_default_client_affinity_is_none(self):
+        """Listener defaults to NONE client affinity when knob is omitted."""
+        from gco.stacks.global_stack import GCOGlobalStack
+
+        app = cdk.App()
+        config = MockConfigLoader(app)
+
+        stack = GCOGlobalStack(app, "test-global-stack-affinity-default", config=config)
+
+        template = assertions.Template.from_stack(stack)
+        template.has_resource_properties(
+            "AWS::GlobalAccelerator::Listener",
+            {"ClientAffinity": "NONE"},
+        )
+
+    def test_listener_honors_source_ip_client_affinity(self):
+        """SOURCE_IP in the GA config flows through to the listener."""
+        from gco.stacks.global_stack import GCOGlobalStack
+
+        class SourceIpConfig(MockConfigLoader):
+            def get_global_accelerator_config(self):
+                cfg = super().get_global_accelerator_config()
+                cfg["client_affinity"] = "SOURCE_IP"
+                return cfg
+
+        app = cdk.App()
+        config = SourceIpConfig(app)
+
+        stack = GCOGlobalStack(app, "test-global-stack-affinity-source-ip", config=config)
+
+        template = assertions.Template.from_stack(stack)
+        template.has_resource_properties(
+            "AWS::GlobalAccelerator::Listener",
+            {"ClientAffinity": "SOURCE_IP"},
+        )
+
+    def test_listener_client_affinity_is_case_insensitive(self):
+        """Lower-case affinity values are normalized to the GA enum."""
+        from gco.stacks.global_stack import GCOGlobalStack
+
+        class LowerCaseConfig(MockConfigLoader):
+            def get_global_accelerator_config(self):
+                cfg = super().get_global_accelerator_config()
+                cfg["client_affinity"] = "source_ip"
+                return cfg
+
+        app = cdk.App()
+        config = LowerCaseConfig(app)
+
+        stack = GCOGlobalStack(app, "test-global-stack-affinity-lower", config=config)
+
+        template = assertions.Template.from_stack(stack)
+        template.has_resource_properties(
+            "AWS::GlobalAccelerator::Listener",
+            {"ClientAffinity": "SOURCE_IP"},
+        )
+
 
 class TestApiGatewayStackSynth:
     """Tests for API Gateway Stack synthesis."""

--- a/tests/test_cdk_stacks.py
+++ b/tests/test_cdk_stacks.py
@@ -10,6 +10,7 @@ after refactors without needing a real AWS environment.
 """
 
 import aws_cdk as cdk
+import pytest
 from aws_cdk import assertions
 
 
@@ -156,46 +157,47 @@ class TestGlobalStackSynth:
             {"ClientAffinity": "NONE"},
         )
 
-    def test_listener_honors_source_ip_client_affinity(self):
-        """SOURCE_IP in the GA config flows through to the listener."""
+    @pytest.mark.parametrize(
+        ("affinity_input", "expected"),
+        [
+            (None, "NONE"),
+            ("NONE", "NONE"),
+            ("SOURCE_IP", "SOURCE_IP"),
+            ("source_ip", "SOURCE_IP"),
+            ("none", "NONE"),
+        ],
+    )
+    def test_listener_client_affinity_synth_matrix(self, affinity_input, expected):
+        """Synthesize the global stack across every client_affinity input.
+
+        Each row drives a full ``Template.from_stack`` synthesis and asserts
+        the rendered ``AWS::GlobalAccelerator::Listener`` carries the expected
+        normalized ``ClientAffinity`` value. ``None`` exercises the
+        omitted-key path that falls back to NONE.
+        """
         from gco.stacks.global_stack import GCOGlobalStack
 
-        class SourceIpConfig(MockConfigLoader):
+        class MatrixConfig(MockConfigLoader):
             def get_global_accelerator_config(self):
                 cfg = super().get_global_accelerator_config()
-                cfg["client_affinity"] = "SOURCE_IP"
+                if affinity_input is None:
+                    cfg.pop("client_affinity", None)
+                else:
+                    cfg["client_affinity"] = affinity_input
                 return cfg
 
         app = cdk.App()
-        config = SourceIpConfig(app)
+        config = MatrixConfig(app)
 
-        stack = GCOGlobalStack(app, "test-global-stack-affinity-source-ip", config=config)
-
-        template = assertions.Template.from_stack(stack)
-        template.has_resource_properties(
-            "AWS::GlobalAccelerator::Listener",
-            {"ClientAffinity": "SOURCE_IP"},
-        )
-
-    def test_listener_client_affinity_is_case_insensitive(self):
-        """Lower-case affinity values are normalized to the GA enum."""
-        from gco.stacks.global_stack import GCOGlobalStack
-
-        class LowerCaseConfig(MockConfigLoader):
-            def get_global_accelerator_config(self):
-                cfg = super().get_global_accelerator_config()
-                cfg["client_affinity"] = "source_ip"
-                return cfg
-
-        app = cdk.App()
-        config = LowerCaseConfig(app)
-
-        stack = GCOGlobalStack(app, "test-global-stack-affinity-lower", config=config)
+        # Construct IDs must be unique per stack within the same app run.
+        stack_id = f"test-ga-affinity-{affinity_input or 'omitted'}".replace("_", "-").lower()
+        stack = GCOGlobalStack(app, stack_id, config=config)
 
         template = assertions.Template.from_stack(stack)
+        template.resource_count_is("AWS::GlobalAccelerator::Listener", 1)
         template.has_resource_properties(
             "AWS::GlobalAccelerator::Listener",
-            {"ClientAffinity": "SOURCE_IP"},
+            {"ClientAffinity": expected},
         )
 
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -211,6 +211,40 @@ class TestGlobalAcceleratorValidation:
         ):
             ConfigLoader(app)
 
+    def test_client_affinity_defaults_to_none(self, valid_context):
+        """Test client_affinity defaults to NONE when omitted."""
+        valid_context["global_accelerator"].pop("client_affinity", None)
+        app = MockApp(valid_context)
+        config = ConfigLoader(app)
+        ga_config = config.get_global_accelerator_config()
+        # When the key is present in context it is returned as-is; when the
+        # whole context is absent the loader falls back to a default dict that
+        # pins NONE. Either way, an omitted key is valid and resolves to NONE
+        # at the stack layer.
+        assert ga_config.get("client_affinity", "NONE") == "NONE"
+
+    @pytest.mark.parametrize("affinity", ["NONE", "SOURCE_IP", "source_ip", "none"])
+    def test_valid_client_affinity(self, valid_context, affinity):
+        """Test accepted client_affinity values pass validation."""
+        valid_context["global_accelerator"]["client_affinity"] = affinity
+        app = MockApp(valid_context)
+        config = ConfigLoader(app)
+        assert config.get_global_accelerator_config()["client_affinity"] == affinity
+
+    def test_invalid_client_affinity(self, valid_context):
+        """Test an unknown client_affinity value raises an error."""
+        valid_context["global_accelerator"]["client_affinity"] = "STICKY"
+        app = MockApp(valid_context)
+        with pytest.raises(ConfigValidationError, match="client_affinity must be one of"):
+            ConfigLoader(app)
+
+    def test_non_string_client_affinity(self, valid_context):
+        """Test a non-string client_affinity value raises an error."""
+        valid_context["global_accelerator"]["client_affinity"] = 1
+        app = MockApp(valid_context)
+        with pytest.raises(ConfigValidationError, match="client_affinity must be one of"):
+            ConfigLoader(app)
+
 
 class TestApiGatewayValidation:
     """Tests for API Gateway config validation."""


### PR DESCRIPTION
Add a client_affinity knob under global_accelerator in cdk.json so operators can choose between NONE (default, spreads connections) and SOURCE_IP (pins client IPs to an endpoint). Validated at synth time and mapped to the ga.ClientAffinity enum in the global stack. Documented in CUSTOMIZATION.md and covered by config and stack-synthesis tests.

<!--
Thanks for contributing to Global Capacity Orchestrator (GCO)! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [ ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
