### PR TITLE
fix(mcp): actionable error + docs when the CDK toolchain is missing

### DIFF
--- a/cli/stacks.py
+++ b/cli/stacks.py
@@ -34,6 +34,7 @@ Environment Variables:
 
 from __future__ import annotations
 
+import importlib.util
 import logging
 import os
 import shutil
@@ -66,6 +67,24 @@ if TYPE_CHECKING:
     from .config import GCOConfig
 
 logger = logging.getLogger(__name__)
+
+# Python packages ``app.py`` imports at CDK synth time. They ship in the
+# optional ``[cdk]`` extra (see pyproject.toml), NOT the base install, so a
+# lightweight ``uvx`` / ``pip install`` of ``gco-cli`` that skips the extra
+# cannot synthesize or deploy. ``StackManager._ensure_cdk_toolchain`` checks
+# for these before invoking ``cdk`` so a missing toolchain is actionable.
+_CDK_TOOLCHAIN_MODULES = ("aws_cdk", "cdk_nag")
+
+
+class CdkToolchainError(RuntimeError):
+    """The CDK Python toolchain (``aws-cdk-lib`` / ``cdk-nag``) is not
+    importable in the environment that will run ``cdk``.
+
+    Raised before shelling out to ``cdk`` so operators get a clear install
+    hint instead of the cryptic ``ImportError: cannot import name 'App' from
+    'aws_cdk'`` that the ``python3 app.py`` synth subprocess would otherwise
+    emit from a base (extra-less) install.
+    """
 
 
 @dataclass
@@ -487,6 +506,36 @@ class StackManager:
 
         return os.pathsep.join(all_paths)
 
+    def _ensure_cdk_toolchain(self) -> None:
+        """Preflight the CDK Python toolchain before invoking ``cdk``.
+
+        Infra operations run ``python3 app.py`` (via the Node ``cdk`` CLI),
+        which imports ``aws_cdk`` and ``cdk_nag``. Those ship in the optional
+        ``[cdk]`` extra — a base ``uvx`` / ``pip`` install of ``gco-cli`` does
+        not include them, so the synth subprocess fails with a cryptic
+        ``ImportError: cannot import name 'App' from 'aws_cdk'``. Detect the
+        missing toolchain up front and raise :class:`CdkToolchainError` with an
+        actionable install hint instead.
+        """
+        missing = [m for m in _CDK_TOOLCHAIN_MODULES if importlib.util.find_spec(m) is None]
+        if not missing:
+            return
+        raise CdkToolchainError(
+            "CDK toolchain not available: cannot import "
+            + ", ".join(missing)
+            + ".\nInfrastructure operations (deploy / synth / diff / list / destroy / "
+            "bootstrap) need the CDK Python packages installed in the SAME "
+            "environment as the `gco` CLI, plus a repository checkout providing "
+            "`app.py` and `cdk.json`.\n"
+            "Install the `[cdk]` extra one of these ways:\n"
+            '  - uv:  uv tool install "gco-cli[cdk] @ '
+            'git+https://github.com/awslabs/global-capacity-orchestrator-on-aws.git@<tag>"\n'
+            '  - pip: pip install -e ".[cdk,mcp]"   (from a clone)\n'
+            "  - or use the dev container (see QUICKSTART.md), which bundles the "
+            "full toolchain.\n"
+            "See gco_mcp/README.md (Setup) for the deploy-capable configuration."
+        )
+
     def _run_cdk(
         self,
         command: list[str],
@@ -510,6 +559,12 @@ class StackManager:
                 post-delete polling loop hanging after CloudFormation has
                 already finished) can't block the orchestrator forever.
         """
+        # Fail fast with an actionable message when the CDK Python toolchain
+        # isn't importable (e.g. a base uvx/pip install without the [cdk]
+        # extra), instead of letting the ``python3 app.py`` subprocess surface
+        # a cryptic ImportError.
+        self._ensure_cdk_toolchain()
+
         full_env = os.environ.copy()
 
         # Inject PYTHONPATH so CDK's python3 subprocess can find aws_cdk

--- a/gco_mcp/README.md
+++ b/gco_mcp/README.md
@@ -117,16 +117,18 @@ The MCP server wraps the `gco` CLI, exposing 109 tools by default (up to 144 wit
 
 The quickest way to *run* the server — no clone, no manual dependency install — is [`uv`](https://docs.astral.sh/uv/). Install it once with the [official uv installation guide](https://docs.astral.sh/uv/getting-started/installation/) (`uvx` ships with `uv`), then jump to [Install with `uv` (recommended)](#install-with-uv-recommended) below; `uv` resolves the pinned GCO dependencies into an isolated environment for you.
 
-For **development** — or when you need the local-clone-only resources (`docs://`, `source://`, `k8s://`, `infra://`, …) and CDK/stack lifecycle operations — work from a checkout instead. The GCO [dev container](../QUICKSTART.md#step-1-clone-and-build-the-dev-container) is the smoothest path here: it ships the `gco` CLI and the `[mcp]` extras (including `fastmcp`) pre-installed at the right versions, so you only point your MCP client at `python3 gco_mcp/run_mcp.py` running inside the container. This sidesteps the dependency-resolver issues that often hit users layering the many pinned GCO packages onto an existing Python environment.
+For **development** — or when you need the local-clone-only resources (`docs://`, `source://`, `k8s://`, `infra://`, …) and CDK/stack lifecycle operations — work from a checkout instead. The GCO [dev container](../QUICKSTART.md#step-1-clone-and-build-the-dev-container) is the smoothest path here: it ships the `gco` CLI and the `.[dev,mcp]` extras (including `fastmcp` **and** the `[cdk]` CDK toolchain, plus the Node CDK CLI, `kubectl`, Docker + Buildx, and the AWS CLI) pre-installed at the right versions, so you only point your MCP client at `python3 gco_mcp/run_mcp.py` running inside the container. This sidesteps the dependency-resolver issues that often hit users layering the many pinned GCO packages onto an existing Python environment.
 
 To set up that clone on your host instead:
 
 - Python 3.14+
 - GCO CLI installed (`pipx install -e .` from the project root)
 - AWS credentials configured (the CLI handles SigV4 auth)
-- `fastmcp` package (`pip install -e ".[mcp]"` from the project root, in a fresh venv if possible)
+- Dependencies installed from the project root, in a fresh venv if possible:
+  - `pip install -e ".[mcp]"` for the base tool surface (jobs, capacity, costs, inference, …).
+  - `pip install -e ".[cdk,mcp]"` if you also want the CDK/stack lifecycle tools (`deploy_*`, `destroy_*`, `bootstrap_cdk`, `stack_synth`/`diff`/`list`). The `[cdk]` extra pulls `aws-cdk-lib` + `cdk-nag`; without it those tools fail fast with an actionable error. See [Deploy-capable setup](#deploy-capable-setup-infrastructure-tools).
 
-> If `pip install -e ".[mcp]"` errors out with `ResolutionImpossible`, see [Troubleshooting → Installation Issues](../docs/TROUBLESHOOTING.md#pip-install-fails-with-dependency-conflicts).
+> If `pip install -e ".[cdk,mcp]"` errors out with `ResolutionImpossible`, see [Troubleshooting → Installation Issues](../docs/TROUBLESHOOTING.md#pip-install-fails-with-dependency-conflicts).
 
 ## Setup
 
@@ -171,14 +173,47 @@ Then point any stdio MCP client at that same command. For Kiro (`~/.kiro/setting
 
 > The `@v3.2.0` pin in JSON is a floor, not a ceiling — any release `>= v3.2.0` works, so bump the tag as newer ones ship. (Shell snippets can interpolate `${GCO_REF}`; JSON cannot, so the tag is written inline.)
 
+> **Heads-up on `GCO_ENABLE_INFRASTRUCTURE_DEPLOY` (shown above):** a bare `uvx` install runs the AWS-facing cluster tools, but the infra/stack tools this flag gates also need the CDK toolchain and a checkout. On a base install they register and then fail fast with an actionable error — to actually deploy, use the [Deploy-capable setup](#deploy-capable-setup-infrastructure-tools).
+
 The identical `command` / `args` pair works in Claude Desktop, Claude Code, and Cursor — drop the `env` block if you do not need any [feature flags](#feature-flags), or use `@main` to track the latest. `uv` caches the build so subsequent launches start quickly.
 
 What this install covers, and what still needs a checkout:
 
 - **Works out of the box, no separate CLI setup** — `uv` installs the `gco` CLI and the `gco-mcp` server together (both are console scripts of the single `gco-cli` package), and the server shells out to its own bundled, version-matched `gco` — so there is nothing extra to install and no dev container needed. Every AWS-facing tool (jobs, capacity, costs, inference, images, queues, nodepools, …) works once your AWS credentials are configured.
-- **Needs a local clone** — resources that read the project tree (`docs://`, `source://`, `k8s://`, `infra://`, `ci://`, …) and CDK/stack lifecycle operations. For those, use a clone-based setup (below) or the [dev container](../QUICKSTART.md#step-1-clone-and-build-the-dev-container).
+- **Needs a local clone _and_ the `[cdk]` extra** — CDK/stack lifecycle operations (`deploy_*`, `destroy_*`, `bootstrap_cdk`, `stack_synth`/`diff`/`list`) plus the resources that read the project tree (`docs://`, `source://`, `k8s://`, `infra://`, `ci://`, …). The base `uvx`/`pip` install does **not** ship `aws-cdk-lib`/`cdk-nag`, so those tools need the CDK toolchain in the same environment as `gco` (the `[cdk]` extra) and a checkout providing `app.py`/`cdk.json` — otherwise they fail fast with an actionable error. See [Deploy-capable setup](#deploy-capable-setup-infrastructure-tools).
 
 The per-client sections below also include a **secondary, clone-based** config (`python3 gco_mcp/run_mcp.py`) for development or when you want the full resource and CDK surface.
+
+### Deploy-capable setup (infrastructure tools)
+
+The `deploy_*`, `destroy_*`, `bootstrap_cdk`, and `stack_synth`/`diff`/`list` tools shell out to the CDK, which imports `aws-cdk-lib` + `cdk-nag` and reads `app.py`/`cdk.json`. A base `uvx`/`pip` install has neither, so those tools fail fast with an actionable error until you use one of the setups below. (The AWS-facing cluster tools — jobs, capacity, costs, inference, … — need none of this.)
+
+**Option 1 — dev container (turnkey, recommended for infra).** The [dev container](../QUICKSTART.md#step-1-clone-and-build-the-dev-container) bundles everything: the `.[dev,mcp]` Python extras (which include `[cdk]`) plus the Node CDK CLI, `kubectl`, Docker + Buildx, and the AWS CLI. Point your client at `python3 gco_mcp/run_mcp.py` inside the container.
+
+**Option 2 — `uv`, with the `[cdk]` extra, from a clone.** Put the `[cdk]` extra in the `--from` spec so the CDK toolchain lands in the server's environment, and set `cwd` to your checkout so `app.py`/`cdk.json` resolve:
+
+```json
+{
+  "mcpServers": {
+    "gco": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "gco-cli[cdk] @ git+https://github.com/awslabs/global-capacity-orchestrator-on-aws.git@v3.13.3",
+        "gco-mcp"
+      ],
+      "cwd": "/path/to/global-capacity-orchestrator-on-aws",
+      "env": { "GCO_ENABLE_INFRASTRUCTURE_DEPLOY": "true" }
+    }
+  }
+}
+```
+
+**Option 3 — `pip`, from a clone.** In a fresh venv at the repo root run `pip install -e ".[cdk,mcp]"`, then point the client at `python3 gco_mcp/run_mcp.py` (add `cwd` on Kiro).
+
+All three also need the non-Python tooling the CDK drives: **Node.js + the AWS CDK CLI** (`cdk`), **`kubectl`**, a **container runtime** (Docker/Finch/Podman, plus Buildx for image builds and CDK Lambda bundling), and the **AWS CLI** with credentials configured. The dev container ships all of these; on a host, install them yourself.
+
+> **Optional metric-file formats.** Reading Parquet or TensorBoard `tfevents` metric files (via `metrics_from_shared_storage_file` / `metrics_from_local_file`) needs extra libraries, added the same way: `.[metrics-parquet]` (pandas + pyarrow), `.[metrics-tfevents]` (tbparse + tensorboard), or `.[metrics]` for both — e.g. `pip install -e ".[cdk,metrics,mcp]"`, or `gco-cli[cdk,metrics] @ git+…@v3.13.3` for the `uvx` form. Every other metric source (CloudWatch, job logs, and JSON/CSV/JSONL/YAML/HF-Trainer-state files) works without them.
 
 ### Kiro
 
@@ -371,6 +406,8 @@ Set environment variables on the launching shell to enable any feature flags (se
 ## Feature Flags
 
 A handful of GCO MCP tools can incur AWS charges, mutate live infrastructure, delete data, or run for tens of minutes at a time. Those tools are disabled by default and gated behind environment-variable feature flags so an LLM can't reach them through a stray prompt — you opt in only the categories you actually want enabled for a given client. Each flag is opt-in, defaults off, and is read fresh from the environment at server startup.
+
+> **A few flags need more than a base install.** `GCO_ENABLE_INFRASTRUCTURE_DEPLOY` and `GCO_ENABLE_INFRASTRUCTURE_DESTROY` require the CDK toolchain (the `[cdk]` extra) plus a repository checkout — see [Deploy-capable setup](#deploy-capable-setup-infrastructure-tools) — and `GCO_ENABLE_IMAGE_PUBLISH` needs a container runtime (Docker/Finch/Podman). On a bare `uvx`/`pip` install these tools still register, but they fail fast with an actionable error until the prerequisites are present. Every other flag works on a base install once AWS credentials are configured.
 
 | Flag | Default | Tools Gated | Why It's Gated |
 |------|---------|-------------|----------------|

--- a/gco_mcp/README.md
+++ b/gco_mcp/README.md
@@ -172,7 +172,7 @@ Then point any stdio MCP client at that same command. For Kiro (`~/.kiro/setting
 ```
 
 > The `@v3.2.0` pin in JSON is a floor, not a ceiling — any release `>= v3.2.0` works, so bump the tag as newer ones ship. (Shell snippets can interpolate `${GCO_REF}`; JSON cannot, so the tag is written inline.)
-
+>
 > **Heads-up on `GCO_ENABLE_INFRASTRUCTURE_DEPLOY` (shown above):** a bare `uvx` install runs the AWS-facing cluster tools, but the infra/stack tools this flag gates also need the CDK toolchain and a checkout. On a base install they register and then fail fast with an actionable error — to actually deploy, use the [Deploy-capable setup](#deploy-capable-setup-infrastructure-tools).
 
 The identical `command` / `args` pair works in Claude Desktop, Claude Code, and Cursor — drop the `env` block if you do not need any [feature flags](#feature-flags), or use `@main` to track the latest. `uv` caches the build so subsequent launches start quickly.
@@ -180,7 +180,7 @@ The identical `command` / `args` pair works in Claude Desktop, Claude Code, and 
 What this install covers, and what still needs a checkout:
 
 - **Works out of the box, no separate CLI setup** — `uv` installs the `gco` CLI and the `gco-mcp` server together (both are console scripts of the single `gco-cli` package), and the server shells out to its own bundled, version-matched `gco` — so there is nothing extra to install and no dev container needed. Every AWS-facing tool (jobs, capacity, costs, inference, images, queues, nodepools, …) works once your AWS credentials are configured.
-- **Needs a local clone _and_ the `[cdk]` extra** — CDK/stack lifecycle operations (`deploy_*`, `destroy_*`, `bootstrap_cdk`, `stack_synth`/`diff`/`list`) plus the resources that read the project tree (`docs://`, `source://`, `k8s://`, `infra://`, `ci://`, …). The base `uvx`/`pip` install does **not** ship `aws-cdk-lib`/`cdk-nag`, so those tools need the CDK toolchain in the same environment as `gco` (the `[cdk]` extra) and a checkout providing `app.py`/`cdk.json` — otherwise they fail fast with an actionable error. See [Deploy-capable setup](#deploy-capable-setup-infrastructure-tools).
+- **Needs a local clone *and* the `[cdk]` extra** — CDK/stack lifecycle operations (`deploy_*`, `destroy_*`, `bootstrap_cdk`, `stack_synth`/`diff`/`list`) plus the resources that read the project tree (`docs://`, `source://`, `k8s://`, `infra://`, `ci://`, …). The base `uvx`/`pip` install does **not** ship `aws-cdk-lib`/`cdk-nag`, so those tools need the CDK toolchain in the same environment as `gco` (the `[cdk]` extra) and a checkout providing `app.py`/`cdk.json` — otherwise they fail fast with an actionable error. See [Deploy-capable setup](#deploy-capable-setup-infrastructure-tools).
 
 The per-client sections below also include a **secondary, clone-based** config (`python3 gco_mcp/run_mcp.py`) for development or when you want the full resource and CDK surface.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,27 @@ inference-monitor = [
     "kubernetes==36.0.2",
     "pyyaml==6.0.3",
 ]
+# Optional metric-reader file formats. The readers in
+# gco_mcp/metric_readers/files.py lazy-import these and, when they are
+# absent, return a FORMAT_DEPENDENCY_UNAVAILABLE envelope instead of
+# crashing -- so they are deliberately opt-in, NOT base dependencies.
+# Install only the format(s) you actually read.
+metrics-parquet = [
+    # Parquet metric files (pandas.read_parquet + its pyarrow engine).
+    "pandas==3.0.3",
+    "pyarrow==25.0.0",
+]
+metrics-tfevents = [
+    # TensorBoard ``tfevents`` metric files. ``tbparse`` pulls in
+    # ``tensorboard`` (grpcio / protobuf / werkzeug / pillow / ...), a large
+    # transitive tree kept out of the base install and the lighter
+    # ``metrics-parquet`` extra on purpose.
+    "tbparse==0.0.9",
+]
+metrics = [
+    # Umbrella: every optional metric-reader file format at once.
+    "gco-cli[metrics-parquet,metrics-tfevents]",
+]
 mcp = [
     # Kept as an alias of the base ``fastmcp[tasks,code-mode]`` dependency
     # so the documented ``pip install -e ".[mcp]"`` install path keeps

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --all-extras --no-emit-index-url --output-file=requirements-lock.txt --strip-extras pyproject.toml
 #
+absl-py==2.5.0
+    # via tensorboard
 aiofile==3.9.0
     # via py-key-value-aio
 aiohappyeyeballs==2.6.2
@@ -160,6 +162,8 @@ greenlet==3.5.0
     # via playwright
 griffelib==2.0.2
     # via fastmcp-slim
+grpcio==1.82.1
+    # via tensorboard
 h11==0.16.0
     # via
     #   httpcore
@@ -242,6 +246,8 @@ lazy-object-proxy==1.12.0
     # via openapi-spec-validator
 librt==0.11.0
     # via mypy
+markdown==3.10.2
+    # via tensorboard
 markdown-it-py==4.0.0
     # via rich
 markupsafe==3.0.3
@@ -271,7 +277,10 @@ mypy-extensions==1.1.0
 nodeenv==1.10.0
     # via pre-commit
 numpy==2.4.6
-    # via rank-bm25
+    # via
+    #   pandas
+    #   rank-bm25
+    #   tensorboard
 oauthlib==3.3.1
     # via requests-oauthlib
 openapi-pydantic==0.5.1
@@ -291,13 +300,21 @@ packaging==26.2
     #   build
     #   fastmcp-slim
     #   pytest
+    #   tensorboard
     #   wheel
+pandas==3.0.3
+    # via
+    #   gco-cli
+    #   gco-cli (pyproject.toml)
+    #   tbparse
 pathable==0.6.0
     # via jsonschema-path
 pathspec==1.1.1
     # via
     #   mypy
     #   yamllint
+pillow==12.3.0
+    # via tensorboard
 pip-tools==7.5.3
     # via
     #   gco-cli
@@ -326,6 +343,8 @@ propcache==0.5.2
     # via
     #   aiohttp
     #   yarl
+protobuf==7.35.1
+    # via tensorboard
 psutil==7.2.2
     # via pytest-xdist
 publication==0.0.3
@@ -341,6 +360,10 @@ py-key-value-aio==0.4.4
     # via
     #   fastmcp-slim
     #   pydocket
+pyarrow==25.0.0
+    # via
+    #   gco-cli
+    #   gco-cli (pyproject.toml)
 pycparser==3.0
     # via cffi
 pydantic==2.13.4
@@ -413,6 +436,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   jsii
     #   kubernetes
+    #   pandas
 python-discovery==1.2.2
     # via virtualenv
 python-dotenv==1.2.2
@@ -505,6 +529,14 @@ starlette==1.3.1
     #   sse-starlette
 stevedore==5.7.0
     # via bandit
+tbparse==0.0.9
+    # via
+    #   gco-cli
+    #   gco-cli (pyproject.toml)
+tensorboard==2.21.0
+    # via tbparse
+tensorboard-data-server==0.7.2
+    # via tensorboard
 typeguard==2.13.3
     # via
     #   aws-cdk-asset-awscli-v1
@@ -527,6 +559,7 @@ typing-extensions==4.15.0
     #   cattrs
     #   fastapi
     #   fastmcp-slim
+    #   grpcio
     #   jsii
     #   mcp
     #   mypy
@@ -572,7 +605,9 @@ websocket-client==1.9.0
 websockets==16.0
     # via fastmcp-slim
 werkzeug==3.1.8
-    # via moto
+    # via
+    #   moto
+    #   tensorboard
 wheel==0.47.0
     # via pip-tools
 xmltodict==1.0.4

--- a/tests/test_stacks.py
+++ b/tests/test_stacks.py
@@ -3480,3 +3480,90 @@ class TestDestroyReconciliationDeleteFailed:
             result = manager.destroy(stack_name="gco-us-east-1", force=True)
 
         assert result is False
+
+
+class TestCdkToolchainPreflight:
+    """Preflight guard: infra ops raise an actionable ``CdkToolchainError``
+    when the CDK Python toolchain (aws-cdk-lib / cdk-nag) isn't importable,
+    instead of a cryptic ImportError from the ``python3 app.py`` synth
+    subprocess.
+
+    Regression coverage for the out-of-the-box failure where a base
+    ``uvx`` / ``pip`` install of ``gco-cli`` (no ``[cdk]`` extra) runs
+    ``deploy`` / ``synth`` / ``list`` and the CDK subprocess dies importing
+    ``aws_cdk``.
+    """
+
+    @staticmethod
+    def _find_spec_missing(*missing):
+        """A ``find_spec`` side effect: ``None`` for the named modules, a
+        truthy sentinel for everything else."""
+
+        def _side_effect(name, *args, **kwargs):
+            return None if name in missing else object()
+
+        return _side_effect
+
+    def test_missing_toolchain_raises_actionable_error(self):
+        from cli.stacks import CdkToolchainError, StackManager
+
+        manager = StackManager(MagicMock())
+
+        with (
+            patch(
+                "importlib.util.find_spec",
+                side_effect=self._find_spec_missing("aws_cdk", "cdk_nag"),
+            ),
+            pytest.raises(CdkToolchainError) as exc,
+        ):
+            manager._ensure_cdk_toolchain()
+
+        msg = str(exc.value)
+        assert "aws_cdk" in msg
+        assert "cdk_nag" in msg
+        assert "[cdk]" in msg  # names the extra to install
+        assert "pip install" in msg  # actionable install hint
+
+    def test_partial_missing_toolchain_raises(self):
+        from cli.stacks import CdkToolchainError, StackManager
+
+        manager = StackManager(MagicMock())
+
+        # Only cdk_nag missing (aws_cdk present) must still raise.
+        with (
+            patch(
+                "importlib.util.find_spec",
+                side_effect=self._find_spec_missing("cdk_nag"),
+            ),
+            pytest.raises(CdkToolchainError, match="cdk_nag"),
+        ):
+            manager._ensure_cdk_toolchain()
+
+    def test_present_toolchain_passes(self):
+        from cli.stacks import StackManager
+
+        manager = StackManager(MagicMock())
+
+        with patch(
+            "importlib.util.find_spec",
+            side_effect=self._find_spec_missing(),  # nothing missing
+        ):
+            assert manager._ensure_cdk_toolchain() is None
+
+    def test_run_cdk_preflights_before_spawning_cdk(self):
+        """``_run_cdk`` must raise the toolchain error BEFORE spawning cdk."""
+        from cli.stacks import CdkToolchainError, StackManager
+
+        manager = StackManager(MagicMock())
+
+        with (
+            patch("subprocess.run") as mock_run,
+            patch(
+                "importlib.util.find_spec",
+                side_effect=self._find_spec_missing("aws_cdk", "cdk_nag"),
+            ),
+            pytest.raises(CdkToolchainError),
+        ):
+            manager._run_cdk(["list"], capture_output=True)
+
+        mock_run.assert_not_called()


### PR DESCRIPTION
## Summary

Infrastructure MCP/CLI tools (`deploy_*`, `destroy_*`, `bootstrap_cdk`, `stack_synth`/`diff`/`list`) shell out to `python3 app.py`, which imports `aws-cdk-lib` and `cdk-nag`. Those live in the optional `[cdk]` extra, so a base `uvx`/`pip` install of `gco-cli` surfaced a cryptic `ImportError: cannot import name 'App' from 'aws_cdk'` from the CDK subprocess instead of a useful message. This makes that failure actionable, documents the deploy-capable setup, and adds supported extras for the optional metric-reader file formats.

## Changes

- **`cli/stacks.py`** — `_run_cdk` now preflights the CDK Python toolchain via a new `StackManager._ensure_cdk_toolchain()`; a missing `aws_cdk`/`cdk_nag` raises `CdkToolchainError` with an install hint (the `[cdk]` extra + a clone, or the dev container) instead of the cryptic `ImportError`. Applies to every cdk operation.
- **`tests/test_stacks.py`** — `TestCdkToolchainPreflight`: missing / partial / present toolchain, and that `_run_cdk` preflights before spawning cdk.
- **`pyproject.toml`** — opt-in metric-format extras `metrics-parquet` (pandas + pyarrow), `metrics-tfevents` (tbparse), and umbrella `metrics`. Kept out of base and `dev` to avoid tensorboard's transitive weight; the readers already lazy-import and degrade gracefully.
- **`gco_mcp/README.md`** — new "Deploy-capable setup (infrastructure tools)" section; corrected the prerequisites and the "needs a clone" bullet to require the `[cdk]` extra; added callouts so bare-`uvx` examples that set infra feature flags aren't misleading. Examples reference `v3.13.3`.
- **`requirements-lock.txt`** — regenerated via the canonical Docker `pip-compile --all-extras` flow for the new extras (adds pandas/pyarrow/tbparse + transitive; no unrelated churn).

## Test plan

- `pytest tests/test_stacks.py tests/test_doc_hygiene.py` → 162 passed locally.
- `ruff check` / `ruff format` clean on changed files.
- New pins verified to resolve on Python 3.14 via `pip-compile --all-extras` inside the `gco-dev` container.
- Relying on CI for the full matrix (unit, lint, typecheck, security, deps-scan).

## Checklist

- [x] Documentation updated (`gco_mcp/README.md`)
- [x] No secrets, credentials, or customer data committed
- [x] `requirements-lock.txt` regenerated (`pyproject.toml` changed)
- [x] Changes align with the architecture described in `docs/ARCHITECTURE.md`
