### PR TITLE
ci: move Pages coverage deploy into its own workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,124 @@
+# =============================================================================
+# pages.yml — Publish the coverage report to GitHub Pages
+# =============================================================================
+#
+# Deploys the HTML coverage report (htmlcov/) plus the shields.io badge
+# endpoint JSON to GitHub Pages, served at
+# https://awslabs.github.io/global-capacity-orchestrator-on-aws/.
+#
+# Why a separate workflow (not a job inside unit-tests.yml)?
+#   Publishing the coverage site is best-effort infrastructure, not a test.
+#   When the GitHub Pages backend stalls — the submitted deployment sits in
+#   `deployment_queued` / `in_progress` and never finalizes — a deploy job
+#   living inside "Unit Tests" drags that whole workflow red even though every
+#   test passed. Giving the deploy its own workflow gives it an independent
+#   status: a Pages outage surfaces here, on "Deploy Pages", and the
+#   "Unit Tests" gate keeps reporting purely on tests.
+#
+# How it gets the report:
+#   `workflow_run` fires when "Unit Tests" finishes on main. This job then
+#   downloads the `pytest-coverage` artifact from that run (via
+#   actions/download-artifact with run-id + github-token — the documented way
+#   to pull an artifact from another run), regenerates the coverage badge,
+#   packages htmlcov/ as a Pages artifact, and deploys it. No pytest re-run,
+#   so there's no duplicate compute and the published report is exactly the
+#   one the gate measured.
+#
+# Note: workflow_run always uses the workflow definition from the default
+# branch, so edits here only take effect once merged to main (they can't be
+# exercised from a PR branch).
+# =============================================================================
+
+name: Deploy Pages
+
+on:
+  workflow_run:
+    workflows: ["Unit Tests"]
+    types: [completed]
+    branches: [main]
+
+# Serialize Pages deployments and never cancel an in-flight real deploy.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: "pages:deploy"
+    # Only publish from a green Unit Tests run. The `branches: [main]` filter
+    # above already restricts the trigger to runs whose head branch is main,
+    # so no additional ref guard is needed here.
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Job-level permissions replace the top-level block for this job. This job
+    # does not check out the repo, so it needs no `contents` scope — only:
+    #   pages: write    — actions/deploy-pages finalizes the deployment
+    #   id-token: write — OIDC token the deploy action authenticates with
+    #   actions: read   — download-artifact reads an artifact from another run
+    permissions:
+      pages: write
+      id-token: write
+      actions: read
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Download coverage artifact from the Unit Tests run
+        uses: actions/download-artifact@v5
+        with:
+          name: pytest-coverage
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: coverage-data
+      - name: Generate shields.io badge endpoint JSON
+        # coverage.json is written by coverage.py during the Unit Tests run
+        # and ships inside the pytest-coverage artifact. Pull
+        # totals.percent_covered, round to one decimal, and emit the
+        # shields.io endpoint schema so the README badge can link to a static
+        # JSON on Pages without calling a third-party service.
+        #
+        # Color threshold matches the --cov-fail-under gate (90%) in
+        # unit-tests.yml: a run below that would have failed and been skipped
+        # by the `if` above, so the badge only has two meaningful states.
+        #
+        # The write is done entirely in Python (heredoc + json.dump) rather
+        # than piped through shell — interpolating an f-string result into
+        # shell printf trips PEP 498's ban on backslash escapes inside
+        # f-string `{ }` expressions.
+        run: |
+          set -euo pipefail
+          python3 <<'PY'
+          import json
+          with open("coverage-data/coverage.json") as f:
+              pct = json.load(f)["totals"]["percent_covered"]
+          color = "brightgreen" if pct >= 90 else "red"
+          badge = {
+              "schemaVersion": 1,
+              "label": "coverage",
+              "message": f"{pct:.1f}%",
+              "color": color,
+          }
+          with open("coverage-data/htmlcov/coverage-badge.json", "w") as f:
+              json.dump(badge, f)
+          print(f"Coverage: {pct:.1f}% ({color})")
+          PY
+      - name: Package htmlcov/ as a Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          # htmlcov/ holds index.html (coverage.py's report root) plus the
+          # coverage-badge.json written above. GitHub Pages serves this at
+          # the site root, so the README badge and report links keep working
+          # unchanged.
+          path: coverage-data/htmlcov
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5
+        with:
+          # Give up after 3 minutes rather than the action's 10-minute
+          # default, so a stuck Pages deployment ends the step cleanly inside
+          # this job's timeout-minutes backstop.
+          timeout: 180000

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,9 +15,13 @@
 #   - unit:fresh-install           — pip install from scratch, verify imports
 #   - unit:lockfile:freshness      — requirements-lock.txt matches pyproject.toml
 #   - unit:mcp:install             — uv-installs gco-mcp from source, then launches the server
-#   - unit:pages:deploy            — publish htmlcov/ (coverage report + badge) to Pages
-#   - unit:pytest:core             — pytest (coverage target 85%) + upload Pages artifact
+#   - unit:pytest:core             — pytest (coverage gate 90%) + upload coverage artifact
 #   - unit:workload:imports        — K8s service import + circular-import detection
+#
+# The HTML coverage report is published to GitHub Pages by a separate
+# workflow — pages.yml ("Deploy Pages") — triggered via workflow_run after
+# this workflow completes on main. Keeping the deploy out of this file means a
+# GitHub Pages outage can't turn this test gate red.
 #
 # =============================================================================
 
@@ -133,77 +137,6 @@ jobs:
             coverage.json
             report.xml
           retention-days: 7
-      - name: Generate shields.io badge endpoint JSON
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          set -euo pipefail
-          # coverage.json is written by coverage.py. Pull totals.percent_covered,
-          # round to one decimal, and emit the shields.io endpoint badge
-          # schema so the README badge can link to a static JSON file on
-          # GitHub Pages without calling a third-party service.
-          #
-          # Color threshold matches the --cov-fail-under value (90%) from
-          # the pytest step above: anything below that would have already
-          # failed CI, so the badge only has two meaningful states.
-          #
-          # The JSON write is done entirely in Python (heredoc + json.dump)
-          # rather than piped back through shell — earlier attempts to
-          # interpolate a Python f-string result into shell printf ran into
-          # PEP 498's ban on backslash escapes inside f-string `{ }`
-          # expressions, producing a `SyntaxError: unexpected character
-          # after line continuation character` at CI time.
-          python3 <<'PY'
-          import json
-          with open("coverage.json") as f:
-              pct = json.load(f)["totals"]["percent_covered"]
-          color = "brightgreen" if pct >= 90 else "red"
-          badge = {
-              "schemaVersion": 1,
-              "label": "coverage",
-              "message": f"{pct:.1f}%",
-              "color": color,
-          }
-          with open("htmlcov/coverage-badge.json", "w") as f:
-              json.dump(badge, f)
-          print(f"Coverage: {pct:.1f}% ({color})")
-          PY
-      - name: Upload coverage report as Pages artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v5
-        with:
-          # htmlcov/ now contains index.html (coverage.py's report root)
-          # plus coverage-badge.json. GitHub Pages serves this at
-          # https://awslabs.github.io/<repo>/ once the deploy job below
-          # finalizes it. The README badge and report link both point
-          # under that base URL.
-          path: htmlcov
-
-  unit-pages-deploy:
-    name: "unit:pages:deploy"
-    # Deploys the htmlcov Pages artifact uploaded by unit-pytest-core to
-    # GitHub Pages. Runs only on push to main — PRs, manual dispatch,
-    # and forks all skip this job. Uses the official actions/deploy-pages
-    # flow rather than pushing to a gh-pages branch, so the Pages site
-    # is managed entirely through GitHub's built-in deployment system.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: unit-pytest-core
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    # `pages: write` lets actions/deploy-pages finalize the deployment.
-    # `id-token: write` gives the action an OIDC token to authenticate
-    # with the Pages service — this is the documented requirement, not
-    # optional. `contents: read` is the default and sufficient since
-    # this job doesn't check out the repo.
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
 
   unit-bats-shell:
     name: "unit:bats:shell"


### PR DESCRIPTION
Splits the coverage-report Pages deploy out of the Unit Tests workflow so a GitHub Pages backend stall can no longer fail an otherwise-green test run. Unit Tests now only runs tests and uploads the pytest-coverage artifact; it no longer generates the badge, uploads a Pages artifact, or deploys.

New workflow pages.yml ("Deploy Pages") triggers via workflow_run when Unit Tests completes on main, downloads the pytest-coverage artifact from that run (actions/download-artifact with run-id + github-token), regenerates the shields.io badge JSON, packages htmlcov/, and deploys via actions/deploy-pages. The Pages site layout is unchanged, so the README coverage badge and report links keep working. Gives Pages deploys an independent status; supersedes the continue-on-error band-aid on ci/harden-pages-deploy.

<!--
Thanks for contributing to Global Capacity Orchestrator (GCO)! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [ ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
