### PR TITLE
fix: deregister ALB from Global Accelerator on stack destroy (#130)

### DIFF
--- a/gco/stacks/nag_suppressions.py
+++ b/gco/stacks/nag_suppressions.py
@@ -472,9 +472,20 @@ def add_iam_suppressions(
 
     # Build dynamic applies_to list based on configured regions
     applies_to = [
+        # The convergence Step Functions state machine's role invokes each
+        # Lambda task's versions — CDK's LambdaInvoke grants `<fn>.Arn:*` for
+        # the version/alias qualifier, which is what these `:*` findings flag.
+        # kubectl-applier: the base and post-Helm manifest passes.
         "Resource::<KubectlApplierFunction6147DA0C.Arn>:*",
+        # GA-registration: the final Global Accelerator registration task.
         "Resource::<GaRegistrationFunction4A12C41B.Arn>:*",
+        # Delete-time GA deregistration guard (issue #130): its cr.Provider
+        # framework-onEvent role invokes the deregistration Lambda's versions.
+        "Resource::<GaDeregistrationFunction5CFAADA4.Arn>:*",
+        # helm-installer: one task per Helm chart.
         "Resource::<HelmInstallerFunction3FEB04EF.Arn>:*",
+        # VPC Flow Logs delivery role writes log events to every stream in the
+        # flow-log group (logs:CreateLogStream/PutLogEvents on `<group>.Arn:*`).
         "Resource::<VpcFlowLogGroup86559C69.Arn>:*",
         # Secrets Manager access for the API Gateway auth token, with a
         # trailing wildcard for the random 6-char suffix. The regional

--- a/gco/stacks/regional_stack.py
+++ b/gco/stacks/regional_stack.py
@@ -2811,6 +2811,115 @@ class GCORegionalStack(Stack):
             ],
         )
 
+        # Wire the delete-time teardown guard that deregisters this region's ALB
+        # from Global Accelerator before the VPC/public subnets are deleted.
+        self._create_ga_deregistration_resource()
+
+    def _create_ga_deregistration_resource(self) -> None:
+        """Deregister the region's ALB from Global Accelerator during teardown.
+
+        Registration is one-directional: the convergence state machine's final
+        task adds the Ingress-created ALB to the shared Global Accelerator
+        endpoint group at deploy time, but nothing removed it at destroy time.
+        When the regional stack is torn down the AWS Load Balancer Controller
+        deletes the ALB, yet the endpoint group still references the now-dangling
+        ALB ARN, so Global Accelerator keeps its ``global_accelerator_managed``
+        ENIs pinned in the VPC's public subnets. VPC subnet deletion then fails
+        and the stack is left in ``DELETE_FAILED`` (see issue #130).
+
+        This wires a dedicated, delete-only custom resource: a no-op on
+        create/update (registration stays owned by the state machine), and on
+        delete it removes the endpoint(s) and waits for the accelerator to
+        redeploy so Global Accelerator releases the ENIs. An explicit dependency
+        on the VPC makes CloudFormation run this deregistration BEFORE it deletes
+        the public subnets those ENIs occupy.
+        """
+        project_name = self.config.get_project_name()
+
+        # Dedicated Lambda built from the SAME asset as the registration Lambda
+        # (it reuses the shared remove/wait helpers, entry point
+        # handler.on_delete_event). Deliberately NOT in the VPC: it only calls
+        # the public Global Accelerator API and must not create its own ENIs in
+        # the VPC it is helping to tear down.
+        ga_deregistration_lambda = lambda_.Function(
+            self,
+            "GaDeregistrationFunction",
+            runtime=getattr(lambda_.Runtime, LAMBDA_PYTHON_RUNTIME),
+            handler="handler.on_delete_event",
+            code=lambda_.Code.from_asset("lambda/ga-registration"),
+            timeout=Duration.minutes(15),  # covers the GA redeploy wait budget
+            memory_size=256,
+            tracing=lambda_.Tracing.ACTIVE,
+        )
+        ga_deregistration_lambda.add_to_role_policy(
+            iam.PolicyStatement(
+                effect=iam.Effect.ALLOW,
+                actions=[
+                    "globalaccelerator:DescribeAccelerator",
+                    "globalaccelerator:DescribeEndpointGroup",
+                    "globalaccelerator:RemoveEndpoints",
+                ],
+                resources=["*"],
+            )
+        )
+
+        # Provider framework fronts the Lambda so CloudFormation invocation,
+        # response signalling and retries are handled for us. An explicit log
+        # group avoids the default LogRetention custom resource.
+        ga_deregistration_log_group = logs.LogGroup(
+            self,
+            "GaDeregistrationProviderLogGroup",
+            retention=logs.RetentionDays.ONE_WEEK,
+            removal_policy=RemovalPolicy.DESTROY,
+        )
+        ga_deregistration_provider = cr.Provider(
+            self,
+            "GaDeregistrationProvider",
+            on_event_handler=ga_deregistration_lambda,
+            log_group=ga_deregistration_log_group,
+        )
+
+        ga_deregistration = CustomResource(
+            self,
+            "GaDeregistration",
+            service_token=ga_deregistration_provider.service_token,
+            properties={
+                # Delete handler reads these from the resource's last-known
+                # properties (CloudFormation replays them on Delete).
+                "EndpointGroupArn": self.endpoint_group_arn,
+                "Region": self.deployment_region,
+                "ProjectName": project_name,
+            },
+        )
+
+        # Teardown ordering: this deregistration must run BEFORE the VPC (and its
+        # public subnets, where Global Accelerator pins its managed ENIs) is
+        # deleted. Depending on the VPC means CloudFormation creates the VPC
+        # first and — critically — deletes this custom resource first on
+        # teardown, releasing the GA ENIs so the subnets can be removed cleanly.
+        ga_deregistration.node.add_dependency(self.vpc)
+
+        # cdk-nag: the deregistration Lambda needs globalaccelerator Describe*/
+        # RemoveEndpoints with Resource: * (these Global Accelerator APIs do not
+        # support resource-level IAM scoping), mirroring the registration Lambda.
+        from gco.stacks.nag_suppressions import acknowledge_nag_findings
+
+        acknowledge_nag_findings(
+            ga_deregistration_lambda,
+            [
+                {
+                    "id": "AwsSolutions-IAM5",
+                    "reason": (
+                        "The GA deregistration Lambda needs globalaccelerator:Describe* "
+                        "and RemoveEndpoints to release the accelerator's managed ENIs "
+                        "during teardown. These APIs do not support resource-level IAM "
+                        "scoping — Resource: * is the only valid form."
+                    ),
+                    "appliesTo": ["Resource::*"],
+                },
+            ],
+        )
+
     def _get_volcano_image_mirror_config(self) -> dict[str, Any]:
         """Parse the ``volcano_image_mirror`` block from cdk.json.
 

--- a/gco/stacks/regional_stack.py
+++ b/gco/stacks/regional_stack.py
@@ -2857,7 +2857,13 @@ class GCORegionalStack(Stack):
                 actions=[
                     "globalaccelerator:DescribeAccelerator",
                     "globalaccelerator:DescribeEndpointGroup",
+                    # RemoveEndpoints is implemented as an endpoint-group update,
+                    # so the caller must ALSO hold globalaccelerator:UpdateEndpointGroup
+                    # — without it RemoveEndpoints fails with AccessDeniedException
+                    # and the ALB is never deregistered (matches the registration
+                    # Lambda's grant).
                     "globalaccelerator:RemoveEndpoints",
+                    "globalaccelerator:UpdateEndpointGroup",
                 ],
                 resources=["*"],
             )
@@ -2910,10 +2916,11 @@ class GCORegionalStack(Stack):
                 {
                     "id": "AwsSolutions-IAM5",
                     "reason": (
-                        "The GA deregistration Lambda needs globalaccelerator:Describe* "
-                        "and RemoveEndpoints to release the accelerator's managed ENIs "
-                        "during teardown. These APIs do not support resource-level IAM "
-                        "scoping — Resource: * is the only valid form."
+                        "The GA deregistration Lambda needs globalaccelerator:Describe*, "
+                        "RemoveEndpoints, and UpdateEndpointGroup (RemoveEndpoints is "
+                        "implemented as an endpoint-group update) to release the "
+                        "accelerator's managed ENIs during teardown. These APIs do not "
+                        "support resource-level IAM scoping — Resource: * is the only valid form."
                     ),
                     "appliesTo": ["Resource::*"],
                 },

--- a/lambda/ga-registration/handler.py
+++ b/lambda/ga-registration/handler.py
@@ -1,17 +1,38 @@
 """
-GA Registration Lambda Handler.
+GA Registration/Deregistration Lambda Handler.
 
-This Lambda registers the Ingress-created ALB with Global Accelerator.
+This Lambda owns both sides of the Ingress-created ALB's lifecycle with the
+shared Global Accelerator endpoint group. This is necessary because the ALB is
+created by the AWS Load Balancer Controller (not CDK), so CloudFormation can't
+directly reference its ARN.
 
-Workflow:
+Registration (deploy time):
     1. Waits for the ALB to be created and become active
     2. Uses multiple detection methods (tags, Ingress status, name prefix)
     3. Registers that ALB with Global Accelerator
     4. Stores the ALB hostname in SSM for cross-region aggregation
     5. Handles idempotency (won't fail if ALB already registered)
 
-This is necessary because the ALB is created by the AWS Load Balancer Controller
-(not CDK), so we can't directly reference its ARN.
+Deregistration (destroy time — issue #130):
+    Registration is one-directional, so without a teardown hook the endpoint
+    group keeps referencing the (LB-controller-deleted) ALB and Global
+    Accelerator keeps its `global_accelerator_managed` ENIs pinned in the VPC's
+    public subnets — blocking subnet deletion and leaving the stack in
+    DELETE_FAILED. On delete this Lambda removes the endpoint(s) from the group
+    and waits for the accelerator to redeploy (return to DEPLOYED), which is
+    when Global Accelerator releases those managed ENIs.
+
+Entrypoints (all share this module's helpers):
+    - `handle_task`: the convergence Step Functions state machine's final task
+      (register). Dispatched by `lambda_handler` when the event carries an
+      `Action` key.
+    - `lambda_handler`: legacy CloudFormation custom-resource path. Create/Update
+      register (`handle_create_update`); Delete deregisters and waits
+      (`handle_delete`). Responds via the CloudFormation ResponseURL protocol.
+    - `on_delete_event`: the delete-time deregistration guard, invoked through a
+      CDK `cr.Provider`. A no-op on Create/Update (registration stays owned by
+      the state machine); on Delete it deregisters and waits so the accelerator
+      releases its ENIs before CloudFormation deletes the public subnets.
 
 SSM Parameter Storage:
     The ALB hostname is stored in SSM Parameter Store at:
@@ -66,6 +87,16 @@ MAX_WAIT_SECONDS = 840  # 14 minutes total budget for finding active ALB
 ALB_POLL_INTERVAL = 5  # Poll every 5 seconds to detect ALB quickly
 ALB_DELETION_POLL_INTERVAL = 10  # 10 seconds for deletion polling
 ALB_DELETION_WAIT_SECONDS = 180  # 3 minutes for ALB deletion during cleanup
+
+# Global Accelerator redeploy budget for the delete-time deregistration guard.
+# After endpoints are removed, GA transitions the accelerator IN_PROGRESS ->
+# DEPLOYED and only releases its `global_accelerator_managed` ENIs once it is
+# back to DEPLOYED. Teardown must wait for that release before CloudFormation
+# deletes the public subnets those ENIs occupy (see issue #130). Kept under the
+# 14-minute ceiling recommended for cr.Provider onEvent handlers (all framework
+# functions time out at 15 minutes).
+GA_DEPLOYED_WAIT_SECONDS = 720  # 12 minutes waiting for the accelerator to redeploy
+GA_DEPLOYED_POLL_INTERVAL = 15  # Poll accelerator status every 15 seconds
 
 
 def send_response(
@@ -506,6 +537,77 @@ def remove_ga_endpoints(ga_client: Any, endpoint_group_arn: str) -> None:
         logger.warning(f"Failed to clean up GA endpoints: {e}")
 
 
+def _accelerator_arn_from_endpoint_group(endpoint_group_arn: str) -> str:
+    """Derive the accelerator ARN from one of its endpoint-group ARNs.
+
+    Endpoint-group ARN:
+        arn:aws:globalaccelerator::<acct>:accelerator/<id>/listener/<lid>/endpoint-group/<egid>
+    Accelerator ARN:
+        arn:aws:globalaccelerator::<acct>:accelerator/<id>
+    """
+    return endpoint_group_arn.split("/listener/")[0]
+
+
+def wait_for_accelerator_deployed(
+    ga_client: Any,
+    endpoint_group_arn: str,
+    timeout_seconds: int = GA_DEPLOYED_WAIT_SECONDS,
+) -> bool:
+    """Block until the accelerator reports ``DEPLOYED`` (or the budget expires).
+
+    Global Accelerator only releases its ``global_accelerator_managed`` ENIs
+    from a region's subnets once the accelerator finishes redeploying after an
+    endpoint change (it reports ``IN_PROGRESS`` until then). During teardown we
+    must wait for that release before CloudFormation deletes the public subnets
+    those ENIs occupy — otherwise subnet deletion fails and the stack is left in
+    DELETE_FAILED (see issue #130).
+
+    Best-effort: returns ``True`` once ``DEPLOYED`` is observed (or the
+    accelerator is already gone), ``False`` on timeout or a non-fatal API error.
+    Never raises, so a Global Accelerator hiccup can't wedge the stack delete.
+    """
+    accelerator_arn = _accelerator_arn_from_endpoint_group(endpoint_group_arn)
+    start_time = time.time()
+    while time.time() - start_time < timeout_seconds:
+        try:
+            accelerator = ga_client.describe_accelerator(AcceleratorArn=accelerator_arn)
+            status = accelerator.get("Accelerator", {}).get("Status", "")
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code == "AcceleratorNotFoundException":
+                logger.info("Accelerator no longer exists; nothing to wait for")
+                return True
+            logger.warning(f"Failed to describe accelerator status: {e}")
+            return False
+        if status == "DEPLOYED":
+            elapsed = int(time.time() - start_time)
+            logger.info(f"Accelerator DEPLOYED after {elapsed}s; GA released its managed ENIs")
+            return True
+        logger.info(f"Accelerator status={status!r}; waiting for DEPLOYED...")
+        # nosemgrep: arbitrary-sleep - intentional polling for GA redeploy
+        time.sleep(GA_DEPLOYED_POLL_INTERVAL)
+
+    logger.warning(
+        f"Timed out after {timeout_seconds}s waiting for the accelerator to reach DEPLOYED"
+    )
+    return False
+
+
+def deregister_alb_from_ga(ga_client: Any, endpoint_group_arn: str) -> None:
+    """Remove every endpoint from the GA endpoint group and wait for GA to
+    release its managed ENIs.
+
+    Used by the delete-time teardown guard: registration is one-directional
+    (the convergence state machine's final task adds the Ingress-created ALB at
+    deploy time), so without this the endpoint group keeps referencing the
+    LB-controller-deleted ALB and Global Accelerator keeps
+    ``global_accelerator_managed`` ENIs pinned in the VPC's public subnets,
+    blocking subnet — and stack — deletion (see issue #130).
+    """
+    remove_ga_endpoints(ga_client, endpoint_group_arn)
+    wait_for_accelerator_deployed(ga_client, endpoint_group_arn)
+
+
 def delete_ingress_and_wait_for_alb_deletion(
     cluster_name: str, region: str, namespace: str, ingress_name: str
 ) -> None:
@@ -561,9 +663,11 @@ def handle_delete(
     global_region = props.get("GlobalRegion", "us-east-2")
     project_name = props.get("ProjectName", "gco")
 
-    # Step 1: Remove all endpoints from GA endpoint group
+    # Step 1: Remove all endpoints from GA endpoint group and wait for Global
+    # Accelerator to release its managed ENIs, so the public subnets those ENIs
+    # occupy can be deleted cleanly during teardown (see issue #130).
     ga = boto3.client("globalaccelerator", region_name="us-west-2")
-    remove_ga_endpoints(ga, endpoint_group_arn)
+    deregister_alb_from_ga(ga, endpoint_group_arn)
 
     # Step 2: Delete the Ingress to trigger ALB deletion
     delete_ingress_and_wait_for_alb_deletion(cluster_name, region, namespace, ingress_name)
@@ -692,6 +796,49 @@ def handle_create_update(
     # IMPORTANT: Keep PhysicalResourceId stable to avoid CloudFormation treating
     # updates as replacements (which would trigger a Delete of the old resource)
     send_response(event, context, "SUCCESS", data, physical_id)
+
+
+def on_delete_event(event: dict[str, Any], _context: Any = None) -> dict[str, Any]:
+    """CDK ``cr.Provider`` handler for the delete-time GA deregistration guard.
+
+    Wired by ``regional_stack.py`` as a standalone custom resource whose sole
+    job is teardown ordering. It is a **no-op on Create/Update** — registration
+    stays owned by the convergence state machine's final task — and on **Delete**
+    it deregisters the region's ALB from the shared Global Accelerator endpoint
+    group and waits for GA to release its managed ENIs, BEFORE CloudFormation
+    deletes the VPC public subnets those ENIs sit in.
+
+    Without this hook the endpoint group keeps referencing the
+    LB-controller-deleted ALB, Global Accelerator keeps
+    ``global_accelerator_managed`` ENIs pinned in the public subnets, subnet
+    deletion fails, and the stack is left in DELETE_FAILED (see issue #130).
+
+    Unlike the raw CloudFormation custom-resource path (:func:`lambda_handler`),
+    this is invoked through the provider framework, so it returns a plain dict
+    instead of POSTing to a response URL. Best-effort: it never raises, so a
+    transient Global Accelerator error can't wedge the stack in DELETE_FAILED.
+    """
+    request_type = event.get("RequestType")
+    props = event.get("ResourceProperties", {})
+    physical_id = event.get("PhysicalResourceId") or f"ga-dereg-{props.get('Region', 'unknown')}"
+
+    # Registration happens in the state machine; this guard only acts on Delete.
+    if request_type != "Delete":
+        return {"PhysicalResourceId": physical_id}
+
+    endpoint_group_arn = props.get("EndpointGroupArn")
+    if not endpoint_group_arn:
+        logger.warning("No EndpointGroupArn in resource properties; skipping GA deregistration")
+        return {"PhysicalResourceId": physical_id}
+
+    logger.info(f"Deregistering region's ALB from Global Accelerator: {endpoint_group_arn}")
+    try:
+        ga = boto3.client("globalaccelerator", region_name="us-west-2")
+        deregister_alb_from_ga(ga, endpoint_group_arn)
+    except Exception as e:  # noqa: BLE001 - teardown guard must never wedge the stack delete
+        logger.error(f"GA deregistration guard failed (continuing teardown): {e}", exc_info=True)
+
+    return {"PhysicalResourceId": physical_id}
 
 
 def lambda_handler(event: dict[str, Any], context: Any) -> Any:

--- a/tests/test_ga_registration.py
+++ b/tests/test_ga_registration.py
@@ -794,3 +794,212 @@ class TestLambdaHandler:
             handler.lambda_handler(event, context)
 
             mock_update.assert_called_once()
+
+
+# ============================================================================
+# Delete-time GA Deregistration Guard Tests (issue #130)
+# ============================================================================
+
+ACCELERATOR_ARN = "arn:aws:globalaccelerator::123:accelerator/abc"
+
+
+class TestAcceleratorArnFromEndpointGroup:
+    """The accelerator ARN is derived from the endpoint-group ARN so the delete
+    guard can poll the accelerator's status without a separate lookup."""
+
+    def test_derives_accelerator_arn(self, ga_module):
+        handler, _, _ = ga_module
+        assert handler._accelerator_arn_from_endpoint_group(ENDPOINT_GROUP_ARN) == ACCELERATOR_ARN
+
+
+class TestRemoveGaEndpoints:
+    """The delete guard must clear every endpoint from the group so Global
+    Accelerator releases its managed ENIs."""
+
+    def test_removes_all_endpoints(self, ga_module):
+        handler, _, _ = ga_module
+        ga = MagicMock()
+        ga.describe_endpoint_group.return_value = {
+            "EndpointGroup": {
+                "EndpointDescriptions": [
+                    {"EndpointId": PLATFORM_ALB_ARN},
+                    {"EndpointId": INFERENCE_ALB_ARN},
+                ]
+            }
+        }
+
+        handler.remove_ga_endpoints(ga, ENDPOINT_GROUP_ARN)
+
+        assert ga.remove_endpoints.call_count == 2
+
+    def test_no_endpoints_is_a_noop(self, ga_module):
+        handler, _, _ = ga_module
+        ga = MagicMock()
+        ga.describe_endpoint_group.return_value = {"EndpointGroup": {"EndpointDescriptions": []}}
+
+        handler.remove_ga_endpoints(ga, ENDPOINT_GROUP_ARN)
+
+        ga.remove_endpoints.assert_not_called()
+
+    def test_endpoint_not_found_is_swallowed(self, ga_module):
+        handler, _, _ = ga_module
+        ga = MagicMock()
+        ga.describe_endpoint_group.return_value = {
+            "EndpointGroup": {"EndpointDescriptions": [{"EndpointId": PLATFORM_ALB_ARN}]}
+        }
+        ga.remove_endpoints.side_effect = ClientError(
+            {"Error": {"Code": "EndpointNotFoundException", "Message": "gone"}},
+            "RemoveEndpoints",
+        )
+
+        # Should not raise — the endpoint is already gone, which is success.
+        handler.remove_ga_endpoints(ga, ENDPOINT_GROUP_ARN)
+
+
+class TestWaitForAcceleratorDeployed:
+    """Global Accelerator only releases its managed ENIs once the accelerator
+    redeploys to DEPLOYED; teardown blocks on that so subnet deletion succeeds."""
+
+    def test_returns_true_when_already_deployed(self, ga_module):
+        handler, _, _ = ga_module
+        ga = MagicMock()
+        ga.describe_accelerator.return_value = {"Accelerator": {"Status": "DEPLOYED"}}
+
+        assert handler.wait_for_accelerator_deployed(ga, ENDPOINT_GROUP_ARN) is True
+        ga.describe_accelerator.assert_called_once_with(AcceleratorArn=ACCELERATOR_ARN)
+
+    def test_polls_until_deployed(self, ga_module):
+        handler, _, _ = ga_module
+        ga = MagicMock()
+        ga.describe_accelerator.side_effect = [
+            {"Accelerator": {"Status": "IN_PROGRESS"}},
+            {"Accelerator": {"Status": "DEPLOYED"}},
+        ]
+
+        with patch.object(handler.time, "sleep"):
+            assert handler.wait_for_accelerator_deployed(ga, ENDPOINT_GROUP_ARN) is True
+
+        assert ga.describe_accelerator.call_count == 2
+
+    def test_returns_true_when_accelerator_gone(self, ga_module):
+        handler, _, _ = ga_module
+        ga = MagicMock()
+        ga.describe_accelerator.side_effect = ClientError(
+            {"Error": {"Code": "AcceleratorNotFoundException", "Message": "gone"}},
+            "DescribeAccelerator",
+        )
+
+        # A missing accelerator means there are no ENIs left to release.
+        assert handler.wait_for_accelerator_deployed(ga, ENDPOINT_GROUP_ARN) is True
+
+    def test_returns_false_on_other_client_error(self, ga_module):
+        handler, _, _ = ga_module
+        ga = MagicMock()
+        ga.describe_accelerator.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "no"}},
+            "DescribeAccelerator",
+        )
+
+        assert handler.wait_for_accelerator_deployed(ga, ENDPOINT_GROUP_ARN) is False
+
+    def test_returns_false_on_timeout(self, ga_module):
+        handler, _, _ = ga_module
+        ga = MagicMock()
+        ga.describe_accelerator.return_value = {"Accelerator": {"Status": "IN_PROGRESS"}}
+
+        # A zero budget exits before the first poll — exercises the timeout path
+        # without sleeping.
+        assert handler.wait_for_accelerator_deployed(ga, ENDPOINT_GROUP_ARN, timeout_seconds=0) is (
+            False
+        )
+
+
+class TestDeregisterAlbFromGa:
+    """The deregistration helper removes endpoints and then waits for the ENIs
+    to be released, in that order."""
+
+    def test_removes_then_waits(self, ga_module):
+        handler, _, _ = ga_module
+        ga = MagicMock()
+
+        with (
+            patch.object(handler, "remove_ga_endpoints") as mock_remove,
+            patch.object(handler, "wait_for_accelerator_deployed") as mock_wait,
+        ):
+            handler.deregister_alb_from_ga(ga, ENDPOINT_GROUP_ARN)
+
+        mock_remove.assert_called_once_with(ga, ENDPOINT_GROUP_ARN)
+        mock_wait.assert_called_once_with(ga, ENDPOINT_GROUP_ARN)
+
+
+class TestOnDeleteEvent:
+    """The cr.Provider entrypoint for the delete-time teardown guard."""
+
+    def _delete_event(self):
+        return {
+            "RequestType": "Delete",
+            "PhysicalResourceId": "ga-dereg-us-east-1",
+            "ResourceProperties": {
+                "EndpointGroupArn": ENDPOINT_GROUP_ARN,
+                "Region": "us-east-1",
+                "ProjectName": "gco",
+            },
+        }
+
+    def test_delete_deregisters_alb(self, ga_module):
+        handler, mock_boto_client, _ = ga_module
+
+        with patch.object(handler, "deregister_alb_from_ga") as mock_dereg:
+            result = handler.on_delete_event(self._delete_event(), None)
+
+        mock_dereg.assert_called_once()
+        # Called with (ga_client, endpoint_group_arn).
+        assert mock_dereg.call_args[0][1] == ENDPOINT_GROUP_ARN
+        assert result["PhysicalResourceId"] == "ga-dereg-us-east-1"
+
+    def test_create_is_noop(self, ga_module):
+        handler, _, _ = ga_module
+        event = {
+            "RequestType": "Create",
+            "ResourceProperties": {"EndpointGroupArn": ENDPOINT_GROUP_ARN, "Region": "us-east-1"},
+        }
+
+        with patch.object(handler, "deregister_alb_from_ga") as mock_dereg:
+            result = handler.on_delete_event(event, None)
+
+        mock_dereg.assert_not_called()
+        assert "PhysicalResourceId" in result
+
+    def test_update_is_noop(self, ga_module):
+        handler, _, _ = ga_module
+        event = {
+            "RequestType": "Update",
+            "PhysicalResourceId": "pid",
+            "ResourceProperties": {"EndpointGroupArn": ENDPOINT_GROUP_ARN},
+        }
+
+        with patch.object(handler, "deregister_alb_from_ga") as mock_dereg:
+            result = handler.on_delete_event(event, None)
+
+        mock_dereg.assert_not_called()
+        assert result["PhysicalResourceId"] == "pid"
+
+    def test_delete_without_endpoint_group_is_noop(self, ga_module):
+        handler, _, _ = ga_module
+        event = {"RequestType": "Delete", "ResourceProperties": {"Region": "us-east-1"}}
+
+        with patch.object(handler, "deregister_alb_from_ga") as mock_dereg:
+            result = handler.on_delete_event(event, None)
+
+        mock_dereg.assert_not_called()
+        assert result["PhysicalResourceId"].startswith("ga-dereg")
+
+    def test_delete_never_raises_on_error(self, ga_module):
+        handler, _, _ = ga_module
+
+        # Even if deregistration blows up, the guard must return success so the
+        # stack delete is never wedged in DELETE_FAILED by the guard itself.
+        with patch.object(handler, "deregister_alb_from_ga", side_effect=Exception("boom")):
+            result = handler.on_delete_event(self._delete_event(), None)
+
+        assert result["PhysicalResourceId"] == "ga-dereg-us-east-1"

--- a/tests/test_regional_stack.py
+++ b/tests/test_regional_stack.py
@@ -676,6 +676,38 @@ class TestRegionalStackSynthesis:
                 f"for teardown ordering; DependsOn={depends_on}"
             )
 
+            # (3) Regression guard for the RemoveEndpoints IAM requirement: the
+            # Global Accelerator RemoveEndpoints API is implemented as an
+            # endpoint-group update, so the dereg role must ALSO hold
+            # UpdateEndpointGroup or teardown deregistration fails at runtime with
+            # AccessDeniedException (see issue #130). The dereg policy is uniquely
+            # identifiable by DescribeAccelerator — the registration Lambda's
+            # policy does not grant it.
+            template.has_resource_properties(
+                "AWS::IAM::Policy",
+                {
+                    "PolicyDocument": assertions.Match.object_like(
+                        {
+                            "Statement": assertions.Match.array_with(
+                                [
+                                    assertions.Match.object_like(
+                                        {
+                                            "Action": assertions.Match.array_with(
+                                                [
+                                                    "globalaccelerator:DescribeAccelerator",
+                                                    "globalaccelerator:RemoveEndpoints",
+                                                    "globalaccelerator:UpdateEndpointGroup",
+                                                ]
+                                            )
+                                        }
+                                    )
+                                ]
+                            )
+                        }
+                    )
+                },
+            )
+
     def test_regional_stack_creates_ecr_repositories(self):
         """Test that RegionalStack creates ECR repositories."""
 

--- a/tests/test_regional_stack.py
+++ b/tests/test_regional_stack.py
@@ -608,6 +608,74 @@ class TestRegionalStackSynthesis:
             template = assertions.Template.from_stack(stack)
             template.resource_count_is("AWS::EC2::VPC", 1)
 
+    def test_regional_stack_ga_deregistration_teardown_guard(self):
+        """Issue #130: a delete-time custom resource must deregister the ALB
+        from Global Accelerator before the VPC public subnets are deleted.
+
+        Registration is one-directional (the convergence state machine adds the
+        ALB at deploy time), so without a teardown hook Global Accelerator keeps
+        its managed ENIs pinned in the public subnets and subnet deletion — and
+        the whole stack delete — fails. This asserts (1) the dedicated
+        deregistration Lambda exists with the ``handler.on_delete_event``
+        entrypoint, and (2) its custom resource depends on the public subnets so
+        CloudFormation runs the deregistration (releasing the ENIs) first.
+        """
+        from gco.stacks.regional_stack import GCORegionalStack
+
+        app = cdk.App()
+        config = MockConfigLoader(app)
+
+        with (
+            patch("gco.stacks.regional_stack.ecr_assets.DockerImageAsset") as mock_docker,
+            patch.object(
+                GCORegionalStack,
+                "_create_helm_installer_lambda",
+                TestRegionalStackSynthesis._mock_helm_installer,
+            ),
+        ):
+            mock_image = MagicMock()
+            mock_image.image_uri = "123456789012.dkr.ecr.us-east-1.amazonaws.com/test:latest"
+            mock_docker.return_value = mock_image
+
+            stack = GCORegionalStack(
+                app,
+                "test-regional-ga-dereg",
+                config=config,
+                region="us-east-1",
+                auth_secret_arn="arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret",  # nosec B106 - test fixture ARN with fake account ID, not a real secret
+                env=cdk.Environment(account="123456789012", region="us-east-1"),
+            )
+
+            template = assertions.Template.from_stack(stack)
+
+            # (1) The dedicated deregistration Lambda uses the on_delete_event entrypoint.
+            template.has_resource_properties(
+                "AWS::Lambda::Function",
+                {"Handler": "handler.on_delete_event"},
+            )
+
+            # (2) The deregistration custom resource must depend on the public
+            # subnets so teardown deregisters (releasing GA ENIs) before subnet
+            # deletion. add_dependency(self.vpc) renders as DependsOn entries on
+            # the custom resource for the VPC's resources, including the subnets.
+            custom_resources = template.find_resources("AWS::CloudFormation::CustomResource")
+            dereg = {
+                lid: res
+                for lid, res in custom_resources.items()
+                if lid.startswith("GaDeregistration")
+            }
+            assert dereg, (
+                f"Expected a GaDeregistration custom resource; found: {list(custom_resources)}"
+            )
+            (dereg_res,) = dereg.values()
+            depends_on = dereg_res.get("DependsOn", [])
+            if isinstance(depends_on, str):
+                depends_on = [depends_on]
+            assert any("PublicSubnet" in d for d in depends_on), (
+                "GaDeregistration custom resource must depend on the VPC public subnets "
+                f"for teardown ordering; DependsOn={depends_on}"
+            )
+
     def test_regional_stack_creates_ecr_repositories(self):
         """Test that RegionalStack creates ECR repositories."""
 


### PR DESCRIPTION
Registration of the Ingress-created ALB into the regional Global Accelerator endpoint group was one-directional: the convergence state machine's final task calls AddEndpoints at deploy time, but nothing called RemoveEndpoints at destroy time. On `cdk destroy`, the AWS Load Balancer Controller deletes the ALB while the endpoint group still references its ARN, so Global Accelerator keeps its managed ENIs (InterfaceType global_accelerator_managed) pinned in the VPC public subnets. Subnet deletion then fails and the stack is left in DELETE_FAILED; a later deploy fails because the stack can't be updated.

Add a dedicated delete-time teardown guard:

- lambda/ga-registration/handler.py: new `on_delete_event` cr.Provider entrypoint. No-op on Create/Update (registration stays owned by the state machine); on Delete it removes the endpoints and waits for the accelerator to return to DEPLOYED, which is when GA releases its managed ENIs. Extracted `deregister_alb_from_ga` and `wait_for_accelerator_deployed` helpers and wired the wait into the legacy `handle_delete` path too. Best-effort: never raises, so a GA hiccup can't wedge a delete.
- gco/stacks/regional_stack.py: `_create_ga_deregistration_resource` creates a non-VPC Lambda (same asset) fronted by a cr.Provider and a CustomResource that depends on the VPC, so CloudFormation runs the deregistration before it deletes the public subnets those ENIs occupy.
- gco/stacks/nag_suppressions.py: scope the provider's IAM5 invoke-versions finding and document the neighbouring entries.

Tests: unit tests for the new handler paths (deregister, wait-for- DEPLOYED, on_delete_event lifecycle) and a synthesis test asserting the guard Lambda exists and its custom resource depends on the public subnets (teardown ordering).

Fixes #130

<!--
Thanks for contributing to Global Capacity Orchestrator (GCO)! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ ] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [ ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
