### PR TITLE
docs: complete tests/CLI/MCP reference docs and add a coverage guard

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1099,6 +1099,34 @@ gco stacks aurora enable --min-acu 2 --max-acu 32 --deletion-protection -y
 gco stacks aurora disable -y
 ```
 
+#### `gco stacks addons`
+
+Inspect and re-converge cluster add-ons (Helm charts). Add-on installation is decoupled from the CloudFormation rollback path, so a chart that fails to install never rolls back the cluster.
+
+```bash
+gco stacks addons COMMAND [OPTIONS]
+```
+
+**Subcommands:**
+
+- `status` - Show per-chart add-on install status (read from SSM)
+- `install` - Re-run the Helm add-on installer (idempotent; never rolls back the cluster)
+
+**Options (both subcommands):**
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--region` | `-r` | AWS region (default: first deployment region) |
+| `--all-regions` | `-A` | Apply across all deployment regions |
+
+**Example:**
+
+```bash
+gco stacks addons status
+gco stacks addons status --all-regions
+gco stacks addons install -r us-west-2
+```
+
 #### `gco stacks synth`
 
 Synthesize CloudFormation templates without deploying.
@@ -2567,6 +2595,31 @@ gco images lifecycle COMMAND [OPTIONS]
 ```bash
 gco images lifecycle get my-app
 gco images lifecycle set my-app --file lifecycle.json
+```
+
+#### `gco images mirror`
+
+Mirror third-party images (e.g. the Volcano `docker.io` images) into the project ECR. This is the same multi-arch copy `gco stacks deploy` runs automatically when `volcano_image_mirror.enabled` is set; run it directly to pre-seed a region before enabling the toggle, or to re-mirror after bumping a mirrored image version. Wraps the shared `cli._image_mirror` core (also used by the `images_mirror` MCP tool).
+
+```bash
+gco images mirror [OPTIONS]
+```
+
+**Options:**
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--region` | `-r` | Target AWS region; must match the regional stack (required) |
+| `--ecr-namespace` | | Destination ECR namespace (default: cdk.json `volcano_image_mirror.ecr_namespace`) |
+| `--no-skip-existing` | | Re-copy images even if the tag already exists in ECR |
+| `--dry-run` | | Print the copy plan without creating repos or copying images |
+
+**Example:**
+
+```bash
+gco images mirror --region us-east-1
+gco images mirror --region us-east-1 --dry-run
+gco images mirror --region us-east-1 --ecr-namespace gco/dockerhub
 ```
 
 #### `gco images replication`

--- a/gco_mcp/tools/README.md
+++ b/gco_mcp/tools/README.md
@@ -5,6 +5,7 @@ MCP tool definitions — one file per domain. Each module registers tools agains
 ## Table of Contents
 
 - [Files](#files)
+- [Tool Reference](#tool-reference)
 - [How Tools Work](#how-tools-work)
 - [Adding a New Tool](#adding-a-new-tool)
 
@@ -39,6 +40,250 @@ flag-to-tool mapping.
 | `docs.py` | 1 | `find_docs` (documentation discovery) |
 | `examples.py` | 1 | `find_examples` (example-manifest discovery) |
 | `tasks.py` | 2 | `task_status`, `task_tail` (read-only observability for long-running tools) |
+
+## Tool Reference
+
+Every registered MCP tool, grouped by module, with a one-line description from the tool docstring. Tools marked `(gated)` in the [Files](#files) table register only when their feature flag (or the umbrella `GCO_ENABLE_ALL_TOOLS`) is set; this reference lists the full set. `tests/test_docs_coverage.py` fails if a registered tool is missing from this section.
+
+### `jobs.py`
+
+| Tool | Description |
+|------|-------------|
+| `cluster_health` | Get health status of GCO clusters. |
+| `delete_job` | Delete a job. |
+| `get_job` | Get details of a specific job. |
+| `get_job_events` | Get Kubernetes events for a job (useful for debugging). |
+| `get_job_logs` | Get logs from a job. |
+| `list_jobs` | List jobs across GCO clusters. |
+| `queue_status` | View SQS queue status (pending, in-flight, DLQ counts). |
+| `submit_job_api` | Submit a job via the authenticated API Gateway (SigV4). |
+| `submit_job_sqs` | Submit a job via SQS queue (recommended for production). |
+
+### `capacity.py`
+
+| Tool | Description |
+|------|-------------|
+| `ai_recommend` | Get AI-powered capacity recommendation using Amazon Bedrock. |
+| `capacity_status` | View capacity status across all deployed regions. |
+| `check_capacity` | Check spot and on-demand capacity for a specific instance type. |
+| `list_reservations` | List On-Demand Capacity Reservations (ODCRs) across regions. |
+| `recommend_region` | Get optimal region recommendation based on capacity. |
+| `reservation_check` | Check reservation availability and Capacity Block offerings. |
+| `reserve_capacity` | Purchase a Capacity Block offering by its ID. |
+| `spot_prices` | Get current spot prices for an instance type. |
+
+### `inference.py`
+
+| Tool | Description |
+|------|-------------|
+| `canary_deploy` | Start a canary deployment (A/B test a new image version). |
+| `chat_inference` | Send a multi-turn chat conversation to an inference endpoint. |
+| `delete_inference` | Delete an inference endpoint. |
+| `deploy_disaggregated_inference` | Deploy a split prefill/decode (XpYd) inference endpoint. |
+| `deploy_inference` | Deploy an inference endpoint across regions. |
+| `inference_health` | Check if an inference endpoint is healthy and ready to serve requests. |
+| `inference_status` | Get detailed status of an inference endpoint including per-region breakdown. |
+| `invoke_inference` | Send a prompt to an inference endpoint and return the generated text. |
+| `list_endpoint_models` | List models loaded on an inference endpoint. |
+| `list_inference_endpoints` | List all inference endpoints. |
+| `mooncake_topology_status` | Show a disaggregated endpoint's per-role topology status. |
+| `populate_kv_cache` | `gco inference populate-kv` — upload data into an endpoint's KV-cache cold tier. |
+| `promote_canary` | Promote canary to primary (100% traffic to new version). |
+| `rollback_canary` | Rollback canary (remove canary, 100% traffic to primary). |
+| `scale_inference` | Scale an inference endpoint. |
+| `set_mooncake_topology` | Resize a disaggregated endpoint's prefill/decode topology. |
+| `start_inference` | Start a stopped inference endpoint. |
+| `stop_inference` | Stop an inference endpoint (scales to zero, keeps config). |
+| `update_inference_image` | Rolling update of an inference endpoint's container image. |
+
+### `costs.py`
+
+| Tool | Description |
+|------|-------------|
+| `cost_by_region` | Get cost breakdown by AWS region. |
+| `cost_forecast` | Forecast GCO costs for the next N days. |
+| `cost_summary` | Get total GCO spend broken down by AWS service. |
+| `cost_trend` | Get daily cost trend. |
+
+### `stacks.py`
+
+| Tool | Description |
+|------|-------------|
+| `aurora_status` | `gco stacks aurora status` — show Aurora database stack status. |
+| `bootstrap_cdk` | `gco stacks bootstrap` — bootstrap CDK in an AWS account/region. |
+| `deploy_all` | `gco stacks deploy-all` — deploy every CDK stack in dependency order. |
+| `deploy_stack` | `gco stacks deploy` — deploy a single CDK stack to AWS. |
+| `destroy_all` | `gco stacks destroy-all` — destroy every CDK stack in reverse dependency order. |
+| `destroy_stack` | `gco stacks destroy` — destroy a single CDK stack. |
+| `disable_aurora` | `gco stacks aurora disable` — flip Aurora pgvector off in cdk.json. |
+| `disable_fsx` | `gco stacks fsx disable` — flip FSx Lustre off in cdk.json. |
+| `disable_valkey` | `gco stacks valkey disable` — flip Valkey Serverless off in cdk.json. |
+| `enable_aurora` | `gco stacks aurora enable` — flip Aurora pgvector on in cdk.json. |
+| `enable_fsx` | `gco stacks fsx enable` — flip FSx Lustre on in cdk.json. |
+| `enable_valkey` | `gco stacks valkey enable` — flip Valkey Serverless on in cdk.json. |
+| `fsx_status` | Check FSx for Lustre configuration status. |
+| `list_stacks` | List all GCO CDK stacks. |
+| `setup_cluster_access` | Configure kubectl access to a GCO EKS cluster. |
+| `stack_diff` | `gco stacks diff` — show CloudFormation diff for a stack. |
+| `stack_outputs` | `gco stacks outputs` — fetch CloudFormation outputs for a stack. |
+| `stack_status` | Get detailed status of a CloudFormation stack. |
+| `stack_synth` | `gco stacks synth` — synthesize CloudFormation templates from CDK. |
+| `valkey_status` | `gco stacks valkey status` — show Valkey cache stack status. |
+
+### `storage.py`
+
+| Tool | Description |
+|------|-------------|
+| `files_access_points` | `gco files access-points` — list EFS access points. |
+| `files_get` | `gco files get` — fetch a single file from EFS. |
+| `list_file_systems` | List EFS and FSx file systems. |
+| `list_storage_contents` | List contents of shared EFS storage. |
+| `upload_to_regional_bucket` | `gco models upload-regional` — upload local files to a region's regional bucket. |
+
+### `models.py`
+
+| Tool | Description |
+|------|-------------|
+| `delete_model` | `gco models delete` — delete a model from the central S3 bucket. |
+| `get_model_uri` | Get the S3 URI for a model (for use with --model-source). |
+| `list_models` | List all uploaded model weights in the S3 bucket. |
+| `models_upload` | data-upload. |
+
+### `nodepools.py`
+
+| Tool | Description |
+|------|-------------|
+| `delete_nodepool` | `gco nodepools delete` — delete a Karpenter NodePool. |
+| `nodepools_create_odcr` | `gco nodepools create-odcr` — create a Karpenter NodePool tied to an ODCR. |
+| `nodepools_describe` | `gco nodepools describe` — describe a single NodePool. |
+| `nodepools_list` | `gco nodepools list` — list Karpenter NodePools in a cluster. |
+
+### `analytics.py`
+
+| Tool | Description |
+|------|-------------|
+| `analytics_doctor` | `gco analytics doctor` — run analytics environment health checks. |
+| `analytics_login_url` | `gco analytics login-url` — get a SageMaker Studio login URL for a user. |
+| `analytics_user_add` | `gco analytics users add` — create a Cognito user in the analytics pool. |
+| `analytics_user_remove` | `gco analytics users remove` — delete a Cognito user from the analytics user pool. |
+| `analytics_users_list` | `gco analytics users list` — list Cognito users in the analytics user pool. |
+| `disable_analytics` | `gco stacks analytics disable` — flip the analytics environment off in cdk.json. |
+| `enable_analytics` | `gco stacks analytics enable` — flip the analytics environment on in cdk.json. |
+
+### `templates.py`
+
+| Tool | Description |
+|------|-------------|
+| `delete_template` | `gco templates delete` — delete a job template. |
+| `templates_create` | `gco templates create` — register a new job template from a manifest. |
+| `templates_get` | `gco templates get` — fetch a single job template by name. |
+| `templates_list` | `gco templates list` — list job templates. |
+| `templates_run` | `gco templates run` — instantiate a job from a stored template. |
+
+### `webhooks.py`
+
+| Tool | Description |
+|------|-------------|
+| `delete_webhook` | `gco webhooks delete` — delete a webhook subscription. |
+| `webhooks_create` | `gco webhooks create` — register a new webhook subscription. |
+| `webhooks_get` | `gco webhooks get` — fetch a single webhook by name. |
+| `webhooks_list` | `gco webhooks list` — list configured webhooks. |
+
+### `queue.py`
+
+| Tool | Description |
+|------|-------------|
+| `cancel_queue_job` | `gco queue cancel` — cancel a queued job (only works for jobs not yet running). |
+| `queue_get` | `gco queue get` — fetch a single job from the global queue. |
+| `queue_list` | `gco queue list` — list jobs in the global queue. |
+| `queue_stats` | `gco queue stats` — show aggregate stats for the global queue. |
+| `queue_submit` | `gco queue submit` — submit a job manifest to the global queue. |
+
+### `images.py`
+
+| Tool | Description |
+|------|-------------|
+| `images_build` | long-running, data-upload. |
+| `images_cleanup` | `gco images cleanup` — remove every untagged image across one or all project repos. |
+| `images_delete_repo` | `gco images delete-repo` — delete a whole repository. |
+| `images_delete_tag` | `gco images delete-tag` — delete a single tag from a repository. |
+| `images_describe` | `gco images describe` — full ECR details for a single image tag. |
+| `images_init` | `gco images init` — create the project ECR repo idempotently with default lifecycle. |
+| `images_lifecycle_get` | `gco images lifecycle get` — print the lifecycle policy on a repository. |
+| `images_lifecycle_set` | `gco images lifecycle set` — replace the lifecycle policy on a repository. |
+| `images_list` | `gco images list` — list every gco/* repository in ECR. |
+| `images_mirror` | image-upload. |
+| `images_mirror_plan` | Image mirror — show which third-party images would be mirrored into ECR. |
+| `images_mirror_status` | Image mirror — report which managed images are already present in ECR. |
+| `images_orphans` | `gco images orphans` — list gco/* tags older than ``threshold_days`` with no references. |
+| `images_prune` | `gco images prune` — remove untagged images older than 30 days. |
+| `images_push` | long-running, data-upload. |
+| `images_replication_get` | `gco images replication get` — current ECR replication configuration. |
+| `images_replication_status` | `gco images replication status` — per-image replication status across project repos. |
+| `images_replication_sync` | `gco images replication sync` — apply the standard gco/* replication rule. |
+| `images_tags` | `gco images tags` — list tags within a repository. |
+| `images_uri` | `gco images uri` — return the registry URI for an image. |
+
+### `dag.py`
+
+| Tool | Description |
+|------|-------------|
+| `dag_run` | `gco dag run` — execute a DAG manifest end-to-end. |
+| `dag_validate` | `gco dag validate` — statically validate a DAG manifest. |
+
+### `config.py`
+
+| Tool | Description |
+|------|-------------|
+| `config_get` | `gco config get` — read a CLI configuration value. |
+
+### `metrics.py`
+
+| Tool | Description |
+|------|-------------|
+| `metrics_cloudwatch_get` | Read one CloudWatch datapoint as a canonical metric. |
+| `metrics_from_job_logs` | Extract a scalar from the tail of a job's logs. |
+| `metrics_from_local_file` | Read a named field from a LOCAL metrics file. |
+| `metrics_from_shared_storage_file` | Read a named field from a shared-storage metrics file. |
+
+### `semantic_progress.py`
+
+| Tool | Description |
+|------|-------------|
+| `metrics_semantic_progress` | Score Mission progress. |
+
+### `mission.py`
+
+| Tool | Description |
+|------|-------------|
+| `mission_abort` | Pause or terminate a Mission session. |
+| `mission_checkpoint` | Re-run the verdict cascade on the latest iteration. |
+| `mission_complete` | Force a Mission session into completed status. |
+| `mission_history` | Get iteration history for a Mission session. |
+| `mission_iterate` | Run iteration(s) on a Mission session. |
+| `mission_list` | List Mission sessions. |
+| `mission_resume` | Resume a paused Mission session. |
+| `mission_start` | Start a new Mission session. |
+| `mission_status` | Get the full state of a Mission session. |
+
+### `docs.py`
+
+| Tool | Description |
+|------|-------------|
+| `find_docs` | `find_docs` — search the docs catalog by topic and free-text query. |
+
+### `examples.py`
+
+| Tool | Description |
+|------|-------------|
+| `find_examples` | `find_examples` — search the example-manifest catalog by keyword and filters. |
+
+### `tasks.py`
+
+| Tool | Description |
+|------|-------------|
+| `task_status` | Return live status of long-running tools. |
+| `task_tail` | Return the last N lines of a long-running task's raw output log. |
 
 ## How Tools Work
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -432,6 +432,7 @@ Static analysis tests act as guardrails against regressions in specific drift di
 | `test_doc_hygiene.py` | Per-feature companion to `test_no_spec_references.py` for the *aggressive* spec-breadcrumb patterns (requirement IDs like `R12.6`, bare `Property N`, `Requirement N`, `task N`, `Validates:`, planning-doc filenames, and "the design" / "the spec" prose) that would false-positive if run repo-wide. One parametrized case per spec-driven feature (currently `mission-metric-reader-tools`, `mission-allow-all-tools`, `mission-semantic-progress-judge`), each scanning only that feature's explicit source files and its own `tests/test_<feature>_*.py` modules; documentation, examples, and a feature's functional flag names / `[gated by ...]` prefixes are out of scope. Adding a feature means appending one `_Feature` row, not a new test file. |
 | `test_pip_audit_ignore_validator.py` | Pins the contract of `.github/scripts/check_pip_audit_ignore.py`, which gates the pip-audit job in `.github/workflows/security.yml`. Every entry in `.pip-audit-ignore` must carry an `exp:YYYY-MM-DD` marker; the validator fails the workflow when any entry is on-or-before today (inclusive — no bonus day) or is missing the marker entirely. Tests cover happy paths (single, multi, blank-line / comment skipping, missing-file-is-clean), expired-date detection (past dates, equal-to-today, ±1 day boundary), missing or malformed markers, `main()` exit codes / stdout, and a live-file check that runs the committed suppression file through the validator with today's date. |
 | `test_ci_config_paths.py` | Guards CI config against stale path references left by a package rename (the `mcp` to `gco_mcp` move broke the CodeQL autobuilder with FileNotFoundError). Asserts every `paths:` entry in `.github/codeql/codeql-config.yml` is a real directory, every `--cov=<pkg>` target across `.github/workflows/*.yml` and `.gitlab-ci.yml` resolves to an existing top-level directory, and every `[tool.coverage.run] source` dir in `pyproject.toml` exists. Catches the silent failure mode where a renamed package leaves coverage recording nothing and CodeQL crashing at scan time. |
+| `test_docs_coverage.py` | Documentation-coverage guard with three cases: every `tests/test_*.py` module appears in `tests/README.md`; every `gco` Click command (the full command tree, walked recursively) is documented in `docs/CLI.md` (matched as a `gco <command>` entry); and every registered MCP tool — enumerated in a subprocess with `GCO_ENABLE_ALL_TOOLS` so the full catalog is visible — appears in `gco_mcp/tools/README.md`. Each case fails with the list of undocumented items so the fix is to add the missing described entry. |
 
 ### Infrastructure Tests
 
@@ -449,6 +450,121 @@ Static analysis tests act as guardrails against regressions in specific drift di
 | `_cdk_config_matrix.py` | The canonical list of `cdk.json` configuration overlays (default, multi-region, feature toggles, thresholds, helm matrix, analytics fixtures). Imported by both `tests/test_cdk_synthesis_matrix.py` and `tests/test_nag_compliance.py` so the two iterate over the same set. See the [CDK Configuration Matrix](#cdk-stack-tests) section. |
 | `_cdk_nag_logger.py` | `CapturingCdkNagLogger` — a custom `INagLogger` implementation that routes every cdk-nag finding into a Python list instead of CDK's annotation system. Used by `test_nag_compliance.py` and `scripts/dump_nag_findings.py` to assert on findings programmatically. |
 | `__init__.py` | Package initialization |
+
+> The category tables above are curated by area. The tables below complete the per-file index so that **every** test module in this directory is documented; new clusters get their own subsection and everything else is listed alphabetically under Additional Tests.
+
+### Mooncake / Disaggregated Inference Tests
+
+| File | Description |
+|------|-------------|
+| `test_mooncake_autoscale_cli.py` | The deploy command routes per-role autoscaling into the mooncake block. |
+| `test_mooncake_autoscaling_bounds.py` | Per-role autoscaler bounds and the static replica fallback. |
+| `test_mooncake_backward_compat.py` | Endpoints without a ``mooncake`` block keep their classic single-instance shape. |
+| `test_mooncake_bootstrap_port.py` | Bootstrap-port assignment for KV-transfer workers is collision-free. |
+| `test_mooncake_cli_mcp_surface.py` | Tests for the disaggregated-serving CLI and MCP surface. |
+| `test_mooncake_config_rendering.py` | Connector chaining and runtime config rendering for mooncake endpoints. |
+| `test_mooncake_connector_config.py` | KV connector configuration emitted for each worker role. |
+| `test_mooncake_e2e.py` | End-to-end reconciliation of a distributed inference endpoint. |
+| `test_mooncake_efa_scheduling.py` | EFA fabric placement for RDMA KV-transfer role pods. |
+| `test_mooncake_image_contract.py` | Contract tests that exercise the *actual* Mooncake vLLM image. |
+| `test_mooncake_kvcache_tooling.py` | KV-cache tooling and split-serving deployability for Mooncake endpoints. |
+| `test_mooncake_master_idempotency.py` | Idempotent maintenance of the shared per-region Mooncake master. |
+| `test_mooncake_master_image.py` | Default image wiring for the shared per-region Mooncake master. |
+| `test_mooncake_master_readiness_gating.py` | Gating dependent role-pod creation on the shared master's readiness. |
+| `test_mooncake_mode_role.py` | Which worker Deployments a reconcile materializes for each serving mode. |
+| `test_mooncake_multi_region_scope.py` | Region-boundary checks for disaggregated mooncake topologies. |
+| `test_mooncake_nodepool_manifest.py` | Dedicated Mooncake EFA NodePool: only GPUs that can serve KV-transfer. |
+| `test_mooncake_pd_proxy_program.py` | Request-shaping contract of the Mooncake PD proxy program. |
+| `test_mooncake_pd_proxy_routing.py` | Front-door routing for disaggregated prefill-decode endpoints. |
+| `test_mooncake_region_services.py` | In-region service resolution for mooncake endpoints. |
+| `test_mooncake_regional_bucket_provisioning.py` | Property-based test — the general-purpose regional bucket is always-on. |
+| `test_mooncake_regional_bucket_synthesis.py` | Synthesis checks for the always-on general-purpose regional bucket. |
+| `test_mooncake_regional_bucket_targeting.py` | Property-based test — a regional upload only ever touches its own region. |
+| `test_mooncake_regional_scope.py` | Regional confinement of disaggregated KV-transfer wiring. |
+| `test_mooncake_regional_upload.py` | Tests for ``RegionalBucketManager`` bucket resolution and upload error paths. |
+| `test_mooncake_security.py` | Access-control guarantees for disaggregated inference. |
+| `test_mooncake_serialization.py` | Round-trip behavior of a ``mooncake`` endpoint-spec block through the store. |
+| `test_mooncake_spec.py` | Tests for the Mooncake endpoint-spec shape, constants, and byte-size helper. |
+| `test_mooncake_spec_validation.py` | Fail-fast validation of a ``mooncake`` endpoint-spec block. |
+| `test_mooncake_topology_fidelity.py` | Materialized role replica counts mirror the requested topology. |
+
+### Metric Reader Tests
+
+| File | Description |
+|------|-------------|
+| `test_metric_readers_aggregate.py` | Tests for the sequence reducer that collapses history to one number. |
+| `test_metric_readers_cloudwatch.py` | Tests for the CloudWatch datapoint reader. |
+| `test_metric_readers_files.py` | Round-trip tests for the file-format metric reader. |
+| `test_metric_readers_localfs.py` | Tests for confining a supplied path to an allowlisted root directory. |
+| `test_metric_readers_logs.py` | Tests for pulling a scalar out of a job's log lines. |
+| `test_metric_readers_observe.py` | Observe_Phase merge-contract integration test. |
+| `test_metric_readers_shape.py` | Tests for the canonical metric-result builder. |
+| `test_metric_readers_tools.py` | Success-path tests for the metric-reader MCP tool wrappers. |
+
+### Additional Mission Tests
+
+| File | Description |
+|------|-------------|
+| `test_mission_allow_all_tools_cli.py` | CLI tests for the ``--allow-all-tools`` flag on ``gco mission``. |
+| `test_mission_allow_all_tools_integration.py` | Integration checks that an all-tools-resolved session behaves like an explicit one. |
+| `test_mission_allow_all_tools_mcp.py` | MCP-tool tests for the ``mission_start`` all-tools resolution path. |
+| `test_mission_allow_all_tools_validation.py` | Property-based checks for the Mission all-tools allowlist resolver. |
+| `test_mission_metric_trend.py` | Tests for the cumulative-metrics view and the ``metric_trend`` criterion. |
+
+### Additional Tests
+
+| File | Description |
+|------|-------------|
+| `test_addons_cli.py` | Tests for ``gco stacks addons`` (status / install) and the ``--all-regions`` flag. |
+| `test_analytics_cleanup_lambda.py` | Tests for the analytics-cleanup Lambda (lambda/analytics-cleanup/handler.py). |
+| `test_api_shared.py` | Tests for shared API helpers in gco/services/api_shared.py. |
+| `test_bug_fixes.py` | Regression tests for a handful of bug fixes across the GCO codebase. |
+| `test_canary.py` | Tests for A/B (canary) inference endpoint deployments. |
+| `test_capacity.py` | Tests for cli/capacity/ — the GPU capacity checker and recommender. |
+| `test_capacity_cmd_coverage.py` | Tests for the capacity CLI subcommands in cli/commands/capacity_cmd.py. |
+| `test_capacity_reservations.py` | Tests for On-Demand Capacity Reservations and EC2 Capacity Blocks. |
+| `test_cli_config.py` | Tests for cli/config.py. |
+| `test_cli_inference_models.py` | Tests for the inference and models CLI subgroups in cli/main.py. |
+| `test_cloudwatch_logs_fallback.py` | Tests for JobManager.get_job_logs CloudWatch Logs fallback. |
+| `test_costs.py` | Tests for the cost-visibility feature in cli/costs.py. |
+| `test_costs_cmd_extended.py` | Extended tests for cli/commands/costs_cmd.py. |
+| `test_cross_region_aggregator_extended.py` | Extended coverage tests for the cross-region aggregator Lambda. |
+| `test_dag.py` | Tests for the job-DAG pipeline feature in cli/dag.py. |
+| `test_drift_detection.py` | Tests for the CloudFormation drift-detection resources on the regional stack. |
+| `test_ga_registration.py` | Tests for the Global Accelerator registration Lambda (lambda/ga-registration/handler.py). |
+| `test_health_check_coverage.py` | Consistency tests between ALB Ingress health-check paths and the auth middleware allowlist. |
+| `test_helm_orchestrator_handler.py` | Unit tests for the helm-orchestrator custom-resource provider handler. |
+| `test_inference_gpu_autoscaling.py` | GPU-aware autoscaling routes through a KEDA ScaledObject. |
+| `test_inference_manager_extended.py` | Extended tests for cli/inference.InferenceManager. |
+| `test_inference_store.py` | Tests for gco/services/inference_store.InferenceEndpointStore. |
+| `test_jobs_dag_extended.py` | Extended tests for cli/jobs.py and cli/dag.py. |
+| `test_kubectl_applier.py` | Tests for the kubectl-applier Lambda (lambda/kubectl-applier-simple/handler.py). |
+| `test_kubectl_helpers.py` | Tests for cli/kubectl_helpers.update_kubeconfig. |
+| `test_kubectl_helpers_extended.py` | Extended tests for cli/kubectl_helpers.update_kubeconfig. |
+| `test_lambda_handlers.py` | Tests for the secret-rotation and alb-header-validator Lambda handlers. |
+| `test_lambda_handlers_extended.py` | Extended tests for secret-rotation and alb-header-validator Lambdas. |
+| `test_lambda_proxy.py` | Tests for the Lambda proxy handlers and shared proxy_utils. |
+| `test_manifest_property.py` | Property-based tests for manifest validation and YAML parsing. |
+| `test_mcp_iam_role.py` | CDK assertion tests for the dedicated MCP server IAM role on the regional stack. |
+| `test_mcp_self_resources.py` | Tests for the self-indexing MCP resources (``mcp://gco/...``). |
+| `test_mcp_task_tools.py` | Tests for the read-only MCP observability tools (``task_status`` and ``task_tail``) and the matching ``gco tasks`` CLI surface. |
+| `test_model_bucket_access_logs.py` | Tests for S3 server access logging on the model weights bucket. |
+| `test_models_cli.py` | Tests for cli/models.ModelManager — S3 model weight management. |
+| `test_network_policies_manifest.py` | Tests for the NetworkPolicy manifest at lambda/kubectl-applier-simple/manifests/03-network-policies.yaml. |
+| `test_nodepools_extended.py` | Extended tests for cli/nodepools.py. |
+| `test_proxy_utils_extended.py` | Extended tests for lambda/proxy-shared/proxy_utils.py. |
+| `test_python_base_image_consistency.py` | Python base-image pins stay consistent across services and CI. |
+| `test_regional_api_gateway_stack.py` | Tests for gco/stacks/regional_api_gateway_stack.GCORegionalApiGatewayStack. |
+| `test_request_size_limit.py` | Tests for the RequestSizeLimitMiddleware on the Manifest API. |
+| `test_resource_quota_config.py` | End-to-end tests that cdk.json resource quota values flow into the Kubernetes manifests applied on the cluster. |
+| `test_resource_quota_manifest.py` | Tests for the ResourceQuota + LimitRange manifest (lambda/kubectl-applier-simple/manifests/06-resource-quotas.yaml). |
+| `test_stacks_access.py` | Tests for `gco stacks access` — the kubectl bootstrap command in cli/commands/stacks_cmd.py. |
+| `test_stacks_ordering_fsx.py` | Tests for stack ordering helpers and FSx configuration in cli/stacks.py. |
+| `test_task_status.py` | Tests for the disk-backed task status writer. |
+| `test_trusted_registries_augmentation.py` | Tests for ``_augment_trusted_registries_with_project_ecr``. |
+| `test_waf_rate_limit.py` | Tests for the WAF PerIPRateLimit rule on GCOApiGatewayGlobalStack. |
+| `test_webhook_dispatcher.py` | Tests for gco/services/webhook_dispatcher.WebhookDispatcher. |
+| `test_yaml_parsing_limits.py` | Tests for YAML parsing limits on the manifest processor. |
 
 ## Writing New Tests
 
@@ -481,14 +597,12 @@ Brief description of what this test file covers.
 from unittest.mock import MagicMock, patch, AsyncMock
 import pytest
 
-
 @pytest.fixture
 def mock_dependency():
     """Fixture description."""
     mock = MagicMock()
     mock.some_method.return_value = "expected_value"
     return mock
-
 
 class TestFeatureName:
     """Tests for [feature name]."""
@@ -521,7 +635,6 @@ When testing FastAPI endpoints, you need to mock both the factory functions AND 
 ```python
 from unittest.mock import MagicMock, patch, AsyncMock
 from fastapi.testclient import TestClient
-
 
 def test_api_endpoint(mock_manifest_processor):
     """Test an API endpoint with proper mocking."""

--- a/tests/test_docs_coverage.py
+++ b/tests/test_docs_coverage.py
@@ -1,0 +1,85 @@
+"""Documentation-coverage guards for the test suite, CLI, and MCP tools.
+
+Three checks fail CI when reference docs fall behind the code they describe:
+
+* test_every_test_file_is_documented: every tests/test_*.py module is listed in tests/README.md.
+* test_every_cli_command_is_documented: every command in the gco Click tree is documented in docs/CLI.md (matched as `gco <path>`).
+* test_every_mcp_tool_is_documented: every registered MCP tool (all feature flags on) appears in gco_mcp/tools/README.md.
+
+Each test fails with the full list of undocumented items so the fix is mechanical: add the missing entry, with a short description, to the doc. Each guard also asserts a sanity floor on the number of items it discovered, so a broken enumeration (an import error, an empty subprocess result) fails loudly instead of passing vacuously. The MCP catalog is enumerated in a subprocess with GCO_ENABLE_ALL_TOOLS set so the guard sees the full set without perturbing the import-time tool registration the other MCP tests rely on.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TESTS_DIR = REPO_ROOT / "tests"
+
+
+def test_every_test_file_is_documented() -> None:
+    readme = (TESTS_DIR / "README.md").read_text(encoding="utf-8")
+    names = sorted(p.name for p in TESTS_DIR.glob("test_*.py"))
+    assert len(names) > 100, f"sanity floor: only discovered {len(names)} test modules"
+    missing = [n for n in names if n not in readme]
+    assert not missing, (
+        "Test modules missing from tests/README.md (add a described row for each):\n "
+        + "\n ".join(missing)
+    )
+
+
+def _iter_cli_commands(cmd: object, prefix: str = "") -> list[str]:
+    out: list[str] = []
+    for name, sub in sorted(getattr(cmd, "commands", {}).items()):
+        path = (prefix + " " + name).strip()
+        out.append(path)
+        out.extend(_iter_cli_commands(sub, path))
+    return out
+
+
+def test_every_cli_command_is_documented() -> None:
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    from cli.main import cli
+
+    doc = (REPO_ROOT / "docs" / "CLI.md").read_text(encoding="utf-8")
+    commands = _iter_cli_commands(cli)
+    assert len(commands) > 50, f"sanity floor: only walked {len(commands)} CLI commands"
+    missing = [c for c in commands if not re.search(r"gco " + re.escape(c) + r"(?![\w-])", doc)]
+    assert not missing, (
+        "CLI commands missing from docs/CLI.md (document each as a `gco <command>` entry):\n "
+        + "\n ".join(missing)
+    )
+
+
+_MCP_ENUM = 'import asyncio, json, sys; sys.path.insert(0, "gco_mcp"); import run_mcp; print(json.dumps(sorted(t.name for t in asyncio.run(run_mcp.mcp._list_tools()))))'
+
+
+def _all_mcp_tool_names() -> list[str]:
+    env = dict(os.environ)
+    env["GCO_ENABLE_ALL_TOOLS"] = "true"
+    proc = subprocess.run(
+        [sys.executable, "-c", _MCP_ENUM],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def test_every_mcp_tool_is_documented() -> None:
+    readme = (REPO_ROOT / "gco_mcp" / "tools" / "README.md").read_text(encoding="utf-8")
+    names = _all_mcp_tool_names()
+    assert len(names) >= 100, f"sanity floor: only enumerated {len(names)} MCP tools"
+    missing = [n for n in names if n not in readme]
+    assert not missing, (
+        "MCP tools missing from gco_mcp/tools/README.md (add a Tool Reference row for each):\n "
+        + "\n ".join(missing)
+    )


### PR DESCRIPTION
tests/README.md now documents all 226 test modules (93 were undocumented) via new Mooncake, Metric Reader, Additional Mission, and Additional Tests subsections, plus a Codebase Guardrail row for the new guard. Descriptions come from each module docstring.

docs/CLI.md documents the 4 previously-missing Click commands: the stacks addons subgroup (status, install) and images mirror.

gco_mcp/tools/README.md gains a Tool Reference section giving each of the 135 registered tools its own one-line description, grouped by module.

tests/test_docs_coverage.py adds three guards that fail when a test module, CLI command, or MCP tool is undocumented; they run in the existing pytest CI job. Each guard asserts a sanity floor so a broken enumeration fails loudly instead of passing vacuously.

<!--
Thanks for contributing to Global Capacity Orchestrator (GCO)! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [ ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
