### PR TITLE
Fix/dev container buildx deps test

### DIFF
--- a/.github/scripts/dependency-scan.sh
+++ b/.github/scripts/dependency-scan.sh
@@ -16,7 +16,7 @@
 #   - Aurora PostgreSQL engine versions (AWS creds)
 #   - EMR Serverless release labels (AWS creds)
 #   - Dockerfile.dev ARG pins (Node LTS major, npm, CDK CLI, kubectl,
-#     AWS CLI v2, Docker CLI) — public endpoints, no AWS creds needed
+#     AWS CLI v2, Docker CLI, Docker Buildx) — public endpoints, no AWS creds needed
 #   - Pre-commit hook revisions in .pre-commit-config.yaml compared
 #     against the latest tag published upstream (GitHub API)
 #   - CDK enum constants from gco/stacks/constants.py compared against the
@@ -492,7 +492,7 @@ EMR_COUNT="$(wc -l < "$EMR_RESULTS" 2>/dev/null | tr -d ' ')"
 # Dockerfile.dev ARG pins
 #
 # Checks the tooling versions pinned in ``Dockerfile.dev`` (Node.js LTS
-# major, AWS CDK CLI, kubectl, AWS CLI v2, Docker CLI). These ARGs sit
+# major, AWS CDK CLI, kubectl, AWS CLI v2, Docker CLI, Docker Buildx). These ARGs sit
 # outside the main dependency surfaces above — Dependabot watches the
 # ``FROM python:…`` base image but not the ARG pins — so drift here has
 # historically gone undetected until someone rebuilt the image.
@@ -506,6 +506,7 @@ EMR_COUNT="$(wc -l < "$EMR_RESULTS" 2>/dev/null | tr -d ' ')"
 #                  (minor from cdk.json::kubernetes_version)
 #   AWSCLI_VERSION github://aws/aws-cli/tags (v2.x.y semver, no GitHub Releases)
 #   DOCKER_VERSION github://moby/moby/releases/latest (``docker-v<ver>``)
+#   BUILDX_VERSION github://docker/buildx/releases/latest (v<ver>)
 #
 # All endpoints are public — no AWS credentials needed.
 # ---------------------------------------------------------------------------
@@ -585,6 +586,15 @@ if candidates:
         "https://api.github.com/repos/moby/moby/releases/latest" 2>/dev/null \
         | jq -r '.tag_name // empty' 2>/dev/null \
         | sed -E 's/^(docker-)?v//')" || true
+      ;;
+    BUILDX_VERSION)
+      # docker/buildx publishes GitHub Releases tagged v<semver>
+      # (e.g. v0.35.0). The release tag is the canonical source;
+      # compare_semver strips the leading v on both sides. The
+      # Dockerfile installs the plugin binary buildx-<tag>.linux-<arch>.
+      latest="$(curl -fsSL --max-time 15 \
+        "https://api.github.com/repos/docker/buildx/releases/latest" 2>/dev/null \
+        | jq -r '.tag_name // empty' 2>/dev/null)" || true
       ;;
     *)
       return

--- a/.github/scripts/lib_dependency_scan.sh
+++ b/.github/scripts/lib_dependency_scan.sh
@@ -247,6 +247,7 @@ extract_k8s_version() {
 #     KUBECTL_VERSION|v1.36.1
 #     AWSCLI_VERSION|2.34.42
 #     DOCKER_VERSION|29.4.2
+#     BUILDX_VERSION|v0.35.0
 extract_dockerfile_pins() {
   local file="${1:-Dockerfile.dev}"
   [ -f "$file" ] || return 0
@@ -259,6 +260,7 @@ allowlist = {
     'KUBECTL_VERSION',
     'AWSCLI_VERSION',
     'DOCKER_VERSION',
+    'BUILDX_VERSION',
 }
 with open(sys.argv[1]) as f:
     for line in f:

--- a/.github/workflows/deps-scan.yml
+++ b/.github/workflows/deps-scan.yml
@@ -15,7 +15,7 @@
 #   - Aurora PostgreSQL engine versions (AWS creds via OIDC)
 #   - EMR Serverless release labels (AWS creds via OIDC)
 #   - Dockerfile.dev ARG pins (NODE_MAJOR, NPM_VERSION, CDK_VERSION,
-#     KUBECTL_VERSION, AWSCLI_VERSION, DOCKER_VERSION) — public endpoints,
+#     KUBECTL_VERSION, AWSCLI_VERSION, DOCKER_VERSION, BUILDX_VERSION) — public endpoints,
 #     no AWS creds needed
 #   - Pre-commit hook revisions in .pre-commit-config.yaml compared against
 #     the latest tag from the upstream Git host (unauthenticated; one call

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -436,8 +436,8 @@ jobs:
           docker run --rm -v "$PWD":/workspace -w /workspace gco-dev gco capacity --help
           docker run --rm -v "$PWD":/workspace -w /workspace gco-dev gco stacks --help
       - name: Verify pinned toolchain versions
-        # The Dockerfile pins Node, kubectl, AWS CLI v2, CDK, and the Docker
-        # CLI to specific releases. Confirm each tool reports a non-empty
+        # The Dockerfile pins Node, kubectl, AWS CLI v2, CDK, the Docker
+        # CLI, and Docker Buildx, to specific releases. Confirm each tool reports a non-empty
         # version — catches pin drift, broken downloads, and PATH issues.
         run: |
           docker run --rm gco-dev bash -c '
@@ -447,6 +447,7 @@ jobs:
             kubectl version --client=true
             aws --version
             docker --version
+            docker buildx version
           '
       - name: Verify image contains native ${{ matrix.arch }} binaries
         # Two layers of verification:

--- a/.trivyignore
+++ b/.trivyignore
@@ -84,3 +84,28 @@ CVE-2026-33814 exp:2026-09-22
 CVE-2026-39821 exp:2026-09-22
 CVE-2026-42502 exp:2026-09-22
 CVE-2026-42506 exp:2026-09-22
+
+# CVE-2026-53488, CVE-2026-53489, CVE-2026-53492 (github.com/containerd/containerd/v2
+# v2.2.4) and CVE-2026-34040 (github.com/docker/docker v28.5.2 — Moby authorization
+# bypass) — Go modules statically linked into the docker-buildx CLI plugin that
+# Dockerfile.dev installs (ARG BUILDX_VERSION). Surfaced by security:trivy:container-scan
+# on the GCO dev image — the only scanned image that carries the Buildx plugin. Fixed
+# in containerd 2.2.5 / 2.3.2 and docker/docker 29.3.1.
+#
+# Not yet clearable by a pin bump: v0.35.0 is the latest buildx release and even buildx
+# master still pins containerd v2.2.4 and docker/docker v28.5.2, so no released or
+# pre-release buildx carries the fixed modules yet.
+#
+# Low runtime risk: buildx is a build-time CLI plugin, not a running containerd or moby
+# daemon, so the containerd runtime CVEs and the Moby daemon authorization-bypass CVE are
+# off the path buildx exercises (registry-to-registry image copy and BuildKit builds).
+# The dev image is a contributor/CI tool that is never deployed to a cluster.
+#
+# Clears when a buildx release ships rebuilt against containerd >= 2.2.5 and docker/docker
+# >= 29.3.1: bump BUILDX_VERSION in Dockerfile.dev (the monthly deps-scan now tracks it)
+# and drop these entries. Advisory: https://avd.aquasec.com/nvd/cve-2026-53488 (and the
+# matching nvd/cve-2026-XXXXX page for each ID above).
+CVE-2026-53488 exp:2026-09-22
+CVE-2026-53489 exp:2026-09-22
+CVE-2026-53492 exp:2026-09-22
+CVE-2026-34040 exp:2026-09-22

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,7 +5,10 @@
 # Docker Desktop on Intel Macs / Linux) and linux/arm64 (Apple Silicon
 # Macs running Docker Desktop, Finch, Colima, or any arm64 Linux host).
 # kubectl, the AWS CLI v2, and the Docker static client all publish both
-# arch builds; we pick the right one via BuildKit's $TARGETARCH.
+# arch builds; we pick the right one via BuildKit's $TARGETARCH. The
+# Docker Buildx plugin is installed alongside the client so the multi-arch
+# image mirror and the linux/amd64 asset builds that `gco stacks deploy-all`
+# performs work out of the box on Apple Silicon (arm64) as well as x86_64.
 #
 # Build:
 #   docker build -f Dockerfile.dev -t gco-dev .
@@ -176,6 +179,31 @@ RUN GNU_ARCH=$(cat /tmp/gnu_arch) \
     && mv /tmp/docker/docker /usr/local/bin/ \
     && rm -rf /tmp/docker /tmp/docker.tgz /tmp/gnu_arch \
     && docker --version
+
+# Install the Docker Buildx CLI plugin.
+#
+# `gco stacks deploy-all` needs a multi-arch image-copy tool for two
+# steps, and on an arm64 host (Apple Silicon) both fail without Buildx:
+#   1. The Volcano ECR image mirror — cli/_image_mirror.py prefers
+#      `docker buildx imagetools create` (a registry-to-registry copy
+#      that preserves the full multi-arch manifest list). Without a
+#      multi-arch copy method it aborts before CloudFormation with
+#      "No multi-arch image-copy method available".
+#   2. The linux/amd64 Lambda/service asset images that CDK bundles —
+#      the legacy builder cannot cross-build, failing with "image ...
+#      does not provide the specified platform (linux/amd64)".
+# The Docker static tarball above ships only the client binary (no
+# cli-plugins/), so the plugin is installed separately here. Buildx
+# publishes per-arch release binaries selected by ${TARGETARCH}; the
+# plugin lives in a system cli-plugins path so the root user's docker
+# CLI discovers it. Pinned for reproducibility — bump in lockstep with
+# the deps-scan report. https://github.com/docker/buildx/releases
+ARG BUILDX_VERSION=v0.35.0
+RUN mkdir -p /usr/local/lib/docker/cli-plugins \
+    && curl -fsSL "https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-${TARGETARCH}" \
+      -o /usr/local/lib/docker/cli-plugins/docker-buildx \
+    && chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx \
+    && docker buildx version
 
 # Set working directory
 WORKDIR /workspace

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -67,7 +67,7 @@ cd global-capacity-orchestrator-on-aws
 docker build -f Dockerfile.dev -t gco-dev .
 ```
 
-The image bundles Python 3.14, Node.js 24, CDK, kubectl, AWS CLI, and all GCO Python dependencies at the exact versions CI uses. The Dockerfile is multi-arch — it builds natively on both `linux/amd64` (Intel/x86_64 hosts and CI) and `linux/arm64` (Apple Silicon Macs, Graviton Linux, etc.) by selecting the right kubectl / AWS CLI / Docker CLI binary via `$TARGETARCH`. No `--platform` flag needed.
+The image bundles Python 3.14, Node.js 24, CDK, kubectl, AWS CLI, Docker CLI + Buildx, and all GCO Python dependencies at the exact versions CI uses. The Dockerfile is multi-arch — it builds natively on both `linux/amd64` (Intel/x86_64 hosts and CI) and `linux/arm64` (Apple Silicon Macs, Graviton Linux, etc.) by selecting the right kubectl / AWS CLI / Docker CLI / Buildx binary via `$TARGETARCH`. No `--platform` flag needed. Buildx ships in the image so the multi-arch image mirror and the `linux/amd64` asset builds that `gco stacks deploy-all` runs succeed on Apple Silicon (arm64) as well as x86_64.
 
 ## Step 2: Run the GCO CLI
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ gco stacks deploy-all -y      # stand up every region defined in cdk.json
 gco stacks destroy-all -y     # destroy every stack across every region — no orphaned resources
 ```
 
-**Recommended: run everything from the dev container.** GCO pins exact versions of a lot of Python packages (CDK, AWS SDKs, FastAPI, mypy, Ruff, etc.), and installing them on top of an existing Python environment is the most common source of "it doesn't install" reports. The dev container ships a fully resolved environment (Python 3.14, Node.js 24, CDK, kubectl, AWS CLI, all Python deps) so you skip the whole problem.
+**Recommended: run everything from the dev container.** GCO pins exact versions of a lot of Python packages (CDK, AWS SDKs, FastAPI, mypy, Ruff, etc.), and installing them on top of an existing Python environment is the most common source of "it doesn't install" reports. The dev container ships a fully resolved environment (Python 3.14, Node.js 24, CDK, kubectl, AWS CLI, Docker CLI + Buildx, all Python deps) so you skip the whole problem. Buildx is included so the multi-arch image mirror and `linux/amd64` asset builds that `gco stacks deploy-all` performs work out of the box on Apple Silicon (arm64).
 
 ```bash
 git clone git@github.com:awslabs/global-capacity-orchestrator-on-aws.git
@@ -452,7 +452,7 @@ Goal-directed iteration loop for orchestrated workflows. The operator declares a
 **Recommended path — dev container only:**
 
 - AWS CLI configured with appropriate credentials (or `~/.aws` to mount in)
-- Docker (or Finch / Colima) — that's it. The container ships Python 3.14, Node.js 24, CDK, kubectl, and AWS CLI at pinned versions.
+- Docker (or Finch / Colima) — that's it. The container ships Python 3.14, Node.js 24, CDK, kubectl, AWS CLI, and Docker CLI + Buildx at pinned versions.
 
 ```bash
 docker build -f Dockerfile.dev -t gco-dev .

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -9,6 +9,7 @@ Common issues and their solutions.
   - [`gco: command not found`](#gco-command-not-found)
 - [Deployment Issues](#deployment-issues)
   - [Stack Creation Fails](#stack-creation-fails)
+  - [Deploy Fails on Image Mirror or linux/amd64 Asset Build (Apple Silicon)](#deploy-fails-on-image-mirror-or-linuxamd64-asset-build-apple-silicon)
   - [Stack Stuck in DELETE_FAILED](#stack-stuck-in-delete_failed)
   - [Lambda Custom Resource Timeout](#lambda-custom-resource-timeout)
 - [kubectl Access Issues](#kubectl-access-issues)
@@ -170,6 +171,24 @@ aws cloudformation describe-stack-resources \
 gco stacks destroy-all -y
 gco stacks deploy-all -y
 ```
+
+### Deploy Fails on Image Mirror or `linux/amd64` Asset Build (Apple Silicon)
+
+**Symptom**: `gco stacks deploy-all` aborts with one of:
+
+- `No multi-arch image-copy method available. Need one of: 'docker buildx' ... 'docker pull --all-platforms' ... or skopeo on PATH.`
+- `failed to ... build ... --platform linux/amd64 ... image ... does not provide the specified platform (linux/amd64)`
+
+**Cause**: The deploy needs a multi-arch image-copy tool for two steps — the Volcano ECR image mirror (`docker buildx imagetools create`) and the cross-architecture build of the `linux/amd64` Lambda/service asset images. On an arm64 host (Apple Silicon) the legacy Docker builder cannot satisfy either. This happens when the deploy runs from an environment without Docker Buildx (Finch/nerdctl or skopeo also work).
+
+**Solution**: Run the deploy from the [dev container](../QUICKSTART.md#step-1-clone-and-build-the-dev-container), which ships Docker Buildx for exactly this. If you built the image before Buildx was added, rebuild it:
+
+```bash
+docker build -f Dockerfile.dev -t gco-dev .
+docker run --rm gco-dev docker buildx version   # confirm Buildx is present
+```
+
+If you deploy from your host instead, ensure one of `docker buildx`, Finch (`docker pull --all-platforms`), or `skopeo` is on `PATH`.
 
 ### Stack Stuck in REVIEW_IN_PROGRESS
 

--- a/tests/BATS/test_dependency_scan.bats
+++ b/tests/BATS/test_dependency_scan.bats
@@ -360,16 +360,17 @@ for m in re.finditer(r\"addon_name=\\\"([^\\\"]+)\\\".*?addon_version=\\\"([^\\\
 
 # ── extract_dockerfile_pins ──────────────────────────────────────────────────
 
-@test "extract_dockerfile_pins: finds all six pins in Dockerfile.dev" {
+@test "extract_dockerfile_pins: finds all seven pins in Dockerfile.dev" {
     run extract_dockerfile_pins "Dockerfile.dev"
     [ "$status" -eq 0 ]
-    # All six allowlisted pins should be present.
+    # All seven allowlisted pins should be present.
     [[ "$output" == *"NODE_MAJOR|"* ]]
     [[ "$output" == *"NPM_VERSION|"* ]]
     [[ "$output" == *"CDK_VERSION|"* ]]
     [[ "$output" == *"KUBECTL_VERSION|"* ]]
     [[ "$output" == *"AWSCLI_VERSION|"* ]]
     [[ "$output" == *"DOCKER_VERSION|"* ]]
+    [[ "$output" == *"BUILDX_VERSION|"* ]]
 }
 
 @test "extract_dockerfile_pins: emits pipe-delimited NAME|VALUE pairs" {
@@ -401,6 +402,17 @@ for m in re.finditer(r\"addon_name=\\\"([^\\\"]+)\\\".*?addon_version=\\\"([^\\\
     [ "$status" -eq 0 ]
     k_line="$(echo "$output" | grep '^KUBECTL_VERSION|')"
     value="${k_line#KUBECTL_VERSION|}"
+    [[ "$value" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+
+@test "extract_dockerfile_pins: BUILDX_VERSION keeps the v prefix" {
+    # Docker Buildx is pinned with the leading v (the GitHub release tag
+    # and the buildx-<tag>.linux-<arch> asset name both use it), so the
+    # deps-scan release-tag compare lines up. Assert it is preserved.
+    run extract_dockerfile_pins "Dockerfile.dev"
+    [ "$status" -eq 0 ]
+    b_line="$(echo "$output" | grep '^BUILDX_VERSION|')"
+    value="${b_line#BUILDX_VERSION|}"
     [[ "$value" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
 }
 


### PR DESCRIPTION
Thank you @mvinci12 for your great contribution https://github.com/awslabs/global-capacity-orchestrator-on-aws/pull/96

I built on top of your existing PR so that the new pin for the buildx version was integrated into the dependency scan and so the existing integration tests for the dev Dockerfile exercise buildx so we can guard against this sort of regression in the future.

<!--
Thanks for contributing to Global Capacity Orchestrator (GCO)! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [ ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
