### PR TITLE
fix: make regional auth-secret IAM ARN deterministic for single-regio…

### DIFF
--- a/gco/stacks/api_gateway_global_stack.py
+++ b/gco/stacks/api_gateway_global_stack.py
@@ -50,7 +50,7 @@ from aws_cdk import aws_secretsmanager as secretsmanager
 from aws_cdk import aws_wafv2 as wafv2
 from constructs import Construct
 
-from gco.stacks.constants import LAMBDA_PYTHON_RUNTIME
+from gco.stacks.constants import API_GATEWAY_AUTH_SECRET_NAME, LAMBDA_PYTHON_RUNTIME
 
 # <pyflowchart-code-diagram> BEGIN - auto-inserted, do not edit
 # Flowchart(s) generated from this file:
@@ -188,7 +188,7 @@ class GCOApiGatewayGlobalStack(Stack):
         secret = secretsmanager.Secret(
             self,
             "GCOAuthSecret",
-            secret_name="gco/api-gateway-auth-token",  # nosec B106 — this is the secret path, not a password
+            secret_name=API_GATEWAY_AUTH_SECRET_NAME,  # nosec B106 — this is the secret path, not a password
             description="Secret token for validating requests from API Gateway to ALB (auto-rotated)",
             generate_secret_string=secretsmanager.SecretStringGenerator(
                 secret_string_template=json.dumps({"description": "GCO API Gateway auth token"}),

--- a/gco/stacks/constants.py
+++ b/gco/stacks/constants.py
@@ -29,6 +29,34 @@ LAMBDA_PYTHON_RUNTIME = "PYTHON_3_14"
 """CDK enum name for the Lambda runtime (e.g. ``lambda_.Runtime.PYTHON_3_14``)."""
 
 # ---------------------------------------------------------------------------
+# API Gateway Auth Secret
+# ---------------------------------------------------------------------------
+# Physical name of the Secrets Manager secret that holds the token API Gateway
+# uses to authenticate requests to the regional ALBs. It is created by
+# ``GCOApiGatewayGlobalStack`` (in the ``api_gateway`` region) and read by the
+# regional service-account role and the regional API proxy Lambda.
+
+API_GATEWAY_AUTH_SECRET_NAME = "gco/api-gateway-auth-token"  # nosec B105 — secret path/name, not a credential
+"""Secrets Manager secret name for the API Gateway → ALB auth token.
+
+Single source of truth shared by three call sites that must agree exactly:
+
+1. ``GCOApiGatewayGlobalStack._create_secret`` — the ``secret_name`` the
+   secret is actually created with.
+2. ``GCORegionalStack`` — the deterministic IAM ``Resource`` ARN granting the
+   service-account role read access to the secret. Built from this name plus
+   the API Gateway region and account so it renders identically whether the
+   API Gateway stack is cross-region or co-located with the regional stack
+   (see issue #125 — a synthesis-time cross-stack export token used to leak
+   into the ARN and dodge the cdk-nag suppression in single-region topologies).
+3. ``gco.stacks.nag_suppressions.add_iam_suppressions`` — the
+   ``AwsSolutions-IAM5`` acknowledgment scoped to this exact ARN.
+
+The name is a fixed string (not derived from ``project_name``); keep the three
+call sites in lockstep by importing this constant rather than re-typing it.
+"""
+
+# ---------------------------------------------------------------------------
 # EKS Add-on Versions
 # ---------------------------------------------------------------------------
 # Pinned to specific eksbuild versions for reproducible deployments.

--- a/gco/stacks/nag_suppressions.py
+++ b/gco/stacks/nag_suppressions.py
@@ -38,6 +38,8 @@ from cdk_nag import (
 )
 from constructs import IConstruct
 
+from gco.stacks.constants import API_GATEWAY_AUTH_SECRET_NAME
+
 # ---------------------------------------------------------------------------
 # cdk-nag v3 acknowledgment mechanism
 # ---------------------------------------------------------------------------
@@ -425,7 +427,10 @@ def add_lambda_suppressions(stack: Stack) -> None:
 
 
 def add_iam_suppressions(
-    stack: Stack, regions: list[str] | None = None, global_region: str | None = None
+    stack: Stack,
+    regions: list[str] | None = None,
+    global_region: str | None = None,
+    api_gateway_region: str | None = None,
 ) -> None:
     """Add suppressions for IAM-related cdk-nag findings.
 
@@ -436,15 +441,31 @@ def add_iam_suppressions(
         stack: The CDK stack to apply suppressions to
         regions: List of regional deployment regions (for EKS addon patterns)
         global_region: Global region for SSM parameters and DynamoDB tables
+        api_gateway_region: Region where the API Gateway auth secret lives.
+            The regional service-account role's read grant is scoped to a
+            deterministic ARN in this region (see ``GCORegionalStack`` and
+            issue #125). Falls back to ``global_region`` for callers that
+            don't split the API Gateway stack into its own region — the two
+            are co-located in the default topology.
     """
+    # Region the API Gateway auth secret is created in. It is normally the
+    # same as ``global_region`` (default cdk.json co-locates them), but the
+    # secret physically lives in the API Gateway stack's region, so scope the
+    # grant/suppression to that region when it is provided.
+    secret_region = api_gateway_region or global_region or "us-east-2"
+
     # Build dynamic applies_to list based on configured regions
     applies_to = [
         "Resource::<KubectlApplierFunction6147DA0C.Arn>:*",
         "Resource::<GaRegistrationFunction4A12C41B.Arn>:*",
         "Resource::<HelmInstallerFunction3FEB04EF.Arn>:*",
         "Resource::<VpcFlowLogGroup86559C69.Arn>:*",
-        # Secrets Manager cross-region access with wildcard for suffix
-        f"Resource::arn:aws:secretsmanager:{global_region or 'us-east-2'}:<AWS::AccountId>:secret:gco/api-gateway-auth-token*",
+        # Secrets Manager access for the API Gateway auth token, with a
+        # trailing wildcard for the random 6-char suffix. The regional
+        # service-account role builds this exact ARN deterministically (from
+        # the secret name + API Gateway region + account) so it matches in
+        # both single-region and cross-region topologies — see issue #125.
+        f"Resource::arn:aws:secretsmanager:{secret_region}:<AWS::AccountId>:secret:{API_GATEWAY_AUTH_SECRET_NAME}*",
     ]
 
     # Add EKS addon patterns for each configured region
@@ -1586,7 +1607,12 @@ def apply_all_suppressions(
     """
     # Common suppressions for all stacks
     add_lambda_suppressions(stack)
-    add_iam_suppressions(stack, regions=regions, global_region=global_region)
+    add_iam_suppressions(
+        stack,
+        regions=regions,
+        global_region=global_region,
+        api_gateway_region=api_gateway_region,
+    )
 
     if stack_type == "regional":
         add_eks_suppressions(stack)

--- a/gco/stacks/regional_stack.py
+++ b/gco/stacks/regional_stack.py
@@ -101,6 +101,7 @@ from constructs import Construct
 
 from gco.config.config_loader import ConfigLoader
 from gco.stacks.constants import (
+    API_GATEWAY_AUTH_SECRET_NAME,
     AURORA_POSTGRES_VERSION,
     CLUSTER_SHARED_SSM_PARAMETER_PREFIX,
     EKS_ADDON_CLOUDWATCH_OBSERVABILITY,
@@ -466,6 +467,7 @@ class GCORegionalStack(Stack):
             stack_type="regional",
             regions=self.config.get_regions(),
             global_region=self.config.get_global_region(),
+            api_gateway_region=self.config.get_api_gateway_region(),
         )
 
     def _create_sqs_queue(self) -> None:
@@ -1213,13 +1215,32 @@ class GCORegionalStack(Stack):
             namespaces=["gco-system", "gco-jobs", "gco-inference"],
         )
 
-        # Grant permission to read the auth secret
-        # Note: We use an explicit IAM policy statement with a wildcard (*) because:
-        # 1. The secret is in a different region (API Gateway region)
-        # 2. CDK's grant_read() generates a policy with ?????? suffix which requires
-        #    exactly 6 characters, but the SDK can call GetSecretValue with either
-        #    the full ARN (with suffix) or partial ARN (without suffix)
-        # 3. Using * ensures both forms work correctly
+        # Grant permission to read the auth secret.
+        #
+        # The resource is built as a *deterministic* ARN from the known secret
+        # name, the API Gateway region (where the secret lives), and this
+        # stack's account — rather than from ``self.auth_secret_arn``, which is
+        # ``api_gateway_stack.secret.secret_arn`` (a cross-stack reference
+        # token). The token was the source of issue #125: it renders
+        # differently depending on topology —
+        #   * cross-region  -> a literal ARN, and
+        #   * same-region   -> a native cross-stack export
+        #                      (``gco-api-gateway:ExportsOutputRefGCOAuthSecret<hash>``)
+        # so the trailing-``*`` IAM resource only matched the stack-level
+        # AwsSolutions-IAM5 suppression in the cross-region (default) topology.
+        # Collapsing every stack into one region left the export-token form
+        # unsuppressed and failed ``cdk synth``. Building the ARN ourselves
+        # makes the ``Resource`` render identically in both topologies so a
+        # single deterministic suppression (see ``add_iam_suppressions``)
+        # always matches.
+        #
+        # The trailing ``*`` matches the random 6-character suffix Secrets
+        # Manager appends to secret ARNs (Secrets Manager accepts either the
+        # full ARN with suffix or the partial ARN without it).
+        auth_secret_resource = (
+            f"arn:aws:secretsmanager:{self.config.get_api_gateway_region()}"
+            f":{self.account}:secret:{API_GATEWAY_AUTH_SECRET_NAME}*"
+        )
         self.service_account_role.add_to_policy(
             iam.PolicyStatement(
                 effect=iam.Effect.ALLOW,
@@ -1227,16 +1248,10 @@ class GCORegionalStack(Stack):
                     "secretsmanager:GetSecretValue",
                     "secretsmanager:DescribeSecret",
                 ],
-                resources=[f"{self.auth_secret_arn}*"],  # Wildcard to match with or without suffix
+                resources=[auth_secret_resource],
             )
         )
 
-        # NOTE: the trailing ``*`` on the auth-secret ARN above matches the
-        # random 6-character suffix Secrets Manager appends to secret ARNs.
-        # cdk-nag v3 does not raise an IAM5 finding on it: the secret is a
-        # cross-stack ``Fn::ImportValue`` token, and the IAM5 wildcard check
-        # does not flag import-based resources — so no acknowledgment is
-        # needed here (verified across the full nag config matrix).
         from gco.stacks.nag_suppressions import acknowledge_nag_findings
 
         # cdk-nag suppression: the ServiceAccountRole grants ec2:Describe*

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -205,7 +205,7 @@ jmespath==1.1.0
     # via
     #   boto3
     #   botocore
-joserfc==1.6.7
+joserfc==1.6.8
     # via
     #   authlib
     #   fastmcp-slim

--- a/tests/_cdk_config_matrix.py
+++ b/tests/_cdk_config_matrix.py
@@ -69,6 +69,29 @@ CONFIGS: list[tuple[str, dict[str, Any]]] = [
         },
     ),
     (
+        # Single-region topology: every stack (global, api_gateway,
+        # monitoring) collapses onto the one regional entry. This is the
+        # exact shape from issue #125 — when the API Gateway stack is
+        # co-located with the regional stack, the auth-secret cross-stack
+        # reference resolves to a native CloudFormation export
+        # (``gco-api-gateway:ExportsOutputRefGCOAuthSecret<hash>``) instead of
+        # a literal ARN, which used to slip past the AwsSolutions-IAM5
+        # suppression and fail ``cdk synth``. Every other topology in this
+        # matrix keeps ``regional`` in a different region from ``global`` /
+        # ``api_gateway``, so this is the only entry that exercises the
+        # same-region auth-secret code path. Keep it here as a regression
+        # guard for both the synthesis matrix and the cdk-nag matrix.
+        "single-region",
+        {
+            "deployment_regions": {
+                "global": "us-east-1",
+                "api_gateway": "us-east-1",
+                "monitoring": "us-east-1",
+                "regional": ["us-east-1"],
+            }
+        },
+    ),
+    (
         "valkey-enabled",
         {
             "valkey": {
@@ -437,6 +460,14 @@ CONFIGS.append(
 _NAG_CONFIG_NAMES = {
     "default-regions",
     "multi-region",
+    # Single-region topology (global == api_gateway == regional). This is the
+    # IAM code path from issue #125: the auth-secret grant on the regional
+    # service-account role must stay covered by its AwsSolutions-IAM5
+    # suppression even when the API Gateway stack is co-located with the
+    # regional stack. It is the only config that exercises the same-region
+    # cross-stack reference form, so it MUST run through cdk-nag, not just the
+    # synthesis matrix.
+    "single-region",
     "fsx-enabled",
     "all-features-enabled",
     "three-regions",


### PR DESCRIPTION
…n deploys

The regional ServiceAccountRole granted read on the API Gateway auth secret using `f"{self.auth_secret_arn}*"`, where `auth_secret_arn` is the cross-stack `api_gateway_stack.secret.secret_arn` token. That token renders differently by topology: a literal ARN cross-region (covered by the AwsSolutions-IAM5 suppression) but a native cross-stack export (`gco-api-gateway:ExportsOutputRefGCOAuthSecret<hash>`) when the API Gateway stack is co-located with the regional stack. The export form was never in the suppression list, so `cdk synth` / `gco stacks deploy` failed cdk-nag IAM5 on any single-region topology.

Build the IAM resource as a deterministic ARN from the (now shared) secret name, the API Gateway region, and the account, so it renders identically in both topologies and always matches one deterministic suppression.

- constants: add API_GATEWAY_AUTH_SECRET_NAME as the single source of truth for the secret name (previously hardcoded in two places).
- api_gateway_global_stack: create the secret from the constant.
- regional_stack: build the deterministic auth-secret ARN and pass api_gateway_region into the suppressions.
- nag_suppressions: scope the IAM5 auth-secret suppression to the API Gateway region (falls back to the global region).
- tests: add a single-region entry to the shared cdk config matrix so both the synthesis and cdk-nag matrices exercise the collapsed topology. This reproduces the exact IAM5 finding from the issue.

Fixes #125

<!--
Thanks for contributing to Global Capacity Orchestrator (GCO)! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [ ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
