### PR TITLE
fix: sanitize untrusted image name before logging (CodeQL #138)

### DIFF
--- a/gco/services/manifest_processor.py
+++ b/gco/services/manifest_processor.py
@@ -714,7 +714,9 @@ class ManifestProcessor:
 
                 if not is_trusted:
                     container_name = container.get("name", "unknown")
-                    logger.warning(f"Untrusted image source: {image}")
+                    # image comes from the user-submitted manifest; sanitize it
+                    # before logging to prevent log injection / forging (CWE-117).
+                    logger.warning("Untrusted image source: %s", sanitize_log_value(image))
                     return (
                         False,
                         f"{container_type} '{container_name}': Untrusted image source '{image}'",


### PR DESCRIPTION
## Summary

Fixes CodeQL code-scanning alert [#138](https://github.com/awslabs/global-capacity-orchestrator-on-aws/security/code-scanning/138) (`py/log-injection`, CWE-117, medium).

`ManifestProcessor._validate_image_sources()` logged the container `image`
value parsed straight from a user-submitted manifest (the request body to
`POST /api/v1/manifests` and `/api/v1/manifests/validate`) without
sanitization:

```python
logger.warning(f"Untrusted image source: {image}")
```

Because `image` is fully attacker-controlled, a caller could embed CRLF
characters in the image field to forge additional log lines (log injection /
log forging).

The fix wraps the value with the existing `sanitize_log_value()` helper and
switches to lazy `%s` logging:

```python
logger.warning("Untrusted image source: %s", sanitize_log_value(image))
```

This is the same convention introduced in #37 for the sibling untrusted
sinks (`job_id` / `namespace` / `api_version` / `kind`) in this file and in
`queue.py`. Line 717 was the one untrusted-image log call that #37 missed.

## Type of change

- [x] `fix:` Bug fix (non-breaking)

## Testing

- [x] `pytest tests/` passes locally (221 passed across the manifest /
  image-source validation suites: `test_manifest_processor.py`,
  `test_manifest_processor_extended.py`, `test_manifest_security_validation.py`,
  `test_trusted_registries_augmentation.py`)
- [x] `ruff check` + `ruff format --check` clean; `mypy` clean
- [x] Verified end-to-end: a manifest whose image contains `\r\n<forged line>`
  now logs the value with the newline escaped to a literal `\r\n` (no raw
  newline reaches the log), and validation still correctly rejects the image.

## Checklist

- [x] No secrets, credentials, or customer data committed
- [x] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Note for reviewers

Consistent with prior log-injection fixes in this repo, CodeQL 2.x does not
recognize `sanitize_log_value()` (which escapes via `unicode_escape`) as a
sanitizer, so alert #138 will likely still surface until it is dismissed as a
"false positive" — the same disposition used for the sibling alerts
(#91/#92/#93 on this file and #94/#95 on `queue.py`). The code change itself
fully neutralizes the CRLF vector.

## Related issues

Fixes code-scanning alert #138.
