### PR TITLE
feat(dev-setup-alias-autobuild): make it so dev setup script autobuilds dockerfile.dev image and minor documentation updates.

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -15,7 +15,7 @@ Helper scripts invoked by GitHub Actions workflows. Separated from the workflows
 | `dependency-scan.sh` | `deps-scan.yml` (monthly) | Checks for outdated Python packages, Docker images, Helm charts, and EKS add-on versions. Writes a Markdown report and sets `has_drift=true` on `$GITHUB_OUTPUT` if any are outdated. |
 | `lib_dependency_scan.sh` | `dependency-scan.sh` | Sourceable helper functions — image registry parsing (`parse_image_registry`), semver comparison (`compare_semver`), tag filtering (`is_semver_tag`, `is_project_image`). Extracted so BATS tests can exercise the logic without running the full scan. |
 | `check_pip_audit_ignore.py` | `security.yml` (`security:pip-audit:deps`) | Validates the project-local `.pip-audit-ignore` suppression file. Fails the workflow when any entry's `exp:YYYY-MM-DD` marker is on-or-before today (inclusive) or when an entry is missing the marker entirely. Importable as a module (`check_file()`, `main()`) so it can be exercised by pytest fixtures rather than only ever run end-to-end through CI. |
-| `dev_alias_live.sh` | `integration-tests.yml` (`integration:dev-alias:{docker,finch,podman,none}`) | Live proof that `scripts/setup-dev-alias.sh` generates a working `gco` shell function. Builds the real `gco-dev` image from `Dockerfile.dev` ("setup GCO"), installs the generated function into a throwaway rc, sources it in a fresh shell, and proves through it: `gco --version` (the real CLI runs) and `gco dag validate ci-dag.yaml` (an offline command that reads a relative-path file from the mounted workspace, proving arg-forwarding, the `$PWD` -> `/workspace` bind mount, and `cwd=/workspace`). `--skip-build` reuses an existing image; `--no-runtime` proves the script refuses cleanly (non-zero exit, no rc block) when no runtime answers. |
+| `dev_alias_live.sh` | `integration-tests.yml` (`integration:dev-alias:{docker,finch,podman,none}`) | Live proof that `scripts/setup-dev-alias.sh` builds the image and generates a working `gco` shell function. Drives `setup-dev-alias.sh` to build the real `gco-dev` image from `Dockerfile.dev` and install the generated function into a throwaway rc, sources it in a fresh shell, and proves through it: `gco --version` (the real CLI runs) and `gco dag validate ci-dag.yaml` (an offline command that reads a relative-path file from the mounted workspace, proving arg-forwarding, the `$PWD` -> `/workspace` bind mount, and `cwd=/workspace`). `--skip-build` reuses an existing image (and tells `setup-dev-alias.sh` to skip its build); `--no-runtime` proves the script refuses cleanly (non-zero exit, no rc block) when no runtime answers. |
 
 ## Testing
 
@@ -34,9 +34,10 @@ pytest tests/test_pip_audit_ignore_validator.py -v
 ```
 
 `dev_alias_live.sh` is itself a live test — it exercises the onboarding alias
-end to end against a real runtime. It builds the real `gco-dev` image, so each
-run takes a few minutes; pass `--skip-build` to reuse an image you already
-built. Run it locally against whichever runtime you have installed:
+end to end against a real runtime. It runs `setup-dev-alias.sh`, which builds
+the real `gco-dev` image, so each run takes a few minutes; pass `--skip-build`
+to reuse an image you already built. Run it locally against whichever runtime
+you have installed:
 
 ```bash
 # From the repository root.

--- a/.github/scripts/dev_alias_live.sh
+++ b/.github/scripts/dev_alias_live.sh
@@ -120,9 +120,12 @@ fi
 # ---------------------------------------------------------------------------
 # Generate the gco function into a throwaway rc.
 # ---------------------------------------------------------------------------
-note "generate the gco function (setup-dev-alias.sh --runtime $RUNTIME --image $IMAGE)"
+# setup-dev-alias.sh now builds the image itself by default. This harness has
+# already built $IMAGE above (or verified it under --skip-build), so pass
+# --no-build here to avoid a redundant rebuild and keep --skip-build honest.
+note "generate the gco function (setup-dev-alias.sh --runtime $RUNTIME --image $IMAGE --no-build)"
 rc="$WORK/rc"
-"$SETUP" --runtime "$RUNTIME" --image "$IMAGE" --rc "$rc" >/dev/null
+"$SETUP" --runtime "$RUNTIME" --image "$IMAGE" --no-build --rc "$rc" >/dev/null
 grep -q '>>> gco >>>' "$rc" || die "setup script did not write a gco function block"
 
 # ---------------------------------------------------------------------------

--- a/.github/scripts/dev_alias_live.sh
+++ b/.github/scripts/dev_alias_live.sh
@@ -5,9 +5,10 @@
 # gco-dev image.
 #
 # tests/BATS/test_setup_dev_alias.bats mocks the runtimes and only inspects the
-# emitted text. This script closes that gap end to end: it builds the real
-# gco-dev image ("setup GCO"), installs the generated function into a throwaway
-# rc, sources it in a fresh shell, and proves through that function:
+# emitted text. This script closes that gap end to end: it runs
+# scripts/setup-dev-alias.sh to build the real gco-dev image and install the
+# generated function into a throwaway rc, sources it in a fresh shell, and
+# proves through that function:
 #   * `gco --version`                — the real CLI runs (and the arg reaches it)
 #   * `gco dag validate <rel>/ci-dag.yaml` — an offline command that reads files
 #                                      from the mounted workspace via a
@@ -31,7 +32,6 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SETUP="$REPO_ROOT/scripts/setup-dev-alias.sh"
-DOCKERFILE="$REPO_ROOT/Dockerfile.dev"
 
 RUNTIME=""
 MODE="runtime"
@@ -105,27 +105,24 @@ command -v "$RUNTIME" >/dev/null 2>&1 || die "$RUNTIME is not on PATH"
 "$RUNTIME" --version || true
 
 # ---------------------------------------------------------------------------
-# Setup GCO: build (or reuse) the real dev image.
+# Setup GCO: setup-dev-alias.sh builds the dev image and installs the function.
 # ---------------------------------------------------------------------------
+# Building the image is the setup script's own job, so the normal path lets it
+# do exactly that: this is the end-to-end proof that `setup-dev-alias.sh` builds
+# gco-dev *and* wires up the alias in a single run. --skip-build instead reuses
+# an already-built image and tells the script to skip its build.
+rc="$WORK/rc"
 if [ "$SKIP_BUILD" -eq 1 ]; then
-    note "using existing image: $IMAGE (--skip-build)"
+    note "using existing image: $IMAGE (--skip-build); setup-dev-alias.sh --no-build"
     "$RUNTIME" image inspect "$IMAGE" >/dev/null 2>&1 \
         || die "--skip-build set but image '$IMAGE' was not found in $RUNTIME"
+    "$SETUP" --runtime "$RUNTIME" --image "$IMAGE" --no-build --rc "$rc" >/dev/null \
+        || die "setup-dev-alias.sh failed to install the gco function for $RUNTIME"
 else
-    note "setup GCO: build $IMAGE from Dockerfile.dev with $RUNTIME"
-    "$RUNTIME" build -f "$DOCKERFILE" -t "$IMAGE" "$REPO_ROOT" \
-        || die "$RUNTIME failed to build $IMAGE from Dockerfile.dev"
+    note "setup GCO: setup-dev-alias.sh builds $IMAGE from Dockerfile.dev with $RUNTIME and installs the function"
+    "$SETUP" --runtime "$RUNTIME" --image "$IMAGE" --rc "$rc" \
+        || die "setup-dev-alias.sh failed to build $IMAGE / install the gco function for $RUNTIME"
 fi
-
-# ---------------------------------------------------------------------------
-# Generate the gco function into a throwaway rc.
-# ---------------------------------------------------------------------------
-# setup-dev-alias.sh now builds the image itself by default. This harness has
-# already built $IMAGE above (or verified it under --skip-build), so pass
-# --no-build here to avoid a redundant rebuild and keep --skip-build honest.
-note "generate the gco function (setup-dev-alias.sh --runtime $RUNTIME --image $IMAGE --no-build)"
-rc="$WORK/rc"
-"$SETUP" --runtime "$RUNTIME" --image "$IMAGE" --no-build --rc "$rc" >/dev/null
 grep -q '>>> gco >>>' "$rc" || die "setup script did not write a gco function block"
 
 # ---------------------------------------------------------------------------

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -876,10 +876,10 @@ jobs:
 
   # --------------------------------------------------------------------------
   # Dev-onboarding alias live proofs. Each job installs the latest version of a
-  # container runtime, builds the gco-dev image ("setup GCO"), then proves the
-  # `gco` shell function emitted by scripts/setup-dev-alias.sh actually launches
-  # the runtime and runs the real CLI — closing the gap left by the mocked
-  # tests/BATS/test_setup_dev_alias.bats suite. Logic lives in
+  # container runtime, then runs scripts/setup-dev-alias.sh end to end — proving
+  # it builds the gco-dev image AND that the `gco` shell function it emits
+  # actually launches the runtime and runs the real CLI — closing the gap left
+  # by the mocked tests/BATS/test_setup_dev_alias.bats suite. Logic lives in
   # .github/scripts/dev_alias_live.sh so it can be run locally too.
   # --------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -60,13 +60,37 @@ gco stacks deploy-all -y      # stand up every region defined in cdk.json
 gco stacks destroy-all -y     # destroy every stack across every region — no orphaned resources
 ```
 
-**Recommended: run everything from the dev container.** GCO pins exact versions of a lot of Python packages (CDK, AWS SDKs, FastAPI, mypy, Ruff, etc.), and installing them on top of an existing Python environment is the most common source of "it doesn't install" reports. The dev container ships a fully resolved environment (Python 3.14, Node.js 24, CDK, kubectl, AWS CLI, Docker CLI + Buildx, all Python deps) so you skip the whole problem. Buildx is included so the multi-arch image mirror and `linux/amd64` asset builds that `gco stacks deploy-all` performs work out of the box on Apple Silicon (arm64).
+**Recommended: run everything from the dev container.** GCO pins exact versions of a lot of Python packages (CDK, AWS SDKs, FastAPI, mypy, Ruff, etc.), and installing them on top of an existing Python environment is the most common source of "it doesn't install" reports. The dev container ships a fully resolved environment (Python 3.14, Node.js 24, CDK, kubectl, AWS CLI, Docker CLI + Buildx, all Python deps) so you skip the whole problem.
+
+**Build the image once, then let the setup script wire up a `gco` command for you.** You shouldn't hand-write `docker run …` invocations or live inside an interactive container shell — `scripts/setup-dev-alias.sh` does the wiring so `gco` runs straight from your normal shell:
 
 ```bash
 git clone git@github.com:awslabs/global-capacity-orchestrator-on-aws.git
 cd global-capacity-orchestrator-on-aws
 
-docker build -f Dockerfile.dev -t gco-dev .
+docker build -f Dockerfile.dev -t gco-dev .   # one-time image build
+./scripts/setup-dev-alias.sh                  # install the `gco` shell function
+source ~/.zshrc                               # or ~/.bashrc — the script prints which file it updated
+```
+
+`setup-dev-alias.sh` detects your container runtime (Docker, Finch, or Podman), wires up the correct socket pass-through for it, and installs an idempotent `gco` shell *function* (not a bare alias, so arguments and pipes forward correctly and a TTY is attached only when one is present) into your profile. From then on, run GCO straight from your repo checkout — each command executes inside the dev container against your current directory:
+
+```bash
+gco --help                # explore every command
+gco stacks deploy-all -y  # stand up every region defined in cdk.json
+gco stacks destroy-all -y # tear it all down
+```
+
+Re-run the script whenever you switch runtimes, or use `--print` to preview the function, `--runtime <name>` to force one, and `--rc <path>` to target a specific profile.
+
+The function shares your host Docker socket with every `gco` call, and `gco stacks deploy-all` uses it for much more than bundling Lambda assets: through your host Docker daemon it builds and bundles the Lambda function assets (as `linux/amd64`, cross-built via Buildx so this works on Apple Silicon / arm64) and — when the Volcano image mirror is enabled in `cdk.json` — mirrors third-party images such as the Volcano scheduler from Docker Hub into your ECR before the Helm install runs. The same socket also backs `gco images build` / `push`. See [Prerequisites](#prerequisites) for Colima/Finch socket paths and the security note about host-socket pass-through. *Finch users:* Finch runs in its own VM with no host Docker socket to share, so the function omits the socket mount — everyday commands work as-is, while build-heavy ones like `deploy-all` run on the host with Finch as the CDK builder.
+
+<details>
+<summary>Prefer an interactive container shell instead?</summary>
+
+You can also drop straight into the dev container and run `gco` from inside it — handy for ad-hoc tools and exploration. The `-v /var/run/docker.sock:/var/run/docker.sock` mount gives the container's Docker CLI access to your host daemon for the asset builds, image mirroring, and bundling described above:
+
+```bash
 docker run -it --rm \
   -v ~/.aws:/root/.aws:ro \
   -v $(pwd):/workspace \
@@ -75,24 +99,7 @@ docker run -it --rm \
   gco-dev
 ```
 
-The `docker.sock` mount lets `gco stacks deploy-all` bundle Lambda assets through your host Docker daemon. See [Prerequisites](#prerequisites) for Colima/Finch socket paths and the security note about host-socket pass-through.
-
-**Run `gco` straight from your shell — no interactive session needed.** Prefer not to drop into the container every time? After building the image once, run the setup script. It detects your container runtime (Docker, Finch, or Podman), wires up the right socket pass-through for it, and installs an idempotent `gco` shell function into your profile (`~/.zshrc` or `~/.bashrc`):
-
-```bash
-./scripts/setup-dev-alias.sh
-source ~/.zshrc   # or ~/.bashrc — the script prints which file it updated
-```
-
-Now run GCO from your repo checkout exactly as the docs show it — each command runs inside the dev container against your current directory:
-
-```bash
-gco --help                # explore every command
-gco stacks deploy-all -y  # stand up every region defined in cdk.json
-gco stacks destroy-all -y # tear it all down
-```
-
-The script installs a shell *function* (not a bare alias) so arguments and pipes forward correctly and a TTY is attached only when one is present. Re-run it whenever you switch runtimes, or use `--print` to preview the function, `--runtime <name>` to force one, and `--rc <path>` to target a specific profile. *Finch users:* Finch runs in its own VM with no host Docker socket to share, so the function omits the socket mount — everyday commands work as-is, while build-heavy ones like `deploy-all` run on the host with Finch as the builder (see the dev-container note above).
+</details>
 
 <details>
 <summary>Prefer to install on your host? (advanced — the dev container is recommended)</summary>
@@ -157,25 +164,21 @@ Running GPU workloads at scale is hard. You need to find regions with available 
 
 The fastest, most reliable path is the dev container — it sidesteps the dependency-conflict issues that come with installing GCO's pinned Python packages on top of your existing Python environment.
 
-Build the dev container (Python, Node.js, CDK, kubectl, and the AWS CLI are all pinned and pre-installed), then drop into a shell with the `gco` CLI already on the path:
+Build the image once (Python, Node.js, CDK, kubectl, and the AWS CLI are all pinned and pre-installed), then run the setup script so `gco` works straight from your shell — no need to hand-write `docker run …` or stay inside an interactive container:
 
 ```bash
-docker build -f Dockerfile.dev -t gco-dev .
-docker run -it --rm \
-  -v ~/.aws:/root/.aws:ro \
-  -v $(pwd):/workspace \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  -w /workspace \
-  gco-dev
+docker build -f Dockerfile.dev -t gco-dev .   # one-time image build
+./scripts/setup-dev-alias.sh                  # install the `gco` shell function
+source ~/.zshrc                               # or ~/.bashrc — the script prints which file it updated
 ```
 
-From inside the container, deploy everything — CDK bootstrap runs automatically for every region defined in `cdk.json`:
+Then deploy everything — CDK bootstrap runs automatically for every region defined in `cdk.json`:
 
 ```bash
 gco stacks deploy-all -y
 ```
 
-If you'd rather install on your host, use a clean virtual environment or pipx — see the [Prerequisites](#prerequisites) and [QUICKSTART.md](QUICKSTART.md) for the details and known caveats.
+Prefer an interactive container shell, or want to install on your host instead? See the [Prerequisites](#prerequisites) and [QUICKSTART.md](QUICKSTART.md) for those options and known caveats.
 
 > **Heads up — Helm charts finish installing in the background.** When `deploy-all` reports the cluster `CREATE_COMPLETE`, the scheduler/operator Helm charts (KEDA, Volcano, KubeRay, cert-manager, Kueue, …) have only been *kicked off*; they converge asynchronously and can take **10–30+ minutes** to all become ready. This is intentional — a slow chart never rolls back the cluster. Track progress with `gco stacks addons status -r <region>` and re-converge any failures with `gco stacks addons install -r <region>`. See [docs/CUSTOMIZATION.md](docs/CUSTOMIZATION.md#helm-chart-configuration).
 
@@ -476,7 +479,7 @@ docker build -f Dockerfile.dev -t gco-dev .
 docker run -it --rm -v ~/.aws:/root/.aws:ro -v $(pwd):/workspace -w /workspace gco-dev
 ```
 
-For `gco stacks deploy-all`, `cdk deploy` needs to run Docker to bundle Lambda assets. Mount the host Docker socket so the container's CLI talks to your host daemon (works with Docker Desktop on macOS/Windows, with Docker on Linux, and with Colima on macOS — see `Dockerfile.dev` for Colima-specific socket paths):
+For `gco stacks deploy-all`, the CLI and `cdk deploy` drive Docker for several steps — building and bundling the Lambda function assets (as `linux/amd64`, via Buildx on Apple Silicon), and, when the Volcano image mirror is enabled, mirroring third-party images from Docker Hub into ECR before the Helm install. `setup-dev-alias.sh` already wires the host Docker socket into the `gco` function; if you instead run the container by hand, mount the socket so the container's CLI talks to your host daemon (works with Docker Desktop on macOS/Windows, with Docker on Linux, and with Colima on macOS — see `Dockerfile.dev` for Colima-specific socket paths):
 
 ```bash
 docker run --rm -it \
@@ -513,7 +516,7 @@ This is host-socket pass-through, not true Docker-in-Docker. Anyone with access 
 │   ├── config/                          # Configuration loader with validation
 │   ├── models/                          # Data models for k8s clusters, health monitor, inference monitor and manifest processor
 │   ├── services/                        # K8s services (health monitor, inference monitor, manifest processor, queue processor)
-│   └── stacks/                          # CDK stacks (global, regional, API gateway, monitoring)
+│   └── stacks/                          # CDK stacks (global, API gateway, regional, regional API gateway, monitoring, analytics)
 │       └── constants.py                 # Pinned versions: EKS addons, Lambda runtime, Aurora engine
 │
 ├── lambda/                              # Lambda functions

--- a/README.md
+++ b/README.md
@@ -62,18 +62,17 @@ gco stacks destroy-all -y     # destroy every stack across every region — no o
 
 **Recommended: run everything from the dev container.** GCO pins exact versions of a lot of Python packages (CDK, AWS SDKs, FastAPI, mypy, Ruff, etc.), and installing them on top of an existing Python environment is the most common source of "it doesn't install" reports. The dev container ships a fully resolved environment (Python 3.14, Node.js 24, CDK, kubectl, AWS CLI, Docker CLI + Buildx, all Python deps) so you skip the whole problem.
 
-**Build the image once, then let the setup script wire up a `gco` command for you.** You shouldn't hand-write `docker run …` invocations or live inside an interactive container shell — `scripts/setup-dev-alias.sh` does the wiring so `gco` runs straight from your normal shell:
+**Let the setup script do it all — build the image and wire up a `gco` command for you.** You shouldn't hand-write `docker run …` invocations or live inside an interactive container shell — `scripts/setup-dev-alias.sh` builds the `gco-dev` image and installs the wiring, so `gco` runs straight from your normal shell:
 
 ```bash
 git clone git@github.com:awslabs/global-capacity-orchestrator-on-aws.git
 cd global-capacity-orchestrator-on-aws
 
-docker build -f Dockerfile.dev -t gco-dev .   # one-time image build
-./scripts/setup-dev-alias.sh                  # install the `gco` shell function
-source ~/.zshrc                               # or ~/.bashrc — the script prints which file it updated
+./scripts/setup-dev-alias.sh   # builds gco-dev from Dockerfile.dev + installs the `gco` shell function
+source ~/.zshrc                # or ~/.bashrc — the script prints which file it updated
 ```
 
-`setup-dev-alias.sh` detects your container runtime (Docker, Finch, or Podman), wires up the correct socket pass-through for it, and installs an idempotent `gco` shell *function* (not a bare alias, so arguments and pipes forward correctly and a TTY is attached only when one is present) into your profile. From then on, run GCO straight from your repo checkout — each command executes inside the dev container against your current directory:
+`setup-dev-alias.sh` detects your container runtime (Docker, Finch, or Podman), builds the `gco-dev` image from `Dockerfile.dev` (re-running rebuilds it, so a stale image is refreshed automatically — pass `--no-build` to skip), wires up the correct socket pass-through, and installs an idempotent `gco` shell *function* (not a bare alias, so arguments and pipes forward correctly and a TTY is attached only when one is present) into your profile. From then on, run GCO straight from your repo checkout — each command executes inside the dev container against your current directory:
 
 ```bash
 gco --help                # explore every command
@@ -88,9 +87,10 @@ The function shares your host Docker socket with every `gco` call, and `gco stac
 <details>
 <summary>Prefer an interactive container shell instead?</summary>
 
-You can also drop straight into the dev container and run `gco` from inside it — handy for ad-hoc tools and exploration. The `-v /var/run/docker.sock:/var/run/docker.sock` mount gives the container's Docker CLI access to your host daemon for the asset builds, image mirroring, and bundling described above:
+You can also build the image yourself and drop straight into the dev container, running `gco` from inside it — handy for ad-hoc tools and exploration. The `-v /var/run/docker.sock:/var/run/docker.sock` mount gives the container's Docker CLI access to your host daemon for the asset builds, image mirroring, and bundling described above:
 
 ```bash
+docker build -f Dockerfile.dev -t gco-dev .
 docker run -it --rm \
   -v ~/.aws:/root/.aws:ro \
   -v $(pwd):/workspace \
@@ -164,12 +164,11 @@ Running GPU workloads at scale is hard. You need to find regions with available 
 
 The fastest, most reliable path is the dev container — it sidesteps the dependency-conflict issues that come with installing GCO's pinned Python packages on top of your existing Python environment.
 
-Build the image once (Python, Node.js, CDK, kubectl, and the AWS CLI are all pinned and pre-installed), then run the setup script so `gco` works straight from your shell — no need to hand-write `docker run …` or stay inside an interactive container:
+Run the setup script — it builds the `gco-dev` image (Python, Node.js, CDK, kubectl, and the AWS CLI all pinned and pre-installed) and wires up `gco` so it works straight from your shell, with no hand-written `docker run …` and no interactive container:
 
 ```bash
-docker build -f Dockerfile.dev -t gco-dev .   # one-time image build
-./scripts/setup-dev-alias.sh                  # install the `gco` shell function
-source ~/.zshrc                               # or ~/.bashrc — the script prints which file it updated
+./scripts/setup-dev-alias.sh   # builds gco-dev from Dockerfile.dev + installs the `gco` shell function
+source ~/.zshrc                # or ~/.bashrc — the script prints which file it updated
 ```
 
 Then deploy everything — CDK bootstrap runs automatically for every region defined in `cdk.json`:

--- a/app.py
+++ b/app.py
@@ -43,9 +43,12 @@ from gco.stacks.regional_stack import GCORegionalStack
 # <pyflowchart-code-diagram> END
 
 
-# AWS Solutions guidance identifier. Every GCO CloudFormation stack description
-# is prefixed with this string so a deployment is attributable to the published
-# guidance (SO9707); each stack's own specific description follows the prefix.
+# AWS Solutions guidance identifier. Only the GCO *global* stack description is
+# prefixed with this string, so a single deployment is attributable to the
+# published guidance (SO9707) through one stack. The guidance crawler counts
+# every stack whose description carries the (SO9707) marker, so prefixing all
+# stacks would over-count one deployment as many. Every other stack keeps just
+# its own specific description (no prefix).
 SOLUTION_ID = "SO9707"
 SOLUTION_DESCRIPTION_PREFIX = (
     f"({SOLUTION_ID}) - Guidance for Automated Deployment of EKS AutoMode Clusters "
@@ -114,7 +117,9 @@ def main() -> None:
         cdk.Tags.of(app).add(key, value)
 
     # Create global stack (Global Accelerator)
-    # Note: Global Accelerator is a global service but needs a "home" region for CloudFormation
+    # Note: Global Accelerator is a global service but needs a "home" region for CloudFormation.
+    # This is the ONLY stack whose description carries the (SO9707) guidance prefix, so the
+    # deployment stays attributable to the published guidance without over-counting (see SOLUTION_ID).
     global_stack = GCOGlobalStack(
         app,
         f"{project_name}-global",
@@ -129,7 +134,7 @@ def main() -> None:
         f"{project_name}-api-gateway",
         global_accelerator_dns=global_stack.accelerator.dns_name,
         env=cdk.Environment(region=api_gateway_region),
-        description=f"{SOLUTION_DESCRIPTION_PREFIX} - Global API Gateway with IAM authentication",
+        description="Global API Gateway with IAM authentication",
     )
     api_gateway_stack.add_dependency(global_stack)
 
@@ -143,7 +148,7 @@ def main() -> None:
             region=region,
             auth_secret_arn=api_gateway_stack.secret.secret_arn,
             env=cdk.Environment(region=region),
-            description=f"{SOLUTION_DESCRIPTION_PREFIX} - Regional resources for {region} - EKS cluster, ALB, and services",
+            description=f"Regional resources for {region} - EKS cluster, ALB, and services",
         )
 
         # Add dependencies
@@ -165,7 +170,7 @@ def main() -> None:
         regional_stacks=regional_stacks,
         api_gateway_stack=api_gateway_stack,
         env=cdk.Environment(region=monitoring_region),
-        description=f"{SOLUTION_DESCRIPTION_PREFIX} - Cross-region monitoring and observability for GCO (Global Capacity Orchestrator on AWS)",
+        description="Cross-region monitoring and observability for GCO (Global Capacity Orchestrator on AWS)",
     )
 
     # Add dependencies on all regional stacks
@@ -191,7 +196,7 @@ def main() -> None:
             f"{project_name}-analytics",
             config=config,
             env=cdk.Environment(region=api_gateway_region),
-            description=f"{SOLUTION_DESCRIPTION_PREFIX} - Optional ML and analytics environment (SageMaker Studio, EMR Serverless, Cognito)",
+            description="Optional ML and analytics environment (SageMaker Studio, EMR Serverless, Cognito)",
         )
         analytics_stack.add_dependency(global_stack)
 

--- a/app.py
+++ b/app.py
@@ -45,10 +45,7 @@ from gco.stacks.regional_stack import GCORegionalStack
 
 # AWS Solutions guidance identifier. Only the GCO *global* stack description is
 # prefixed with this string, so a single deployment is attributable to the
-# published guidance (SO9707) through one stack. The guidance crawler counts
-# every stack whose description carries the (SO9707) marker, so prefixing all
-# stacks would over-count one deployment as many. Every other stack keeps just
-# its own specific description (no prefix).
+# published guidance (SO9707) through one stack.
 SOLUTION_ID = "SO9707"
 SOLUTION_DESCRIPTION_PREFIX = (
     f"({SOLUTION_ID}) - Guidance for Automated Deployment of EKS AutoMode Clusters "
@@ -117,9 +114,7 @@ def main() -> None:
         cdk.Tags.of(app).add(key, value)
 
     # Create global stack (Global Accelerator)
-    # Note: Global Accelerator is a global service but needs a "home" region for CloudFormation.
-    # This is the ONLY stack whose description carries the (SO9707) guidance prefix, so the
-    # deployment stays attributable to the published guidance without over-counting (see SOLUTION_ID).
+    # Note: Global Accelerator is a global service but needs a "home" region for CloudFormation
     global_stack = GCOGlobalStack(
         app,
         f"{project_name}-global",

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -217,7 +217,7 @@ jmespath==1.1.0
     # via
     #   boto3
     #   botocore
-joserfc==1.6.4
+joserfc==1.6.7
     # via
     #   authlib
     #   fastmcp-slim

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,7 +20,7 @@ Utility scripts for development, testing, and operations.
 | Script | Description |
 |--------|-------------|
 | `setup-cluster-access.sh` | Configures kubectl access to a GCO EKS cluster. Adds your IAM principal to the cluster's access entries and verifies connectivity. |
-| `setup-dev-alias.sh` | Installs a `gco` shell function (between `# >>> gco >>>` markers) into your shell rc file so the CLI runs inside the dev container against your current directory. Auto-detects the container runtime (Docker/Finch/Podman), picks the matching socket mount, and is safe to re-run. |
+| `setup-dev-alias.sh` | Builds (or refreshes) the `gco-dev` image from `Dockerfile.dev`, then installs a `gco` shell function (between `# >>> gco >>>` markers) into your shell rc file so the CLI runs inside the dev container against your current directory. Auto-detects the container runtime (Docker/Finch/Podman), picks the matching socket mount, and is safe to re-run (`--no-build` skips the rebuild). |
 | `bump_version.py` | Bumps the project version across all locations (pyproject.toml, CLI, docs). Supports major, minor, and patch increments. |
 | `dump_nag_findings.py` | Dev-only debugging helper: runs the `tests/test_nag_compliance.py` harness and prints every cdk-nag finding grouped by rule + resource path + config. Use this when the compliance test gate fails in CI and you want a compact per-finding view instead of pytest's `AssertionError` repr. |
 | `test_webhook_delivery.py` | Tests the webhook dispatcher by sending sample events and verifying delivery, HMAC signatures, and retry behavior. |
@@ -45,15 +45,18 @@ Requires `PUBLIC_AND_PRIVATE` endpoint access mode in `cdk.json`. See [Customiza
 ### Setup Dev Alias
 
 ```bash
-# Detect your container runtime and install the `gco` shell function
+# Build the gco-dev image and install the `gco` shell function
 ./scripts/setup-dev-alias.sh
 source ~/.zshrc   # or ~/.bashrc — the script prints which file it updated
 
-# Preview the generated function without writing anything
+# Preview the generated function without building or writing anything
 ./scripts/setup-dev-alias.sh --print
+
+# Reuse an existing image (skip the Dockerfile.dev build)
+./scripts/setup-dev-alias.sh --no-build
 ```
 
-Makes `gco` run inside the dev container against your current directory — no interactive session needed. Auto-detects Docker, Finch, or Podman (override with `--runtime`) and writes an idempotent block to your shell profile (`--rc` to target a specific file). This is the onboarding path recommended in the [main README](../README.md).
+Builds (or refreshes) the `gco-dev` image from `Dockerfile.dev`, then makes `gco` run inside the dev container against your current directory — no interactive session needed, and no separate build step. Re-running rebuilds the image so a stale one is refreshed automatically (`--no-build` skips it). Auto-detects Docker, Finch, or Podman (override with `--runtime`) and writes an idempotent block to your shell profile (`--rc` to target a specific file). This is the onboarding path recommended in the [main README](../README.md).
 
 ### Bump Version
 

--- a/scripts/setup-dev-alias.sh
+++ b/scripts/setup-dev-alias.sh
@@ -10,6 +10,12 @@
 # not. The block is written between marker lines, so re-running this script
 # updates it in place instead of appending duplicates.
 #
+# By default it also builds (or refreshes) the dev image from Dockerfile.dev
+# with the detected runtime before installing the function, so a single run
+# takes a fresh clone all the way to a working `gco`. Re-running always rebuilds
+# (cached layers make that cheap), which transparently replaces a stale local
+# image. Pass --no-build to skip the build when you manage the image yourself.
+#
 set -euo pipefail
 
 MARKER_BEGIN="# >>> gco >>>"
@@ -18,6 +24,13 @@ IMAGE="gco-dev"
 FORCED_RUNTIME=""
 RC_FILE=""
 PRINT_ONLY=0
+NO_BUILD=0
+
+# The dev image is built from Dockerfile.dev at the repository root. Resolve it
+# from this script's own location so the build works from any working directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DOCKERFILE="$REPO_ROOT/Dockerfile.dev"
 
 log()  { printf '%s\n' "$*"; }
 warn() { printf 'warning: %s\n' "$*" >&2; }
@@ -29,14 +42,17 @@ setup-dev-alias.sh — install a `gco` shell function for the dev container.
 
 Usage: scripts/setup-dev-alias.sh [options]
 
-  -p, --print          Print the shell function to stdout and exit (no writes).
+  -p, --print          Print the shell function to stdout and exit (no build, no writes).
   -r, --runtime NAME   Force a runtime (docker|finch|podman) vs auto-detecting.
       --rc PATH        Target this rc file instead of the one inferred from $SHELL.
-      --image NAME     Dev image to run (default: gco-dev).
+      --image NAME     Dev image to build and run (default: gco-dev).
+      --no-build       Skip building the dev image; assume it already exists.
   -h, --help           Show this help and exit.
 
-Detection prefers docker, then finch, then podman (the first whose daemon
-answers `<rt> info`). GCO_CONTAINER_RUNTIME or CDK_DOCKER override detection.
+By default the script builds (or refreshes) the dev image from Dockerfile.dev
+with the detected runtime, then installs the `gco` function. Detection prefers
+docker, then finch, then podman (the first whose daemon answers `<rt> info`).
+GCO_CONTAINER_RUNTIME or CDK_DOCKER override detection.
 EOF
 }
 
@@ -49,6 +65,7 @@ while [ "$#" -gt 0 ]; do
         --rc=*) RC_FILE="${1#*=}"; shift ;;
         --image) [ "$#" -ge 2 ] || die "--image needs a value"; IMAGE="$2"; shift 2 ;;
         --image=*) IMAGE="${1#*=}"; shift ;;
+        --no-build) NO_BUILD=1; shift ;;
         -h|--help) usage; exit 0 ;;
         *) die "unknown option: $1 (try --help)" ;;
     esac
@@ -135,6 +152,16 @@ $MARKER_END
 EOF
 }
 
+build_image() {
+    local rt="$1"
+    [ -f "$DOCKERFILE" ] || die "cannot build '$IMAGE': $DOCKERFILE not found."
+    log "Building the '$IMAGE' image from Dockerfile.dev with $rt ..."
+    log "(the first build can take a few minutes; re-runs reuse cached layers and just refresh what changed)"
+    "$rt" build -f "$DOCKERFILE" -t "$IMAGE" "$REPO_ROOT" || die "$rt failed to build '$IMAGE' from $DOCKERFILE."
+    log "Image '$IMAGE' is ready."
+    log ""
+}
+
 install_block() {
     local rc="$1" block="$2" tmp
     tmp="$(mktemp)"
@@ -175,6 +202,16 @@ block="$(emit_block "$runtime" "$socket" "$image_ref")"
 if [ "$PRINT_ONLY" -eq 1 ]; then
     printf '%s\n' "$block"
     exit 0
+fi
+
+# Build (or refresh) the dev image before wiring up the function, so a single
+# run takes a fresh clone all the way to a working `gco`. Always rebuilding also
+# means a stale local image is transparently replaced. Skipped with --no-build.
+if [ "$NO_BUILD" -eq 1 ]; then
+    log "Skipping the image build (--no-build); assuming '$image_ref' already exists."
+    log ""
+else
+    build_image "$runtime"
 fi
 
 rc="$(choose_rc_file)"

--- a/tests/BATS/test_setup_dev_alias.bats
+++ b/tests/BATS/test_setup_dev_alias.bats
@@ -12,14 +12,16 @@
 SCRIPT="scripts/setup-dev-alias.sh"
 
 # Make a fake runtime executable on PATH. It answers `<rt> info` with the exit
-# code requested via $3 (so detection can be steered), exits 0 otherwise, and
-# logs every invocation's args to $GCO_SHIM_LOG when that var is set.
+# code requested via $3 (so detection can be steered) and `<rt> build` with the
+# optional exit code in $4 (default 0, so a build failure can be simulated),
+# exits 0 otherwise, and logs every invocation's args to $GCO_SHIM_LOG when set.
 make_shim() {
-    local dir="$1" name="$2" code="$3"
+    local dir="$1" name="$2" code="$3" build_code="${4:-0}"
     cat > "$dir/$name" <<SHIM
 #!/usr/bin/env bash
 if [ -n "\${GCO_SHIM_LOG:-}" ]; then printf '%s\n' "\$*" >> "\$GCO_SHIM_LOG"; fi
 if [ "\$1" = "info" ]; then exit $code; fi
+if [ "\$1" = "build" ]; then exit $build_code; fi
 exit 0
 SHIM
     chmod +x "$dir/$name"
@@ -174,37 +176,80 @@ teardown() {
 
 # -- Idempotent rc-file install -----------------------------------------------
 @test "install writes exactly one marked block" {
-    bash "$SCRIPT" --runtime docker --rc "$RCFILE" >/dev/null
+    bash "$SCRIPT" --runtime docker --no-build --rc "$RCFILE" >/dev/null
     [ "$(grep -c '# >>> gco >>>' "$RCFILE")" -eq 1 ]
     [ "$(grep -c '# <<< gco <<<' "$RCFILE")" -eq 1 ]
     grep -q 'gco()' "$RCFILE"
 }
 
 @test "install is idempotent across repeated runs" {
-    bash "$SCRIPT" --runtime docker --rc "$RCFILE" >/dev/null
-    bash "$SCRIPT" --runtime docker --rc "$RCFILE" >/dev/null
+    bash "$SCRIPT" --runtime docker --no-build --rc "$RCFILE" >/dev/null
+    bash "$SCRIPT" --runtime docker --no-build --rc "$RCFILE" >/dev/null
     [ "$(grep -c '# >>> gco >>>' "$RCFILE")" -eq 1 ]
     [ "$(grep -c '# <<< gco <<<' "$RCFILE")" -eq 1 ]
 }
 
 @test "install preserves pre-existing rc content" {
     printf '%s\n' "export FOO=bar" > "$RCFILE"
-    bash "$SCRIPT" --runtime docker --rc "$RCFILE" >/dev/null
+    bash "$SCRIPT" --runtime docker --no-build --rc "$RCFILE" >/dev/null
     grep -q 'export FOO=bar' "$RCFILE"
     [ "$(grep -c '# >>> gco >>>' "$RCFILE")" -eq 1 ]
 }
 
 @test "re-running with a different image replaces the block in place" {
-    bash "$SCRIPT" --runtime docker --image old/img --rc "$RCFILE" >/dev/null
-    bash "$SCRIPT" --runtime docker --image new/img --rc "$RCFILE" >/dev/null
+    bash "$SCRIPT" --runtime docker --no-build --image old/img --rc "$RCFILE" >/dev/null
+    bash "$SCRIPT" --runtime docker --no-build --image new/img --rc "$RCFILE" >/dev/null
     grep -q 'new/img gco' "$RCFILE"
     ! grep -q 'old/img gco' "$RCFILE"
     [ "$(grep -c '# >>> gco >>>' "$RCFILE")" -eq 1 ]
 }
 
 @test "the installed rc block passes bash -n" {
-    bash "$SCRIPT" --runtime docker --rc "$RCFILE" >/dev/null
+    bash "$SCRIPT" --runtime docker --no-build --rc "$RCFILE" >/dev/null
     bash -n "$RCFILE"
+}
+
+# -- Image build (always builds unless --no-build / --print) ------------------
+@test "install builds the dev image by default with the resolved runtime" {
+    make_shim "$SHIMDIR" docker 0
+    export GCO_SHIM_LOG="$SHIMDIR/calls.log"
+    : > "$GCO_SHIM_LOG"
+    PATH="$SHIMDIR:$PATH" run bash "$SCRIPT" --runtime docker --rc "$RCFILE"
+    [ "$status" -eq 0 ]
+    # The build ran: it tagged the image and pointed at Dockerfile.dev.
+    grep -q '^build ' "$GCO_SHIM_LOG"
+    grep -q -- '-t gco-dev' "$GCO_SHIM_LOG"
+    grep -qE -- '-f .*Dockerfile\.dev' "$GCO_SHIM_LOG"
+    # ...and the function was still installed afterwards.
+    [ "$(grep -c '# >>> gco >>>' "$RCFILE")" -eq 1 ]
+}
+
+@test "--no-build installs the function without building" {
+    make_shim "$SHIMDIR" docker 0
+    export GCO_SHIM_LOG="$SHIMDIR/calls.log"
+    : > "$GCO_SHIM_LOG"
+    PATH="$SHIMDIR:$PATH" run bash "$SCRIPT" --runtime docker --no-build --rc "$RCFILE"
+    [ "$status" -eq 0 ]
+    ! grep -q '^build ' "$GCO_SHIM_LOG"
+    [ "$(grep -c '# >>> gco >>>' "$RCFILE")" -eq 1 ]
+}
+
+@test "--print never builds the image" {
+    make_shim "$SHIMDIR" docker 0
+    export GCO_SHIM_LOG="$SHIMDIR/calls.log"
+    : > "$GCO_SHIM_LOG"
+    PATH="$SHIMDIR:$PATH" run bash "$SCRIPT" --print --runtime docker
+    [ "$status" -eq 0 ]
+    ! grep -q '^build ' "$GCO_SHIM_LOG"
+}
+
+@test "a failed image build aborts before writing the rc file" {
+    # info succeeds so the runtime is accepted; build fails.
+    make_shim "$SHIMDIR" docker 0 1
+    PATH="$SHIMDIR:$PATH" run bash "$SCRIPT" --runtime docker --rc "$RCFILE"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"failed to build"* ]]
+    [ ! -f "$RCFILE" ]
 }
 
 # -- The emitted function actually runs the runtime correctly -----------------


### PR DESCRIPTION
The AWS Solutions guidance crawler counts every CloudFormation stack whose description carries the (SO9707) marker. Prefixing all five GCO stacks (global, api-gateway, regional, monitoring, analytics) turned a single deployment into many counted deployments. Keep the prefix on the global stack only; every other stack now uses just its own per-stack description. Verified via cdk synth that only gco-global carries the marker.

Also improve README accuracy:
- Lead the dev-container setup with scripts/setup-dev-alias.sh (the recommended path) instead of hand-running the container; move the interactive `docker run` into a details block.
- Correct the Docker-socket description: deploy-all drives the host daemon for more than Lambda bundling (Lambda asset builds, Volcano image mirroring into ECR, and `gco images build`/`push`).
- List all six stacks in the Project Structure tree.

<!--
Thanks for contributing to Global Capacity Orchestrator (GCO)! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [ ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
