### PR TITLE
docs: document the Deploy Pages (pages.yml) workflow

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -46,6 +46,7 @@ For contributor-facing docs (how to run tests locally, release process, dependen
 │   ├── integration-tests.yml       # Integration Tests workflow
 │   ├── security.yml                # Security workflow
 │   ├── lint.yml                    # Linting workflow
+│   ├── mooncake-image.yml          # Mooncake vLLM image contract test (push/PR)
 │   ├── release.yml                 # Manual workflow_dispatch release
 │   ├── deps-scan.yml               # Monthly dependency scan
 │   ├── cve-scan.yml                # Weekly CVE scan
@@ -65,12 +66,14 @@ Each file maps to one row in the README badge table.
 
 | File | README row | What it covers |
 |------|------------|----------------|
-| `workflows/unit-tests.yml` | Unit Tests | pytest with coverage (fail under 85%), BATS, CLI smoke, CDK synth + config matrix, lockfile freshness, fresh install, MCP install + launch smoke, workload import checks |
+| `workflows/unit-tests.yml` | Unit Tests | pytest with coverage (fail under 90%), BATS, CLI smoke, CDK synth + config matrix, lockfile freshness, fresh install, MCP install + launch smoke, workload import checks |
 | `workflows/integration-tests.yml` | Integration Tests | Per-Dockerfile build + module-import smoke, dev-container smoke, kind E2E with Calico (NetworkPolicy enforcement, RBAC verification, ResourceQuota/LimitRange, PDB validation, cross-namespace traffic blocking, all 3 service deployments), K8s manifest validation, Lambda import validation, cross-module pytest, MCP server pytest |
 | `workflows/security.yml` | Security | bandit, pip-audit, trivy (filesystem + per-image matrix), trufflehog, gitleaks, semgrep, checkov, KICS, CodeQL (Python) |
 | `workflows/lint.yml` | Linting | actionlint, hadolint, markdownlint, mypy (strict / stacks / lambda), ruff (format + check, imports included), shellcheck, yamllint |
 
 ### Satellites
+
+Workflows outside the four badged gates. Most are schedule- or dispatch-driven; `mooncake-image.yml` also runs on push and PR but is a narrow, feature-specific contract test rather than a headline gate.
 
 | File | Trigger | Purpose |
 |------|---------|---------|
@@ -78,6 +81,7 @@ Each file maps to one row in the README badge table.
 | `workflows/deps-scan.yml` | `cron: 0 9 1 * *` (monthly, UTC) + manual | Check Python / Docker / Helm / EKS-addon / Bedrock-model versions; open a GitHub issue if drift is found |
 | `workflows/cve-scan.yml` | `cron: 0 9 * * 1` (Mondays, UTC) + manual | Re-run trivy against current CVE databases |
 | `workflows/pages.yml` | `workflow_run` after **Unit Tests** completes on `main` | Download the `pytest-coverage` artifact from the triggering run, regenerate the shields.io coverage badge, and deploy `htmlcov/` to GitHub Pages via `actions/deploy-pages`. Split out of `unit-tests.yml` so a GitHub Pages backend stall surfaces here instead of failing the test gate |
+| `workflows/mooncake-image.yml` | `push`: `main`, PR, manual | Pull the upstream Mooncake vLLM image pinned in `cli/images.py` (`_DISAGGREGATED_DEFAULT_IMAGE`) and run `tests/test_mooncake_image_contract.py`: prefill-decode proxy health under the image's `python3`, `MooncakeStoreConfig` acceptance of the rendered store config, and KV-connector name registration. Deliberately not Trivy/CVE-scanned — the image is upstream and unpatchable; version drift is surfaced by `deps-scan` |
 
 ### Naming conventions
 

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -48,7 +48,8 @@ For contributor-facing docs (how to run tests locally, release process, dependen
 │   ├── lint.yml                    # Linting workflow
 │   ├── release.yml                 # Manual workflow_dispatch release
 │   ├── deps-scan.yml               # Monthly dependency scan
-│   └── cve-scan.yml                # Weekly CVE scan
+│   ├── cve-scan.yml                # Weekly CVE scan
+│   └── pages.yml                   # Publish coverage report to GitHub Pages (workflow_run)
 ├── CODEOWNERS
 ├── dependabot.yml
 ├── pull_request_template.md
@@ -76,6 +77,7 @@ Each file maps to one row in the README badge table.
 | `workflows/release.yml` | `workflow_dispatch` | Bump version, tag, create a GitHub Release with auto-generated notes. Uses the built-in `GITHUB_TOKEN` — no PAT required |
 | `workflows/deps-scan.yml` | `cron: 0 9 1 * *` (monthly, UTC) + manual | Check Python / Docker / Helm / EKS-addon / Bedrock-model versions; open a GitHub issue if drift is found |
 | `workflows/cve-scan.yml` | `cron: 0 9 * * 1` (Mondays, UTC) + manual | Re-run trivy against current CVE databases |
+| `workflows/pages.yml` | `workflow_run` after **Unit Tests** completes on `main` | Download the `pytest-coverage` artifact from the triggering run, regenerate the shields.io coverage badge, and deploy `htmlcov/` to GitHub Pages via `actions/deploy-pages`. Split out of `unit-tests.yml` so a GitHub Pages backend stall surfaces here instead of failing the test gate |
 
 ### Naming conventions
 
@@ -87,9 +89,9 @@ Each file maps to one row in the README badge table.
 
 All CI workflows share the same safety defaults:
 
-- `concurrency.group: ${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true` so rapid pushes on the same branch supersede in-flight runs. Explicitly **off** on `release.yml` — a half-run release is worse than a slow one.
+- `concurrency.group: ${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true` so rapid pushes on the same branch supersede in-flight runs. Explicitly **off** on `release.yml` — a half-run release is worse than a slow one. `pages.yml` is the other exception: it uses a dedicated `concurrency.group: pages` with `cancel-in-progress: false` so a real Pages deployment is never cancelled mid-flight.
 - `timeout-minutes` on every job (10 min for lint, 15 for unit, 20–30 for integration).
-- `permissions:` scoped narrowly. All CI workflows run with `contents: read`; `release.yml` upgrades to `contents: write` so the version-bump job can push a tag and create a GitHub Release.
+- `permissions:` scoped narrowly. All CI workflows run with `contents: read`; `release.yml` upgrades to `contents: write` so the version-bump job can push a tag and create a GitHub Release. `pages.yml`'s deploy job grants `pages: write` + `id-token: write` (to publish to Pages) and `actions: read` (to pull the `pytest-coverage` artifact from the triggering Unit Tests run).
 - Caching: `actions/setup-python@v6` with `cache: pip` and `cache-dependency-path: requirements-lock.txt`. Mypy jobs add an explicit `actions/cache@v5` on `.mypy_cache/`.
 - AWS auth (when a future test needs it) uses OIDC via `aws-actions/configure-aws-credentials@v4` — not long-lived access keys.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -27,6 +27,7 @@ Run on every push to `main` and every pull request.
 | `release.yml` | `workflow_dispatch` | Bump version, tag, create GitHub Release with auto-generated notes |
 | `deps-scan.yml` | Monthly cron + manual | Check Python, Docker, Helm, EKS-addon versions; open issue if drift found |
 | `cve-scan.yml` | Weekly cron + manual | Re-run trivy against current CVE databases |
+| `pages.yml` | `workflow_run` after Unit Tests on `main` | Publish the HTML coverage report + shields.io badge JSON to GitHub Pages. Split out of Unit Tests so a Pages outage can't fail the test gate |
 
 ## Naming Conventions
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,12 +15,14 @@ Run on every push to `main` and every pull request.
 
 | File | Badge | Description |
 |------|-------|-------------|
-| `unit-tests.yml` | Unit Tests | pytest with coverage (85% gate), BATS shell tests, CDK synth, config matrix, cdk-nag compliance, lockfile freshness, CLI smoke |
+| `unit-tests.yml` | Unit Tests | pytest with coverage (90% gate), BATS shell tests, CDK synth, config matrix, cdk-nag compliance, lockfile freshness, CLI smoke |
 | `integration-tests.yml` | Integration Tests | Dockerfile builds, kind cluster E2E with Calico (3 service deployments, RBAC enforcement, NetworkPolicy blocking, ResourceQuota, PDB validation), K8s manifest validation, Lambda import checks, MCP server tests |
 | `security.yml` | Security | bandit, pip-audit, trivy (filesystem + container), trufflehog, gitleaks, semgrep, checkov, KICS |
 | `lint.yml` | Linting | actionlint, hadolint, markdownlint, mypy (strict + stacks + lambda), ruff (format + check, imports included), shellcheck, yamllint |
 
 ## Satellite Workflows
+
+Workflows outside the four badged gates above. Most are schedule- or dispatch-driven; `mooncake-image.yml` also runs on push and PR but is a narrow, feature-specific contract test rather than a headline gate.
 
 | File | Trigger | Description |
 |------|---------|-------------|
@@ -28,6 +30,7 @@ Run on every push to `main` and every pull request.
 | `deps-scan.yml` | Monthly cron + manual | Check Python, Docker, Helm, EKS-addon versions; open issue if drift found |
 | `cve-scan.yml` | Weekly cron + manual | Re-run trivy against current CVE databases |
 | `pages.yml` | `workflow_run` after Unit Tests on `main` | Publish the HTML coverage report + shields.io badge JSON to GitHub Pages. Split out of Unit Tests so a Pages outage can't fail the test gate |
+| `mooncake-image.yml` | `push`: `main`, PR, manual | Contract-test the real upstream Mooncake vLLM image GCO defaults to — proxy `/healthz`, store-config loader, KV-connector names. Not CVE-scanned (upstream image); version drift is caught by `deps-scan` |
 
 ## Naming Conventions
 


### PR DESCRIPTION
pages.yml was added in #123 but not reflected in the .github docs. Add it to the Satellite Workflows tables in .github/workflows/README.md and .github/CI.md, list it in the CI.md layout tree, and note its concurrency (group: pages, cancel-in-progress: false) and permissions (pages/id-token write + actions read) deviations in the Cross-cutting defaults section.

<!--
Thanks for contributing to Global Capacity Orchestrator (GCO)! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [ ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
