### PR TITLE
feat: place a subnet in every AZ for regional cluster VPCs

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,8 @@ Usage:
     cdk destroy --all                   # Cleanup all resources
 """
 
+import os
+
 import aws_cdk as cdk
 import jsii
 from constructs import IConstruct
@@ -110,13 +112,24 @@ def main() -> None:
     for key, value in tags.items():
         cdk.Tags.of(app).add(key, value)
 
+    # Resolve the target AWS account for every stack. Deploying (or even
+    # synthesizing against real infrastructure) requires valid credentials, so
+    # the CDK CLI populates CDK_DEFAULT_ACCOUNT from the active identity. Pairing
+    # it with each stack's region makes the stacks *environment-specific*, which
+    # is what lets CDK's availability-zones context provider look up the real AZ
+    # list for the account+region. The regional VPC relies on that lookup to
+    # place a subnet in every AZ (regional_stack.py uses max_azs=99). When the
+    # variable is unset — e.g. an environment-agnostic ``cdk synth`` in CI — this
+    # is None and stacks stay agnostic exactly as before.
+    account = os.environ.get("CDK_DEFAULT_ACCOUNT")
+
     # Create global stack (Global Accelerator)
     # Note: Global Accelerator is a global service but needs a "home" region for CloudFormation
     global_stack = GCOGlobalStack(
         app,
         f"{project_name}-global",
         config=config,
-        env=cdk.Environment(region=global_region),
+        env=cdk.Environment(account=account, region=global_region),
         description=f"{SOLUTION_DESCRIPTION_PREFIX} - Global resources including AWS Global Accelerator for GCO (Global Capacity Orchestrator on AWS)",
     )
 
@@ -125,7 +138,7 @@ def main() -> None:
         app,
         f"{project_name}-api-gateway",
         global_accelerator_dns=global_stack.accelerator.dns_name,
-        env=cdk.Environment(region=api_gateway_region),
+        env=cdk.Environment(account=account, region=api_gateway_region),
         description="Global API Gateway with IAM authentication",
     )
     api_gateway_stack.add_dependency(global_stack)
@@ -139,7 +152,7 @@ def main() -> None:
             config=config,
             region=region,
             auth_secret_arn=api_gateway_stack.secret.secret_arn,
-            env=cdk.Environment(region=region),
+            env=cdk.Environment(account=account, region=region),
             description=f"Regional resources for {region} - EKS cluster, ALB, and services",
         )
 
@@ -161,7 +174,7 @@ def main() -> None:
         global_stack=global_stack,
         regional_stacks=regional_stacks,
         api_gateway_stack=api_gateway_stack,
-        env=cdk.Environment(region=monitoring_region),
+        env=cdk.Environment(account=account, region=monitoring_region),
         description="Cross-region monitoring and observability for GCO (Global Capacity Orchestrator on AWS)",
     )
 
@@ -187,7 +200,7 @@ def main() -> None:
             app,
             f"{project_name}-analytics",
             config=config,
-            env=cdk.Environment(region=api_gateway_region),
+            env=cdk.Environment(account=account, region=api_gateway_region),
             description="Optional ML and analytics environment (SageMaker Studio, EMR Serverless, Cognito)",
         )
         analytics_stack.add_dependency(global_stack)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,7 +51,7 @@ Each region contains:
 
 **VPC Configuration**
 
-- 3 Availability Zones
+- Spans every Availability Zone in the region (one public + one private subnet per AZ)
 - Public subnets (24-bit CIDR) for ALB
 - Private subnets (24-bit CIDR) for EKS nodes
 - 2 NAT Gateways for high availability

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -773,6 +773,17 @@ gco stacks deploy-all -y
 
 ## Modifying Network Configuration
 
+### Availability Zone coverage
+
+Each regional VPC spans **every** Availability Zone in its region: `max_azs=99` in
+`gco/stacks/regional_stack.py` is the CDK idiom for "use all AZs", and each AZ gets
+one public and one private subnet (so a 6-AZ region such as `us-east-1` yields 12
+subnets). CDK can only enumerate a region's real AZ list when the stack is
+environment-specific, so `app.py` sets each stack's account from
+`CDK_DEFAULT_ACCOUNT` — which the CDK CLI populates automatically from your active
+credentials at `gco stacks` / `cdk` time. To pin a fixed number of AZs instead,
+lower `max_azs` (e.g. `max_azs=3`).
+
 ### Change VPC CIDR
 
 Edit `gco/stacks/regional_stack.py`:
@@ -781,7 +792,7 @@ Edit `gco/stacks/regional_stack.py`:
 self.vpc = ec2.Vpc(
     self, "GCOVpc",
     vpc_name=f"{config.get_project_name()}-vpc-{region}",
-    max_azs=3,
+    max_azs=99,  # span every AZ in the region (lower this to cap AZ count)
     ip_addresses=ec2.IpAddresses.cidr("10.1.0.0/16"),  # Custom CIDR
     nat_gateways=2,
     subnet_configuration=[

--- a/gco/stacks/README.md
+++ b/gco/stacks/README.md
@@ -29,7 +29,7 @@ GCO deploys four stack layers in order: Global → API Gateway → Regional (per
 |------|-------------|
 | `global_stack.py` | Global Accelerator, SSM parameters, S3 model bucket, DynamoDB tables (templates, webhooks, inference endpoints) |
 | `api_gateway_global_stack.py` | Edge-optimized API Gateway with IAM auth (SigV4), Lambda proxy, Secrets Manager secret with daily rotation, multi-region replication |
-| `regional_stack.py` | Per-region VPC (3 AZs), EKS Auto Mode cluster, ALB, EFS/FSx storage, ECR images, Lambda functions (kubectl-applier, helm-installer, GA registration), IRSA roles |
+| `regional_stack.py` | Per-region VPC (spans all AZs in the region), EKS Auto Mode cluster, ALB, EFS/FSx storage, ECR images, Lambda functions (kubectl-applier, helm-installer, GA registration), IRSA roles |
 | `regional_api_gateway_stack.py` | Regional API Gateway for private VPC access via internal NLB |
 | `monitoring_stack.py` | Cross-region CloudWatch dashboard (GA, API GW, Lambda, SQS, DynamoDB, EKS, ALB widgets), SNS alerting, CloudWatch alarms |
 | `nag_suppressions.py` | CDK-nag compliance suppressions for five rule packs (AWS Solutions, HIPAA, NIST 800-53, PCI DSS, Serverless) |

--- a/gco/stacks/constants.py
+++ b/gco/stacks/constants.py
@@ -79,6 +79,32 @@ EKS_ADDON_FSX_CSI_DRIVER = "v1.9.0-eksbuild.1"
 """Amazon FSx CSI Driver — mounts FSx for Lustre file systems as Kubernetes persistent volumes."""
 
 # ---------------------------------------------------------------------------
+# EKS Cluster Subnet Constraints
+# ---------------------------------------------------------------------------
+# A few Availability Zones cannot host the subnets you pass when creating an
+# EKS cluster (the control-plane elastic network interfaces). EKS rejects
+# cluster creation if any supplied subnet is in one of these zones. The
+# constraint is published by *Availability Zone ID* (e.g. ``use1-az3``), which
+# is stable across accounts — unlike the AZ *name* (``us-east-1e``), which AWS
+# randomizes per account. Match by ID, then resolve to this account's names.
+# Source: https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html
+# ("Subnet requirements for clusters" — disallowed Availability Zone IDs).
+
+EKS_UNSUPPORTED_AZ_IDS: dict[str, tuple[str, ...]] = {
+    "us-east-1": ("use1-az3",),
+    "us-west-1": ("usw1-az2",),
+    "ca-central-1": ("cac1-az3",),
+}
+"""AWS-region → Availability Zone IDs that cannot hold EKS cluster subnets.
+
+The regional VPC deliberately spans every AZ in the region (one public + one
+private subnet each), but the EKS cluster's control-plane subnet selection must
+exclude any subnet in these zones or ``CreateCluster`` fails with
+``InvalidParameterException``. Regions absent from this map have no such
+restriction. Keep in sync with the AWS EKS networking requirements doc.
+"""
+
+# ---------------------------------------------------------------------------
 # Aurora PostgreSQL Engine Version
 # ---------------------------------------------------------------------------
 # Pinned to a specific minor version. The dependency scanner checks

--- a/gco/stacks/global_stack.py
+++ b/gco/stacks/global_stack.py
@@ -1561,11 +1561,14 @@ class GCOGlobalStack(Stack):
         # ARN pattern (and to all ECR Describe/Read action wildcards in
         # the policy below) rather than a blanket ``Resource::*`` bypass.
         #
-        # ``self.account`` resolves to the unresolved CDK token
-        # ``<AWS::AccountId>`` at synth time, which is the literal form
-        # cdk-nag uses when it reports the finding's ``finding_id``. The
-        # ``appliesTo`` value below has to match that literal form exactly,
-        # so we hard-code the token rather than interpolating ``self.account``.
+        # cdk-nag reports this finding's account as the ``<AWS::AccountId>``
+        # placeholder for an environment-agnostic synth, but as the concrete
+        # account id for an environment-specific one (the ARN above is
+        # hand-built from ``self.account``, which becomes a literal once the
+        # stack has a resolved account). We author the ``appliesTo`` with the
+        # placeholder; ``acknowledge_nag_findings`` additionally registers the
+        # concrete-account rendering when the account is resolved, so the
+        # acknowledgment matches in both cases.
         from gco.stacks.nag_suppressions import acknowledge_nag_findings
 
         acknowledge_nag_findings(

--- a/gco/stacks/nag_suppressions.py
+++ b/gco/stacks/nag_suppressions.py
@@ -138,31 +138,46 @@ def acknowledge_nag_findings(
     acknowledgment on a stack covers all resources in that stack, and one on a
     role covers the role's generated policies.
     """
-    # cdk-nag renders CloudFormation pseudo-parameters in finding details as
-    # literals (``<AWS::Region>``, ``<AWS::AccountId>``). A detail built with
-    # this stack's region/account *token* must be normalized to that literal
-    # form: the finding id is used as a metadata *map key*, and an unresolved
-    # token in a key makes CloudFormation synthesis fail with
-    # ``KeyMustResolveToString``. When the stack has a concrete env the
-    # region/account are not tokens, so nothing is rewritten and the detail
-    # still matches the concrete finding cdk-nag emits.
+    # cdk-nag renders the CloudFormation account/region pseudo-parameters in a
+    # finding's detail two different ways, and which one appears is decided
+    # per-ARN, not per-stack:
+    #   * an ARN built from an ``Aws.ACCOUNT_ID`` / ``Aws.REGION`` pseudo-param
+    #     always renders as the angle-bracket literal ``<AWS::AccountId>`` /
+    #     ``<AWS::Region>`` (CloudFormation resolves the pseudo-param at deploy,
+    #     never at synth), whereas
+    #   * an ARN hand-built from ``stack.account`` / ``stack.region`` renders as
+    #     the *concrete* value when the stack is environment-specific, and as
+    #     the pseudo-param literal when it is environment-agnostic.
+    # So for a concrete env we can't know from here which form cdk-nag will
+    # emit for any given finding. We therefore register the acknowledgment
+    # under BOTH the placeholder detail and its literal rendering; extra keys
+    # that match no finding are harmless, and whichever form cdk-nag emits then
+    # has a matching acknowledgment. A detail we ourselves built from a region/
+    # account *token* is first normalized to the placeholder form — a raw token
+    # can't be used as a metadata-map key (synth fails with
+    # ``KeyMustResolveToString``).
     stack = Stack.of(scope)
-    token_literals: list[tuple[str, str]] = []
-    if Token.is_unresolved(stack.region):
-        token_literals.append((stack.region, "<AWS::Region>"))
-    if Token.is_unresolved(stack.account):
-        token_literals.append((stack.account, "<AWS::AccountId>"))
 
-    def _key_for(rule_id: str, detail: str) -> str:
-        for token_str, literal in token_literals:
-            detail = detail.replace(token_str, literal)
+    def _keys_for(rule_id: str, detail: str) -> list[str]:
+        if Token.is_unresolved(stack.region):
+            detail = detail.replace(stack.region, "<AWS::Region>")
+        if Token.is_unresolved(stack.account):
+            detail = detail.replace(stack.account, "<AWS::AccountId>")
         if Token.is_unresolved(detail):
             raise ValueError(
                 "cdk-nag acknowledgment detail contains an unresolved token and "
                 f"cannot be used as a metadata key: {detail!r}. Use cdk-nag's "
                 "literal rendering (e.g. '<AWS::Region>', '<LogicalId.Arn>') instead."
             )
-        return f"{rule_id}[{detail}]"
+        # Expand the placeholder detail into every form cdk-nag might emit: for
+        # each concrete env dimension, add a variant with the pseudo-param
+        # placeholder swapped for its literal value.
+        variants = {detail}
+        if not Token.is_unresolved(stack.account):
+            variants.update(v.replace("<AWS::AccountId>", stack.account) for v in list(variants))
+        if not Token.is_unresolved(stack.region):
+            variants.update(v.replace("<AWS::Region>", stack.region) for v in list(variants))
+        return [f"{rule_id}[{v}]" for v in variants]
 
     ack: dict[str, str] = {}
     for supp in suppressions:
@@ -170,7 +185,8 @@ def acknowledge_nag_findings(
         if not details:
             ack[rule_id] = reason
         for detail in details:
-            ack[_key_for(rule_id, detail)] = reason
+            for key in _keys_for(rule_id, detail):
+                ack[key] = reason
     if ack:
         scope.node.add_metadata(_ACK_METADATA_KEY, ack)
 

--- a/gco/stacks/regional_stack.py
+++ b/gco/stacks/regional_stack.py
@@ -323,7 +323,7 @@ class GCORegionalStack(Stack):
             self,
             "GCOVpc",
             # vpc_name intentionally omitted - let CDK generate unique name
-            max_azs=99,  # one subnet per AZ across all AZs in the region
+            max_azs=99,  # use every AZ in the region (each AZ gets 1 public + 1 private subnet)
             nat_gateways=2,  # For high availability
             subnet_configuration=[
                 ec2.SubnetConfiguration(

--- a/gco/stacks/regional_stack.py
+++ b/gco/stacks/regional_stack.py
@@ -7,7 +7,7 @@ in cdk.json.
 
 Resources Created:
     VPC & Networking:
-        - VPC with 3 AZs, public subnets (ALB), private subnets (EKS nodes)
+        - VPC spanning every AZ in the region, public subnets (ALB), private subnets (EKS nodes)
         - 2 NAT Gateways for high availability
         - VPC endpoints for ECR, S3, STS, Secrets Manager, SSM, CloudWatch
         - VPC Flow Logs (CloudWatch Logs, 30-day retention)
@@ -309,12 +309,21 @@ class GCORegionalStack(Stack):
         cluster_config = self.config.get_cluster_config(region)
         self.cluster_config = cluster_config
 
-        # Create VPC for the EKS cluster
+        # Create VPC for the EKS cluster.
+        #
+        # ``max_azs=99`` is the CDK idiom for "span every Availability Zone the
+        # region offers" — CDK caps the value at the number of AZs actually
+        # returned for this account+region, so each AZ gets one public and one
+        # private subnet. This only enumerates the *real* AZ list when the stack
+        # is environment-specific (account + region both resolved); app.py sets
+        # the account from CDK_DEFAULT_ACCOUNT for exactly this reason. In an
+        # environment-agnostic synth (no account, e.g. some CI paths) CDK falls
+        # back to a fixed placeholder AZ list rather than the full set.
         self.vpc = ec2.Vpc(
             self,
             "GCOVpc",
             # vpc_name intentionally omitted - let CDK generate unique name
-            max_azs=3,
+            max_azs=99,  # one subnet per AZ across all AZs in the region
             nat_gateways=2,  # For high availability
             subnet_configuration=[
                 ec2.SubnetConfiguration(

--- a/gco/stacks/regional_stack.py
+++ b/gco/stacks/regional_stack.py
@@ -61,6 +61,7 @@ Modification Guide:
 
 from __future__ import annotations
 
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -109,6 +110,7 @@ from gco.stacks.constants import (
     EKS_ADDON_FSX_CSI_DRIVER,
     EKS_ADDON_METRICS_SERVER,
     EKS_ADDON_POD_IDENTITY_AGENT,
+    EKS_UNSUPPORTED_AZ_IDS,
     LAMBDA_PYTHON_RUNTIME,
     MOONCAKE_MASTER_DEFAULT_IMAGE,
     REGIONAL_SHARED_BUCKET_NAME_PREFIX,
@@ -775,6 +777,71 @@ class GCORegionalStack(Stack):
                 description="Queue Processor Docker image URI",
             )
 
+    def _resolve_unsupported_az_names(self) -> list[str]:
+        """Resolve this region's EKS-unsupported AZ *IDs* to this account's AZ *names*.
+
+        EKS rejects cluster subnets in a small set of Availability Zones,
+        published by AZ ID (``EKS_UNSUPPORTED_AZ_IDS``). AZ *names* are
+        randomized per account, so the disallowed ``use1-az3`` may be
+        ``us-east-1e`` in one account and a different name in another — we must
+        map ID -> name for the deploy account.
+
+        Returns an empty list when the region has no restriction (the common
+        case), when the deploy account is not resolved (environment-agnostic
+        synth in CI/unit tests never sets ``CDK_DEFAULT_ACCOUNT``, and CDK uses
+        placeholder AZs that never include a real restricted zone), or when the
+        EC2 lookup fails. In every one of those cases the caller falls back to
+        selecting all private subnets, matching the pre-existing behavior.
+        """
+        unsupported_ids = EKS_UNSUPPORTED_AZ_IDS.get(self.deployment_region, ())
+        if not unsupported_ids:
+            return []
+        # Only reach EC2 during a credentialed, environment-specific synth or
+        # deploy. The CDK CLI exports CDK_DEFAULT_ACCOUNT from the active
+        # identity; unit tests and agnostic synth don't, so we never call AWS
+        # (nor block synthesis on missing credentials) there.
+        if not os.environ.get("CDK_DEFAULT_ACCOUNT"):
+            return []
+        try:
+            import boto3
+            from botocore.config import Config
+
+            ec2_client = boto3.client(
+                "ec2",
+                region_name=self.deployment_region,
+                config=Config(connect_timeout=5, read_timeout=5, retries={"max_attempts": 2}),
+            )
+            response = ec2_client.describe_availability_zones(
+                Filters=[{"Name": "zone-id", "Values": list(unsupported_ids)}]
+            )
+            return [zone["ZoneName"] for zone in response.get("AvailabilityZones", [])]
+        except Exception:
+            # No credentials / throttling / API error: fall back to no filtering
+            # rather than break synthesis.
+            return []
+
+    def _eks_control_plane_subnets(self) -> ec2.SubnetSelection:
+        """Private-subnet selection for the EKS control plane, excluding any AZ
+        EKS does not support for cluster subnets.
+
+        Records the outcome on ``self`` (``eks_unsupported_az_names`` and
+        ``eks_control_plane_subnets``) so tests and operators can introspect
+        exactly which subnets the cluster was given.
+        """
+        unsupported = set(self._resolve_unsupported_az_names())
+        usable = [
+            subnet
+            for subnet in self.vpc.private_subnets
+            if subnet.availability_zone not in unsupported
+        ]
+        self.eks_unsupported_az_names = sorted(unsupported)
+        self.eks_control_plane_subnets = usable
+        if not unsupported:
+            # No restricted AZ in this region: keep the subnet-type selection so
+            # the synthesized template is identical to before for the common case.
+            return ec2.SubnetSelection(subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS)
+        return ec2.SubnetSelection(subnets=usable)
+
     def _create_eks_cluster(self, cluster_config: Any) -> None:
         """Create the EKS cluster with auto mode and GPU node groups"""
 
@@ -852,7 +919,11 @@ class GCORegionalStack(Stack):
             #   Allows direct kubectl access but less secure
             endpoint_access=endpoint_access,
             role=cluster_admin_role,
-            vpc_subnets=[ec2.SubnetSelection(subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS)],
+            # The VPC spans every AZ, but EKS refuses control-plane subnets in a
+            # few AZs (by stable AZ ID; see EKS_UNSUPPORTED_AZ_IDS). Select the
+            # private subnets in supported AZs only — worker/other subnets in the
+            # excluded AZs still exist in the VPC.
+            vpc_subnets=[self._eks_control_plane_subnets()],
             # Enable all control plane logging for security and compliance
             cluster_logging=[
                 eks.ClusterLoggingTypes.API,

--- a/tests/test_nag_compliance.py
+++ b/tests/test_nag_compliance.py
@@ -144,13 +144,24 @@ def _format_violations(findings: list[dict[str, Any]]) -> str:
     return "\n".join(lines) if lines else "(no findings)"
 
 
-def _build_all_stacks(app: cdk.App) -> None:
+def _build_all_stacks(app: cdk.App, account: str | None = None) -> None:
     """Instantiate every stack ``app.py`` builds: global, API gateway,
     one regional stack per configured region, monitoring, and — when
     ``analytics_environment.enabled=true`` — the optional
     ``GCOAnalyticsStack``. Matches ``app.py::main`` one-for-one so the
     cdk-nag findings captured here are the same ones a
     ``cdk deploy --all`` would surface.
+
+    Args:
+        app: the CDK app to attach the stacks to.
+        account: when provided, every stack is created with a concrete
+            ``env`` account (mirroring ``app.py`` resolving
+            ``CDK_DEFAULT_ACCOUNT`` at deploy time). This flips the
+            account from the ``<AWS::AccountId>`` pseudo-parameter to a
+            literal in synthesized ARNs, which is the exact rendering
+            that a ``cdk deploy`` performs and that agnostic-only synth
+            never exercises. Leave ``None`` for the environment-agnostic
+            case.
 
     The heavy per-stack mocks (Docker asset + helm installer) are
     applied with ``patch.object`` inside the caller's ``with`` block;
@@ -179,14 +190,14 @@ def _build_all_stacks(app: cdk.App) -> None:
         app,
         f"{project_name}-global",
         config=config,
-        env=cdk.Environment(region=global_region),
+        env=cdk.Environment(account=account, region=global_region),
     )
 
     api_gateway_stack = GCOApiGatewayGlobalStack(
         app,
         f"{project_name}-api-gateway",
         global_accelerator_dns=global_stack.accelerator.dns_name,
-        env=cdk.Environment(region=api_gateway_region),
+        env=cdk.Environment(account=account, region=api_gateway_region),
     )
     api_gateway_stack.add_dependency(global_stack)
 
@@ -198,7 +209,7 @@ def _build_all_stacks(app: cdk.App) -> None:
             config=config,
             region=region,
             auth_secret_arn=api_gateway_stack.secret.secret_arn,
-            env=cdk.Environment(region=region),
+            env=cdk.Environment(account=account, region=region),
         )
         regional_stack.add_dependency(global_stack)
         regional_stack.add_dependency(api_gateway_stack)
@@ -212,7 +223,7 @@ def _build_all_stacks(app: cdk.App) -> None:
         global_stack=global_stack,
         regional_stacks=regional_stacks,
         api_gateway_stack=api_gateway_stack,
-        env=cdk.Environment(region=monitoring_region),
+        env=cdk.Environment(account=account, region=monitoring_region),
     )
     for regional_stack in regional_stacks:
         monitoring_stack.add_dependency(regional_stack)
@@ -227,7 +238,7 @@ def _build_all_stacks(app: cdk.App) -> None:
             app,
             f"{project_name}-analytics",
             config=config,
-            env=cdk.Environment(region=api_gateway_region),
+            env=cdk.Environment(account=account, region=api_gateway_region),
             description=(
                 "Optional ML and analytics environment (SageMaker Studio, EMR Serverless, Cognito)"
             ),
@@ -318,4 +329,56 @@ class TestCdkNagCompliance:
             f"specific resource. Do NOT add broad ``Resource::*`` or "
             f"``Action::*`` entries — those defeat the whole point of "
             f"cdk-nag."
+        )
+
+    # An obviously-fake 12-digit account used only to force
+    # environment-specific synthesis. It never reaches AWS — it just makes CDK
+    # render account-bearing ARNs as a literal instead of the <AWS::AccountId>
+    # pseudo-parameter.
+    _CONCRETE_ACCOUNT = "123456789012"
+
+    def test_no_unsuppressed_findings_with_concrete_account(self) -> None:
+        """The full app must also synthesize with zero unacknowledged cdk-nag
+        findings when the stacks are environment-specific (a concrete ``env``
+        account).
+
+        ``app.py`` resolves ``CDK_DEFAULT_ACCOUNT`` into every stack's ``env``
+        so the regional VPC can enumerate the region's real AZ list. That flips
+        account-bearing ARNs from the ``<AWS::AccountId>`` pseudo-parameter to a
+        literal — exactly the rendering a ``cdk deploy`` uses, and one the
+        agnostic ``test_no_unsuppressed_findings`` parametrization never
+        exercises. This is the regression guard for suppressions whose
+        ``applies_to`` previously matched only the pseudo-parameter form (see
+        ``acknowledge_nag_findings`` in ``gco/stacks/nag_suppressions.py``). The
+        account rendering is config-independent, so the default config suffices.
+        """
+        from gco.stacks.regional_stack import GCORegionalStack
+
+        app = _build_app()
+
+        with (
+            patch("gco.stacks.regional_stack.ecr_assets.DockerImageAsset") as mock_docker,
+            patch.object(
+                GCORegionalStack,
+                "_create_helm_installer_lambda",
+                _mock_helm_installer,
+            ),
+        ):
+            mock_image = MagicMock()
+            mock_image.image_uri = "123456789012.dkr.ecr.us-east-1.amazonaws.com/test:latest"
+            mock_docker.return_value = mock_image
+
+            _build_all_stacks(app, account=self._CONCRETE_ACCOUNT)
+            app.synth()
+
+        findings = _collect_nag_violations(app)
+        assert not findings, (
+            f"cdk-nag found {len(findings)} unacknowledged finding(s) when synthesizing with "
+            f"a concrete env account ({self._CONCRETE_ACCOUNT}).\n\n"
+            f"{_format_violations(findings)}\n\n"
+            f"These do NOT appear in the environment-agnostic matrix because account-bearing "
+            f"ARNs render as the <AWS::AccountId> pseudo-parameter there, but as a literal "
+            f"account id under a real ``cdk deploy``. Fix by making the acknowledgment's "
+            f"applies_to match both renderings — ``acknowledge_nag_findings`` registers both "
+            f"forms when the stack account is concrete."
         )

--- a/tests/test_regional_stack.py
+++ b/tests/test_regional_stack.py
@@ -2378,3 +2378,134 @@ class TestRegionalStackVolcanoImageMirror:
         app = self._enabled_app(ecr_namespace="gco/Bad_Seg!")
         with pytest.raises(ValueError, match="ecr_namespace"):
             self._build(app)
+
+
+class TestRegionalStackEksControlPlaneAzExclusion:
+    """EKS control-plane subnets must exclude AZs EKS does not support.
+
+    Regression guard for the all-AZ VPC change (max_azs=99): the VPC spans every
+    Availability Zone, but EKS refuses to create a cluster whose subnets land in
+    a disallowed AZ (published by *AZ ID* — e.g. ``use1-az3`` in us-east-1). A
+    real ``deploy-all`` fails at ``CreateCluster`` if such a subnet is passed, so
+    ``_eks_control_plane_subnets`` filters them out while leaving the subnet in
+    the VPC for worker/other use.
+
+    ``_resolve_unsupported_az_names`` (which does a credentialed EC2 AZ-ID -> name
+    lookup) is patched here so the test is fully hermetic — it never calls AWS.
+    """
+
+    _SIX_AZS = [f"us-east-1{s}" for s in "abcdef"]
+
+    @staticmethod
+    def _mock_helm_installer(stack):
+        stack.helm_installer_lambda = MagicMock()
+        stack.helm_installer_provider = MagicMock()
+        stack.helm_installer_provider.service_token = (
+            "arn:aws:lambda:us-east-1:123456789012:function:mock"  # nosec B106 - test fixture ARN
+        )
+
+    def _build(self, unsupported_names):
+        from gco.stacks.regional_stack import GCORegionalStack
+
+        # Seed the availability-zones context so the VPC spans all six us-east-1
+        # AZs with concrete names (mirrors what a real credentialed synth caches).
+        app = cdk.App(
+            context={
+                "availability-zones:account=123456789012:region=us-east-1": self._SIX_AZS,
+            }
+        )
+        with (
+            patch("gco.stacks.regional_stack.ecr_assets.DockerImageAsset") as mock_docker,
+            patch.object(
+                GCORegionalStack,
+                "_create_helm_installer_lambda",
+                TestRegionalStackEksControlPlaneAzExclusion._mock_helm_installer,
+            ),
+            patch.object(
+                GCORegionalStack,
+                "_resolve_unsupported_az_names",
+                return_value=unsupported_names,
+            ),
+        ):
+            mock_docker.return_value.image_uri = (
+                "123456789012.dkr.ecr.us-east-1.amazonaws.com/test:latest"
+            )
+            return GCORegionalStack(
+                app,
+                "test-regional-eks-az",
+                config=MockConfigLoader(app),
+                region="us-east-1",
+                auth_secret_arn="arn:aws:secretsmanager:us-east-1:123456789012:secret:test",  # nosec B106
+                env=cdk.Environment(account="123456789012", region="us-east-1"),
+            )
+
+    def test_control_plane_excludes_unsupported_az(self):
+        """When an AZ is unsupported (use1-az3 -> us-east-1e here), the EKS
+        control-plane subnets drop it but the VPC keeps a subnet in every AZ."""
+        stack = self._build(["us-east-1e"])
+
+        control_plane_azs = {s.availability_zone for s in stack.eks_control_plane_subnets}
+        assert "us-east-1e" not in control_plane_azs
+        assert control_plane_azs == {
+            "us-east-1a",
+            "us-east-1b",
+            "us-east-1c",
+            "us-east-1d",
+            "us-east-1f",
+        }
+
+        # The VPC itself still spans all six AZs — "a subnet in every AZ" holds.
+        vpc_azs = {s.availability_zone for s in stack.vpc.private_subnets}
+        assert vpc_azs == set(self._SIX_AZS)
+
+    def test_no_restriction_keeps_all_private_subnets(self):
+        """Regions without a restriction (empty resolver result) hand the EKS
+        control plane every private subnet, unchanged from before."""
+        stack = self._build([])
+
+        control_plane_azs = {s.availability_zone for s in stack.eks_control_plane_subnets}
+        assert control_plane_azs == set(self._SIX_AZS)
+        assert stack.eks_unsupported_az_names == []
+
+    def test_resolver_no_ec2_call_without_account_env(self, monkeypatch):
+        """``_resolve_unsupported_az_names`` must not touch AWS when the deploy
+        account isn't resolved (the unit-test / agnostic-synth case): no
+        ``CDK_DEFAULT_ACCOUNT`` => empty result, no EC2 client constructed."""
+        from gco.stacks import regional_stack as rs
+
+        monkeypatch.delenv("CDK_DEFAULT_ACCOUNT", raising=False)
+
+        def _boom(*args, **kwargs):  # pragma: no cover - must never run
+            raise AssertionError("boto3 must not be called without CDK_DEFAULT_ACCOUNT")
+
+        # Build a stack (region us-east-1 has a restriction) with the resolver
+        # UNpatched; the env guard alone must keep it from calling boto3.
+        app = cdk.App(
+            context={
+                "availability-zones:account=123456789012:region=us-east-1": self._SIX_AZS,
+            }
+        )
+        with (
+            patch("gco.stacks.regional_stack.ecr_assets.DockerImageAsset") as mock_docker,
+            patch.object(
+                rs.GCORegionalStack,
+                "_create_helm_installer_lambda",
+                TestRegionalStackEksControlPlaneAzExclusion._mock_helm_installer,
+            ),
+            patch("boto3.client", _boom),
+        ):
+            mock_docker.return_value.image_uri = (
+                "123456789012.dkr.ecr.us-east-1.amazonaws.com/test:latest"
+            )
+            stack = rs.GCORegionalStack(
+                app,
+                "test-regional-eks-az-guard",
+                config=MockConfigLoader(app),
+                region="us-east-1",
+                auth_secret_arn="arn:aws:secretsmanager:us-east-1:123456789012:secret:test",  # nosec B106
+                env=cdk.Environment(account="123456789012", region="us-east-1"),
+            )
+
+        # No credentials env => no filtering => control plane uses all private subnets.
+        assert stack.eks_unsupported_az_names == []
+        assert {s.availability_zone for s in stack.eks_control_plane_subnets} == set(self._SIX_AZS)


### PR DESCRIPTION
Regional cluster VPCs used max_azs=3, but the stacks were environment-agnostic (env=Environment(region=...) with no account), so CDK could not enumerate the region's real AZs and fell back to 2 AZs at synth time. Clusters therefore only ever got subnets in 2 AZs.

- app.py: resolve the account from CDK_DEFAULT_ACCOUNT and pass it into every stack's env, making them environment-specific so CDK's availability-zones context provider returns the real AZ list. No-op when the var is unset (agnostic synth in CI), so existing behavior is preserved there.

- regional_stack.py: raise the VPC max_azs to 99 (CDK idiom for 'every available AZ'), so each AZ gets one public and one private subnet. In us-east-1 this yields 12 subnets across 6 AZs instead of 4.

<!--
Thanks for contributing to Global Capacity Orchestrator (GCO)! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [x] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [x] `pytest tests/` passes locally
- [x] `cdk synth` succeeds (if CDK code changed)
- [x] New tests added for new behavior
- [x] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [x] Documentation updated (README, `docs/`, inline docstrings) as needed
- [x] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [x] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
