### PR TITLE
ci: make Pages coverage deploy non-blocking

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -189,6 +189,15 @@ jobs:
     needs: unit-pytest-core
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Publishing the coverage report to Pages is best-effort. A GitHub Pages
+    # backend stall — where the submitted deployment sits in
+    # `deployment_queued` / `in_progress` and never finalizes — must not turn
+    # the whole Unit Tests workflow red when every test job has passed. With
+    # continue-on-error the job still surfaces as "failed (allowed)" for
+    # visibility, but the overall run stays green. The deploy-pages `timeout`
+    # input (below) makes the step self-terminate before this job's
+    # timeout-minutes cap so a stall ends cleanly instead of a hard cancel.
+    continue-on-error: true
     # `pages: write` lets actions/deploy-pages finalize the deployment.
     # `id-token: write` gives the action an OIDC token to authenticate
     # with the Pages service — this is the documented requirement, not
@@ -204,6 +213,11 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+        with:
+          # Give up after 3 minutes rather than the action's 10-minute
+          # default, so a stuck Pages deployment ends the step cleanly well
+          # inside this job's 5-minute timeout-minutes backstop.
+          timeout: 180000
 
   unit-bats-shell:
     name: "unit:bats:shell"


### PR DESCRIPTION
unit:pages:deploy publishes the htmlcov coverage report to GitHub Pages via actions/deploy-pages. When the Pages backend stalls (deployment stuck in deployment_queued/in_progress and never finalizing), the action polls until the job's 5-minute timeout cancels it, turning the whole Unit Tests workflow red even though every test job passed. Observed 2026-07-02 with no repo change and GitHub reporting Pages 'operational'.

Publishing the coverage report is best-effort, so: continue-on-error keeps a Pages outage from failing the run (job still shows 'failed (allowed)' for visibility); deploy-pages timeout=180000 makes the step self-terminate at 3m, inside the existing 5m job backstop.

<!--
Thanks for contributing to Global Capacity Orchestrator (GCO)! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [ ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
