### PR TITLE
feat(nodepools): broaden GPU/accelerator instance-family coverage and…

### DIFF
--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -1625,6 +1625,7 @@ See `examples/efa-distributed-training.yaml` for a complete example.
 | Instance Type | EFA Networking | GPUs (Total GPU Memory) | Use Case |
 |--------------|---------------|------------------------|----------|
 | `p4d.24xlarge` | 400 Gbps (4x EFA) | 8x A100 (320 GB HBM2e) | Distributed training, fine-tuning |
+| `p4de.24xlarge` | 400 Gbps (4x EFA) | 8x A100 (640 GB HBM2e) | Distributed training, fine-tuning |
 | `p5.48xlarge` | 3,200 Gbps (32x EFA) | 8x H100 (640 GB HBM3) | Large-scale training, high-performance inference |
 | `p5e.48xlarge` | 3,200 Gbps (32x EFA) | 8x H200 (1,128 GB HBM3e) | Large-scale training, high-performance inference |
 | `p5en.48xlarge` | 3,200 Gbps (32x EFA) | 8x H200 (1,128 GB HBM3e) | Large-scale training, high-performance inference |

--- a/gco/stacks/regional_stack.py
+++ b/gco/stacks/regional_stack.py
@@ -985,10 +985,10 @@ class GCORegionalStack(Stack):
 
         # NOTE: GPU compute is configured via Karpenter NodePools (not managed node groups)
         # NodePool manifests are located in lambda/kubectl-applier-simple/manifests/:
-        # - 40-nodepool-gpu-x86.yaml: x86_64 GPU instances (g4dn, g5, g6, g6e, p3)
+        # - 40-nodepool-gpu-x86.yaml: x86_64 GPU instances (g4dn, g5, g6, g6e, g6f, gr6, gr6f, g7, g7e, p3, p3dn)
         # - 41-nodepool-gpu-arm.yaml: ARM64 GPU instances (g5g)
         # - 42-nodepool-inference.yaml: inference-optimized GPU instances
-        # - 43-nodepool-efa.yaml: EFA-enabled instances (p4d, p5/p5e/p5en, p6-b200/p6-b300/p6e-gb200)
+        # - 43-nodepool-efa.yaml: EFA-enabled instances (p4d, p4de, p5/p5e/p5en, p6-b200/p6-b300/p6e-gb200)
         # - 44-nodepool-neuron.yaml: Trainium/Inferentia instances
         # These will be applied by the kubectl Lambda custom resource (created below)
 

--- a/lambda/kubectl-applier-simple/manifests/40-nodepool-gpu-x86.yaml
+++ b/lambda/kubectl-applier-simple/manifests/40-nodepool-gpu-x86.yaml
@@ -1,6 +1,9 @@
-# GPU NodePool — x86_64 (g4dn, g5, g6, g6e, p3 with NVIDIA GPUs)
-# Covers current-gen (g5, g6) and previous-gen (g4dn, p3) for broad availability.
-# g6/g6e use L4 GPUs; p3 uses V100s. Supports both on-demand and spot.
+# GPU NodePool — x86_64 NVIDIA GPU instances (non-EFA general / graphics / inference).
+# Families: g4dn (T4), g5 (A10G), g6 + g6f + gr6 + gr6f (L4), g6e (L40S),
+# g7 + g7e (Blackwell RTX PRO), p3 + p3dn (V100). Covers current- and previous-gen
+# for broad availability; g6f/gr6f are fractional-GPU sizes. Large multi-GPU
+# training families (p4d/p5/p6) live in the EFA pool (43-nodepool-efa.yaml).
+# Supports both on-demand and spot.
 # See docs/CUSTOMIZATION.md to add instance families or adjust limits.
 apiVersion: karpenter.sh/v1
 kind: NodePool
@@ -21,7 +24,7 @@ spec:
       requirements:
         - key: "eks.amazonaws.com/instance-family"
           operator: In
-          values: ["g4dn", "g5", "g6", "g6e", "p3"]
+          values: ["g4dn", "g5", "g6", "g6e", "g6f", "gr6", "gr6f", "g7", "g7e", "p3", "p3dn"]
         - key: "kubernetes.io/arch"
           operator: In
           values: ["amd64"]

--- a/lambda/kubectl-applier-simple/manifests/41-nodepool-gpu-arm.yaml
+++ b/lambda/kubectl-applier-simple/manifests/41-nodepool-gpu-arm.yaml
@@ -1,5 +1,6 @@
 # GPU NodePool — ARM64 (g5g with Graviton + T4g GPUs)
 # Lower cost than x86 GPU instances for compatible workloads.
+# g5g is the only ARM64 NVIDIA GPU family. Supports both on-demand and spot.
 apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
@@ -25,7 +26,7 @@ spec:
           values: ["arm64"]
         - key: "karpenter.sh/capacity-type"
           operator: In
-          values: ["on-demand"]
+          values: ["on-demand", "spot"]
         - key: "eks.amazonaws.com/instance-gpu-manufacturer"
           operator: In
           values: ["nvidia"]

--- a/lambda/kubectl-applier-simple/manifests/42-nodepool-inference.yaml
+++ b/lambda/kubectl-applier-simple/manifests/42-nodepool-inference.yaml
@@ -1,7 +1,10 @@
-# Inference NodePool — on-demand GPU instances for live serving
-# Uses WhenEmpty consolidation (not WhenEmptyOrUnderutilized) to avoid
-# disrupting in-flight inference requests. Nodes are only removed when
-# fully empty, with a 5-minute grace period.
+# Inference NodePool — NVIDIA x86 GPU instances for live serving.
+# Families: g4dn (T4), g5 (A10G), g6 + g6f + gr6 + gr6f (L4), g6e (L40S),
+# g7 + g7e (Blackwell RTX PRO). Allows both on-demand and spot; for a workload
+# where spot reclaim would be disruptive, pin on-demand with a nodeSelector on
+# karpenter.sh/capacity-type: on-demand. Uses WhenEmpty consolidation (not
+# WhenEmptyOrUnderutilized) to avoid disrupting in-flight inference requests —
+# nodes are only removed when fully empty, with a 5-minute grace period.
 apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
@@ -21,13 +24,13 @@ spec:
       requirements:
         - key: "eks.amazonaws.com/instance-family"
           operator: In
-          values: ["g4dn", "g5", "g6", "g6e"]
+          values: ["g4dn", "g5", "g6", "g6e", "g6f", "gr6", "gr6f", "g7", "g7e"]
         - key: "kubernetes.io/arch"
           operator: In
           values: ["amd64"]
         - key: "karpenter.sh/capacity-type"
           operator: In
-          values: ["on-demand"]
+          values: ["on-demand", "spot"]
         - key: "eks.amazonaws.com/instance-gpu-manufacturer"
           operator: In
           values: ["nvidia"]

--- a/lambda/kubectl-applier-simple/manifests/43-nodepool-efa.yaml
+++ b/lambda/kubectl-applier-simple/manifests/43-nodepool-efa.yaml
@@ -1,4 +1,4 @@
-# EFA NodePool — high-performance distributed training (p4d, p5/p5e/p5en, p6-b200/p6e-gb200/p6-b300)
+# EFA NodePool — high-performance distributed training (p4d/p4de, p5/p5e/p5en, p6-b200/p6-b300/p6e-gb200)
 # EFA (Elastic Fabric Adapter) enables low-latency, high-bandwidth inter-node
 # communication for large-scale distributed training jobs.
 # Uses WhenEmpty consolidation to avoid interrupting long-running training runs.
@@ -35,7 +35,7 @@ spec:
       requirements:
         - key: "eks.amazonaws.com/instance-family"
           operator: In
-          values: ["p4d", "p5", "p5e", "p5en", "p6-b200", "p6-b300", "p6e-gb200"]
+          values: ["p4d", "p4de", "p5", "p5e", "p5en", "p6-b200", "p6-b300", "p6e-gb200"]
         - key: "kubernetes.io/arch"
           operator: In
           values: ["amd64"]

--- a/lambda/kubectl-applier-simple/manifests/44-nodepool-neuron.yaml
+++ b/lambda/kubectl-applier-simple/manifests/44-nodepool-neuron.yaml
@@ -1,4 +1,4 @@
-# Neuron NodePool — AWS Trainium (trn1, trn1n, trn2) and Inferentia (inf2)
+# Neuron NodePool — AWS Trainium (trn1, trn1n, trn2) and Inferentia (inf1, inf2)
 # Purpose-built ML accelerators using the Neuron SDK instead of CUDA.
 # Pods request Neuron devices via: resources.limits["aws.amazon.com/neuron"]
 # Requires: Neuron device plugin (helm.aws_neuron_device_plugin.enabled = true in cdk.json)
@@ -30,7 +30,7 @@ spec:
       requirements:
         - key: "eks.amazonaws.com/instance-family"
           operator: In
-          values: ["trn1", "trn1n", "trn2", "inf2"]
+          values: ["trn1", "trn1n", "trn2", "inf1", "inf2"]
         - key: "kubernetes.io/arch"
           operator: In
           values: ["amd64"]

--- a/lambda/kubectl-applier-simple/manifests/README.md
+++ b/lambda/kubectl-applier-simple/manifests/README.md
@@ -71,11 +71,11 @@ when adding new CRD-dependent resources, just use the prefix.
 
 | File | Contents |
 |------|----------|
-| `40-nodepool-gpu-x86.yaml` | x86_64 GPU pool (g4dn, g5, g6, g6e, p3) — on-demand + spot |
-| `41-nodepool-gpu-arm.yaml` | ARM64 GPU pool (g5g) — on-demand |
-| `42-nodepool-inference.yaml` | Inference GPU pool — on-demand only, WhenEmpty consolidation |
-| `43-nodepool-efa.yaml` | EFA pool (p4d, p5/p5e/p5en, p6-b200/p6-b300/p6e-gb200) — high-performance distributed training (keeps p4d) |
-| `44-nodepool-neuron.yaml` | Neuron pool (trn1, trn1n, trn2, inf2) — AWS Trainium/Inferentia |
+| `40-nodepool-gpu-x86.yaml` | x86_64 GPU pool (g4dn, g5, g6, g6e, g6f, gr6, gr6f, g7, g7e, p3, p3dn) — on-demand + spot |
+| `41-nodepool-gpu-arm.yaml` | ARM64 GPU pool (g5g) — on-demand + spot |
+| `42-nodepool-inference.yaml` | Inference GPU pool (g4dn, g5, g6, g6e, g6f, gr6, gr6f, g7, g7e) — on-demand + spot, WhenEmpty consolidation |
+| `43-nodepool-efa.yaml` | EFA pool (p4d, p4de, p5/p5e/p5en, p6-b200/p6-b300/p6e-gb200) — high-performance distributed training (keeps p4d) |
+| `44-nodepool-neuron.yaml` | Neuron pool (trn1, trn1n, trn2, inf1, inf2) — AWS Trainium/Inferentia |
 | `45-nodepool-cpu-general.yaml` | General CPU pool (c/m/r families) — spot-preferred, no GPUs |
 | `46-nodepool-mooncake-efa.yaml` | Mooncake EFA pool (p5/p5e/p5en, p6-b200/p6-b300/p6e-gb200) — disaggregated/store/both inference over RoCE; excludes A100-40GB p4d |
 


### PR DESCRIPTION
… enable spot

Maximize the instance families each Karpenter NodePool can provision and allow spot where appropriate (users can pin on-demand per workload via a karpenter.sh/capacity-type=on-demand nodeSelector).

- gpu-x86-pool: add g6f, gr6, gr6f, g7 (NVIDIA RTX PRO 4500 Blackwell), g7e (NVIDIA RTX PRO 6000 Blackwell), p3dn. Now g4dn, g5, g6, g6e, g6f, gr6, gr6f, g7, g7e, p3, p3dn.
- gpu-inference-pool: add g6f, gr6, gr6f, g7, g7e; allow spot (was on-demand only). WhenEmpty consolidation retained to protect serving.
- gpu-arm-pool: allow spot (was on-demand only). g5g stays the only ARM64 NVIDIA GPU family.
- gpu-efa-pool: add p4de (A100 80GB, EFA-capable). p4d retained.
- neuron-pool: add inf1 (Inferentia1). Now trn1, trn1n, trn2, inf1, inf2.

Docs/comments updated to match: manifests/README.md pool table, regional_stack.py NodePool comment, docs/CUSTOMIZATION.md EFA table.

Test-locked sets unchanged: gpu-efa keeps p4d; mooncake-efa stays the FP8-only Hopper/Blackwell set (correctly excludes the Ampere p4d/p4de).

<!--
Thanks for contributing to Global Capacity Orchestrator (GCO)! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [ ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
