### PR TITLE
fix(dev-container): install Docker Buildx so deploy-all works on Apple Silicon

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,7 +5,10 @@
 # Docker Desktop on Intel Macs / Linux) and linux/arm64 (Apple Silicon
 # Macs running Docker Desktop, Finch, Colima, or any arm64 Linux host).
 # kubectl, the AWS CLI v2, and the Docker static client all publish both
-# arch builds; we pick the right one via BuildKit's $TARGETARCH.
+# arch builds; we pick the right one via BuildKit's $TARGETARCH. The
+# Docker Buildx plugin is installed alongside the client so the multi-arch
+# image mirror and the linux/amd64 asset builds that `gco stacks deploy-all`
+# performs work out of the box on Apple Silicon (arm64) as well as x86_64.
 #
 # Build:
 #   docker build -f Dockerfile.dev -t gco-dev .
@@ -176,6 +179,31 @@ RUN GNU_ARCH=$(cat /tmp/gnu_arch) \
     && mv /tmp/docker/docker /usr/local/bin/ \
     && rm -rf /tmp/docker /tmp/docker.tgz /tmp/gnu_arch \
     && docker --version
+
+# Install the Docker Buildx CLI plugin.
+#
+# `gco stacks deploy-all` needs a multi-arch image-copy tool for two
+# steps, and on an arm64 host (Apple Silicon) both fail without Buildx:
+#   1. The Volcano ECR image mirror — cli/_image_mirror.py prefers
+#      `docker buildx imagetools create` (a registry-to-registry copy
+#      that preserves the full multi-arch manifest list). Without a
+#      multi-arch copy method it aborts before CloudFormation with
+#      "No multi-arch image-copy method available".
+#   2. The linux/amd64 Lambda/service asset images that CDK bundles —
+#      the legacy builder cannot cross-build, failing with "image ...
+#      does not provide the specified platform (linux/amd64)".
+# The Docker static tarball above ships only the client binary (no
+# cli-plugins/), so the plugin is installed separately here. Buildx
+# publishes per-arch release binaries selected by ${TARGETARCH}; the
+# plugin lives in a system cli-plugins path so the root user's docker
+# CLI discovers it. Pinned for reproducibility — bump in lockstep with
+# the deps-scan report. https://github.com/docker/buildx/releases
+ARG BUILDX_VERSION=v0.35.0
+RUN mkdir -p /usr/local/lib/docker/cli-plugins \
+    && curl -fsSL "https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-${TARGETARCH}" \
+      -o /usr/local/lib/docker/cli-plugins/docker-buildx \
+    && chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx \
+    && docker buildx version
 
 # Set working directory
 WORKDIR /workspace

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -67,7 +67,7 @@ cd global-capacity-orchestrator-on-aws
 docker build -f Dockerfile.dev -t gco-dev .
 ```
 
-The image bundles Python 3.14, Node.js 24, CDK, kubectl, AWS CLI, and all GCO Python dependencies at the exact versions CI uses. The Dockerfile is multi-arch — it builds natively on both `linux/amd64` (Intel/x86_64 hosts and CI) and `linux/arm64` (Apple Silicon Macs, Graviton Linux, etc.) by selecting the right kubectl / AWS CLI / Docker CLI binary via `$TARGETARCH`. No `--platform` flag needed.
+The image bundles Python 3.14, Node.js 24, CDK, kubectl, AWS CLI, Docker CLI + Buildx, and all GCO Python dependencies at the exact versions CI uses. The Dockerfile is multi-arch — it builds natively on both `linux/amd64` (Intel/x86_64 hosts and CI) and `linux/arm64` (Apple Silicon Macs, Graviton Linux, etc.) by selecting the right kubectl / AWS CLI / Docker CLI / Buildx binary via `$TARGETARCH`. No `--platform` flag needed. Buildx ships in the image so the multi-arch image mirror and the `linux/amd64` asset builds that `gco stacks deploy-all` runs succeed on Apple Silicon (arm64) as well as x86_64.
 
 ## Step 2: Run the GCO CLI
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ gco stacks deploy-all -y      # stand up every region defined in cdk.json
 gco stacks destroy-all -y     # destroy every stack across every region — no orphaned resources
 ```
 
-**Recommended: run everything from the dev container.** GCO pins exact versions of a lot of Python packages (CDK, AWS SDKs, FastAPI, mypy, Ruff, etc.), and installing them on top of an existing Python environment is the most common source of "it doesn't install" reports. The dev container ships a fully resolved environment (Python 3.14, Node.js 24, CDK, kubectl, AWS CLI, all Python deps) so you skip the whole problem.
+**Recommended: run everything from the dev container.** GCO pins exact versions of a lot of Python packages (CDK, AWS SDKs, FastAPI, mypy, Ruff, etc.), and installing them on top of an existing Python environment is the most common source of "it doesn't install" reports. The dev container ships a fully resolved environment (Python 3.14, Node.js 24, CDK, kubectl, AWS CLI, Docker CLI + Buildx, all Python deps) so you skip the whole problem. Buildx is included so the multi-arch image mirror and `linux/amd64` asset builds that `gco stacks deploy-all` performs work out of the box on Apple Silicon (arm64).
 
 ```bash
 git clone git@github.com:awslabs/global-capacity-orchestrator-on-aws.git
@@ -452,7 +452,7 @@ Goal-directed iteration loop for orchestrated workflows. The operator declares a
 **Recommended path — dev container only:**
 
 - AWS CLI configured with appropriate credentials (or `~/.aws` to mount in)
-- Docker (or Finch / Colima) — that's it. The container ships Python 3.14, Node.js 24, CDK, kubectl, and AWS CLI at pinned versions.
+- Docker (or Finch / Colima) — that's it. The container ships Python 3.14, Node.js 24, CDK, kubectl, AWS CLI, and Docker CLI + Buildx at pinned versions.
 
 ```bash
 docker build -f Dockerfile.dev -t gco-dev .

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -9,6 +9,7 @@ Common issues and their solutions.
   - [`gco: command not found`](#gco-command-not-found)
 - [Deployment Issues](#deployment-issues)
   - [Stack Creation Fails](#stack-creation-fails)
+  - [Deploy Fails on Image Mirror or linux/amd64 Asset Build (Apple Silicon)](#deploy-fails-on-image-mirror-or-linuxamd64-asset-build-apple-silicon)
   - [Stack Stuck in DELETE_FAILED](#stack-stuck-in-delete_failed)
   - [Lambda Custom Resource Timeout](#lambda-custom-resource-timeout)
 - [kubectl Access Issues](#kubectl-access-issues)
@@ -170,6 +171,24 @@ aws cloudformation describe-stack-resources \
 gco stacks destroy-all -y
 gco stacks deploy-all -y
 ```
+
+### Deploy Fails on Image Mirror or `linux/amd64` Asset Build (Apple Silicon)
+
+**Symptom**: `gco stacks deploy-all` aborts with one of:
+
+- `No multi-arch image-copy method available. Need one of: 'docker buildx' ... 'docker pull --all-platforms' ... or skopeo on PATH.`
+- `failed to ... build ... --platform linux/amd64 ... image ... does not provide the specified platform (linux/amd64)`
+
+**Cause**: The deploy needs a multi-arch image-copy tool for two steps — the Volcano ECR image mirror (`docker buildx imagetools create`) and the cross-architecture build of the `linux/amd64` Lambda/service asset images. On an arm64 host (Apple Silicon) the legacy Docker builder cannot satisfy either. This happens when the deploy runs from an environment without Docker Buildx (Finch/nerdctl or skopeo also work).
+
+**Solution**: Run the deploy from the [dev container](../QUICKSTART.md#step-1-clone-and-build-the-dev-container), which ships Docker Buildx for exactly this. If you built the image before Buildx was added, rebuild it:
+
+```bash
+docker build -f Dockerfile.dev -t gco-dev .
+docker run --rm gco-dev docker buildx version   # confirm Buildx is present
+```
+
+If you deploy from your host instead, ensure one of `docker buildx`, Finch (`docker pull --all-platforms`), or `skopeo` is on `PATH`.
 
 ### Stack Stuck in REVIEW_IN_PROGRESS
 


### PR DESCRIPTION
## Problem

Running `gco stacks deploy-all` from the dev container on an arm64 host (Apple Silicon) fails at two separate steps:

1. **Volcano ECR image mirror** aborts before CloudFormation:
   ```
   Image mirror failed for region <r>: No multi-arch image-copy method available.
   Need one of: 'docker buildx' (Docker Buildx), 'docker pull --all-platforms'
   (Finch/nerdctl), or skopeo on PATH.
   ```
2. **`linux/amd64` asset build** (the Lambda/service images CDK bundles) fails:
   ```
   docker build ... --platform linux/amd64 ... exited with error code 1:
   ... image ... does not provide the specified platform (linux/amd64)
   ```

The dev container is the **documented, supported path** for deploying stacks (README/QUICKSTART), and the docs already state the deploy needs *Docker Buildx, Finch, or skopeo* (`docs/IMAGE_MIRROR.md`, `docs/CUSTOMIZATION.md`) — but `Dockerfile.dev` ships **none** of them. The ECR image mirror feature added in v3.0.0 (#83) introduced this requirement without adding the tooling to the image.

## Root cause

- The Docker CLI install in `Dockerfile.dev` extracts only the `docker` client binary from the static tarball, which does **not** include `cli-plugins/` (no Buildx).
- On arm64, the legacy builder cannot cross-build `linux/amd64`, and there is no multi-arch copy tool for the mirror.

## Fix

Install the **Docker Buildx** CLI plugin in `Dockerfile.dev`, pinned (`v0.35.0`) and selected by `$TARGETARCH`, into a system `cli-plugins` path.

Buildx alone satisfies **both** steps:
- It is the preferred mirror strategy in `cli/_image_mirror.py::resolve_copy_strategy()` (`docker buildx imagetools create`).
- It provides BuildKit cross-builds for the `linux/amd64` assets.

skopeo/Finch were intentionally not added — Buildx is sufficient and is the project's first-listed preferred tool.

Docs updated: README, QUICKSTART, and a new TROUBLESHOOTING entry mapping both error strings to the fix.

## Verification (local, no AWS spend)

- Native arm64 rebuild of `Dockerfile.dev` succeeds; `docker buildx version` → `v0.35.0`, `gco --version` → `3.2.2`.
- `docker build --platform linux/amd64` inside the image uses BuildKit (no legacy/DEPRECATED warning) and produces an `amd64` image.
- `markdownlint-cli2` passes (0 errors) on the changed docs.
- Originally surfaced during a real multi-region `deploy-all` (us-west-2 + ap-southeast-1); both failures reproduced and resolved by adding Buildx.

## Files changed

- `Dockerfile.dev` — install Buildx plugin + header note
- `README.md`, `QUICKSTART.md` — mention Buildx in the dev-container tooling list
- `docs/TROUBLESHOOTING.md` — new entry for the two error strings