### PR TITLE
fix(ci): retry helm network failures in charts-valid job

### DIFF
--- a/.github/scripts/validate_helm_charts.py
+++ b/.github/scripts/validate_helm_charts.py
@@ -28,11 +28,10 @@ Two layers, matching what each CI stage can afford:
         the values ``charts.yaml`` ships.
 
     Every network-touching helm call (repo add/update, show chart, template)
-    is issued through ``_run_with_retry``, which retries transient registry
-    failures — timeouts, connection resets, TLS handshake errors, 5xx/429 —
-    with exponential backoff. An intermittent blip is ridden out in-process
-    instead of forcing a manual job rerun, while a genuinely bad pin fails on
-    every attempt and still surfaces.
+    is issued through ``_run_with_retry``, which retries a fixed number of
+    times with exponential backoff and takes the first success. An intermittent
+    registry blip is ridden out in-process instead of forcing a manual job
+    rerun, while a genuinely bad pin fails on every attempt and still surfaces.
 
 By default *every* chart in the file is validated, including entries with
 ``enabled: false``: those are toggled on via ``cdk.json``, so their pinned
@@ -70,7 +69,6 @@ from __future__ import annotations
 import argparse
 import contextlib
 import os
-import random
 import re
 import shutil
 import subprocess  # nosec B404 - used only to invoke the pinned `helm` binary with fixed argv
@@ -260,121 +258,45 @@ def _run(cmd: list[str], env: dict[str, str], *, timeout: int = 120) -> tuple[in
     return proc.returncode, proc.stdout, proc.stderr
 
 
-# Substrings that mark a helm failure as a transient network / registry blip
-# rather than a genuinely bad pin. Matched case-insensitively against helm's
-# stderr. A mistyped chart name or a version that never shipped fails
-# deterministically with a "not found" / "no chart version" style message that
-# matches none of these, so it is not granted the extra transient retries and
-# still surfaces quickly. Keep this list broad: misclassifying a transient
-# error as permanent costs a spurious CI failure and a manual rerun — exactly
-# what this guard exists to prevent — whereas misclassifying a permanent error
-# as transient only costs a few seconds of backoff before it fails anyway.
-_TRANSIENT_ERROR_SIGNATURES: tuple[str, ...] = (
-    "timeout",
-    "timed out",
-    "deadline exceeded",
-    "connection refused",
-    "connection reset",
-    "broken pipe",
-    "network is unreachable",
-    "no route to host",
-    "i/o timeout",
-    "dial tcp",
-    "eof",
-    "tls handshake",
-    "handshake failure",
-    "temporary failure in name resolution",
-    "no such host",
-    "could not resolve host",
-    "server misbehaving",
-    "service unavailable",
-    "bad gateway",
-    "gateway timeout",
-    "too many requests",
-    "internal server error",
-    "temporarily unavailable",
-    "try again",
-    "request canceled",
-    "client timeout",
-)
-
-
-def _is_transient_error(stderr: str) -> bool:
-    """Heuristic: does this helm stderr look like a transient network blip?
-
-    Registries (ghcr.io, public.ecr.aws, artifacthub-backed HTTP repos)
-    intermittently return timeouts, connection resets, TLS handshake failures
-    and 5xx/429 responses. Those clear on their own given a moment, so they are
-    worth retrying harder; a deterministic bad-pin failure is not.
-    """
-    low = (stderr or "").lower()
-    return any(sig in low for sig in _TRANSIENT_ERROR_SIGNATURES)
-
-
-def _backoff_delay(attempt: int, *, base_delay: float, max_delay: float) -> float:
-    """Exponential backoff (``base_delay * 2**(attempt-1)``), capped, plus jitter.
-
-    ``attempt`` is the 1-based number of the attempt that just failed. Jitter
-    spreads retries from concurrent CI runs so they don't stampede a registry
-    that is only just coming back.
-    """
-    delay = min(base_delay * (2 ** (attempt - 1)), max_delay)
-    # Full jitter on top of the capped delay. `random` is fine here: this only
-    # perturbs a retry sleep — nothing security-sensitive depends on it.
-    delay += random.uniform(0, min(1.0, delay / 4))  # nosec B311
-    return delay
-
-
 def _run_with_retry(
     cmd: list[str],
     env: dict[str, str],
     *,
-    attempts: int = 3,
-    transient_attempts: int = 5,
+    attempts: int = 4,
     base_delay: float = 2.0,
     max_delay: float = 20.0,
     timeout: int = 120,
     verbose: bool = False,
     description: str = "",
 ) -> tuple[int, str, str]:
-    """Run a network-touching helm command, retrying transient failures with backoff.
+    """Run a network-touching helm command up to ``attempts`` times; first success wins.
 
-    Every failure is retried up to ``attempts`` times; failures whose stderr
-    looks like a transient network / registry blip (see ``_is_transient_error``)
-    are retried further, up to ``transient_attempts``. Between tries we sleep an
-    exponentially growing, jittered delay (``base_delay`` doubling each round,
-    capped at ``max_delay``).
+    The command is retried on any non-zero exit, regardless of why it failed:
+    the first attempt that succeeds (rc 0) is returned immediately, and if none
+    do, the last failure is returned. Between attempts we sleep an exponentially
+    growing delay (``base_delay`` doubling each round, capped at ``max_delay``)
+    to give a blipping registry a moment to recover.
 
-    This is the guard against the intermittent registry timeouts that otherwise
-    force a manual rerun of the ``integration:helm:charts-valid`` job: a blip is
-    ridden out in-process, while a genuinely bad pin fails on every attempt and
-    still surfaces (just a few seconds later). A subprocess timeout is reported
-    by ``_run`` as ``"timeout: ..."``, which the classifier treats as transient,
-    so a stalled pull is retried too.
+    This is the guard against intermittent registry failures (timeouts, resets,
+    5xx) that otherwise force a manual rerun of the ``integration:helm:charts-valid``
+    job. A genuinely bad pin fails on every attempt and still surfaces, just a
+    few seconds later.
     """
     result: tuple[int, str, str] = (1, "", "")
-    attempt = 0
-    while True:
-        attempt += 1
+    for attempt in range(1, attempts + 1):
         result = _run(cmd, env, timeout=timeout)
-        rc, _out, err = result
-        if rc == 0:
+        if result[0] == 0:
             return result
-
-        transient = _is_transient_error(err)
-        limit = transient_attempts if transient else attempts
-        if attempt >= limit:
-            return result
-
-        delay = _backoff_delay(attempt, base_delay=base_delay, max_delay=max_delay)
-        if verbose:
-            label = description or " ".join(cmd)
-            kind = "transient" if transient else "error"
-            print(
-                f"  retry {attempt}/{limit - 1} after {kind} failure "
-                f"(sleep {delay:.1f}s) — {label}: {_tail(err, 200)}"
-            )
-        time.sleep(delay)
+        if attempt < attempts:
+            delay = min(base_delay * (2 ** (attempt - 1)), max_delay)
+            if verbose:
+                label = description or " ".join(cmd)
+                print(
+                    f"  attempt {attempt}/{attempts} failed, retrying in "
+                    f"{delay:.1f}s — {label}: {_tail(result[2], 200)}"
+                )
+            time.sleep(delay)
+    return result
 
 
 def _helm_env(helm_home: Path) -> dict[str, str]:

--- a/.github/scripts/validate_helm_charts.py
+++ b/.github/scripts/validate_helm_charts.py
@@ -27,6 +27,13 @@ Two layers, matching what each CI stage can afford:
         proves the chart renders to Kubernetes manifests (installable) with
         the values ``charts.yaml`` ships.
 
+    Every network-touching helm call (repo add/update, show chart, template)
+    is issued through ``_run_with_retry``, which retries transient registry
+    failures — timeouts, connection resets, TLS handshake errors, 5xx/429 —
+    with exponential backoff. An intermittent blip is ridden out in-process
+    instead of forcing a manual job rerun, while a genuinely bad pin fails on
+    every attempt and still surfaces.
+
 By default *every* chart in the file is validated, including entries with
 ``enabled: false``: those are toggled on via ``cdk.json``, so their pinned
 ``(name, version)`` must be valid too.
@@ -63,6 +70,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import os
+import random
 import re
 import shutil
 import subprocess  # nosec B404 - used only to invoke the pinned `helm` binary with fixed argv
@@ -252,27 +260,121 @@ def _run(cmd: list[str], env: dict[str, str], *, timeout: int = 120) -> tuple[in
     return proc.returncode, proc.stdout, proc.stderr
 
 
+# Substrings that mark a helm failure as a transient network / registry blip
+# rather than a genuinely bad pin. Matched case-insensitively against helm's
+# stderr. A mistyped chart name or a version that never shipped fails
+# deterministically with a "not found" / "no chart version" style message that
+# matches none of these, so it is not granted the extra transient retries and
+# still surfaces quickly. Keep this list broad: misclassifying a transient
+# error as permanent costs a spurious CI failure and a manual rerun — exactly
+# what this guard exists to prevent — whereas misclassifying a permanent error
+# as transient only costs a few seconds of backoff before it fails anyway.
+_TRANSIENT_ERROR_SIGNATURES: tuple[str, ...] = (
+    "timeout",
+    "timed out",
+    "deadline exceeded",
+    "connection refused",
+    "connection reset",
+    "broken pipe",
+    "network is unreachable",
+    "no route to host",
+    "i/o timeout",
+    "dial tcp",
+    "eof",
+    "tls handshake",
+    "handshake failure",
+    "temporary failure in name resolution",
+    "no such host",
+    "could not resolve host",
+    "server misbehaving",
+    "service unavailable",
+    "bad gateway",
+    "gateway timeout",
+    "too many requests",
+    "internal server error",
+    "temporarily unavailable",
+    "try again",
+    "request canceled",
+    "client timeout",
+)
+
+
+def _is_transient_error(stderr: str) -> bool:
+    """Heuristic: does this helm stderr look like a transient network blip?
+
+    Registries (ghcr.io, public.ecr.aws, artifacthub-backed HTTP repos)
+    intermittently return timeouts, connection resets, TLS handshake failures
+    and 5xx/429 responses. Those clear on their own given a moment, so they are
+    worth retrying harder; a deterministic bad-pin failure is not.
+    """
+    low = (stderr or "").lower()
+    return any(sig in low for sig in _TRANSIENT_ERROR_SIGNATURES)
+
+
+def _backoff_delay(attempt: int, *, base_delay: float, max_delay: float) -> float:
+    """Exponential backoff (``base_delay * 2**(attempt-1)``), capped, plus jitter.
+
+    ``attempt`` is the 1-based number of the attempt that just failed. Jitter
+    spreads retries from concurrent CI runs so they don't stampede a registry
+    that is only just coming back.
+    """
+    delay = min(base_delay * (2 ** (attempt - 1)), max_delay)
+    # Full jitter on top of the capped delay. `random` is fine here: this only
+    # perturbs a retry sleep — nothing security-sensitive depends on it.
+    delay += random.uniform(0, min(1.0, delay / 4))  # nosec B311
+    return delay
+
+
 def _run_with_retry(
     cmd: list[str],
     env: dict[str, str],
     *,
-    attempts: int = 2,
+    attempts: int = 3,
+    transient_attempts: int = 5,
+    base_delay: float = 2.0,
+    max_delay: float = 20.0,
     timeout: int = 120,
+    verbose: bool = False,
+    description: str = "",
 ) -> tuple[int, str, str]:
-    """Run a network-touching helm command, retrying transient failures once.
+    """Run a network-touching helm command, retrying transient failures with backoff.
 
-    Registries (ghcr.io, public.ecr.aws, artifacthub-backed HTTP repos) blip;
-    a single retry clears most of those without masking a genuinely bad pin,
-    which fails on every attempt.
+    Every failure is retried up to ``attempts`` times; failures whose stderr
+    looks like a transient network / registry blip (see ``_is_transient_error``)
+    are retried further, up to ``transient_attempts``. Between tries we sleep an
+    exponentially growing, jittered delay (``base_delay`` doubling each round,
+    capped at ``max_delay``).
+
+    This is the guard against the intermittent registry timeouts that otherwise
+    force a manual rerun of the ``integration:helm:charts-valid`` job: a blip is
+    ridden out in-process, while a genuinely bad pin fails on every attempt and
+    still surfaces (just a few seconds later). A subprocess timeout is reported
+    by ``_run`` as ``"timeout: ..."``, which the classifier treats as transient,
+    so a stalled pull is retried too.
     """
     result: tuple[int, str, str] = (1, "", "")
-    for attempt in range(1, attempts + 1):
+    attempt = 0
+    while True:
+        attempt += 1
         result = _run(cmd, env, timeout=timeout)
-        if result[0] == 0:
+        rc, _out, err = result
+        if rc == 0:
             return result
-        if attempt < attempts:
-            time.sleep(2)
-    return result
+
+        transient = _is_transient_error(err)
+        limit = transient_attempts if transient else attempts
+        if attempt >= limit:
+            return result
+
+        delay = _backoff_delay(attempt, base_delay=base_delay, max_delay=max_delay)
+        if verbose:
+            label = description or " ".join(cmd)
+            kind = "transient" if transient else "error"
+            print(
+                f"  retry {attempt}/{limit - 1} after {kind} failure "
+                f"(sleep {delay:.1f}s) — {label}: {_tail(err, 200)}"
+            )
+        time.sleep(delay)
 
 
 def _helm_env(helm_home: Path) -> dict[str, str]:
@@ -314,13 +416,22 @@ def _versions_match(resolved: str, requested: str) -> bool:
     return resolved.lstrip("v") == requested.lstrip("v")
 
 
-def _render_chart(ref: ChartRef, ref_str: str, helm_binary: str, env: dict[str, str]) -> str | None:
+def _render_chart(
+    ref: ChartRef,
+    ref_str: str,
+    helm_binary: str,
+    env: dict[str, str],
+    *,
+    verbose: bool = False,
+) -> str | None:
     """``helm template`` the chart with its shipped values; return an error or None.
 
     Rendering with the exact ``values`` block from ``charts.yaml`` proves the
     chart is installable *as GCO configures it*, not just with upstream
-    defaults. No cluster is contacted — templating is purely local once the
-    chart is pulled.
+    defaults. No cluster is contacted, but templating a remote ``--version``
+    ref still pulls the chart from its registry, so it goes through
+    ``_run_with_retry`` to ride out the same transient blips as the resolve
+    step.
     """
     args = [
         helm_binary,
@@ -345,7 +456,13 @@ def _render_chart(ref: ChartRef, ref_str: str, helm_binary: str, env: dict[str, 
         args.extend(["--values", values_path])
 
     try:
-        rc, _out, err = _run(args, env, timeout=180)
+        rc, _out, err = _run_with_retry(
+            args,
+            env,
+            timeout=180,
+            verbose=verbose,
+            description=f"helm template {ref.name}",
+        )
     finally:
         if values_path:
             with contextlib.suppress(OSError):
@@ -382,11 +499,21 @@ def validate_online(
             rc, _out, err = _run_with_retry(
                 [helm_binary, "repo", "add", repo_name, repo_url, "--force-update"],
                 env,
+                verbose=verbose,
+                description=f"helm repo add {repo_name}",
             )
             if rc != 0:
                 errors.append(f"helm repo add {repo_name} ({repo_url}) failed: {_tail(err)}")
         if classic:
-            _run([helm_binary, "repo", "update"], env, timeout=180)
+            # Index refresh is network-bound too — retry it so a blip here
+            # doesn't cascade into spurious "cannot resolve" errors below.
+            _run_with_retry(
+                [helm_binary, "repo", "update"],
+                env,
+                timeout=180,
+                verbose=verbose,
+                description="helm repo update",
+            )
 
         # 2. Resolve + render each chart at exactly its pinned version.
         for ref in refs:
@@ -396,6 +523,8 @@ def validate_online(
             rc, out, err = _run_with_retry(
                 [helm_binary, "show", "chart", ref_str, "--version", ref.version],
                 env,
+                verbose=verbose,
+                description=f"helm show chart {ref.name}",
             )
             if rc != 0:
                 errors.append(
@@ -417,7 +546,7 @@ def validate_online(
             if skip_template:
                 continue
 
-            render_error = _render_chart(ref, ref_str, helm_binary, env)
+            render_error = _render_chart(ref, ref_str, helm_binary, env, verbose=verbose)
             if render_error:
                 errors.append(f"{ref.name}: {render_error}")
                 if verbose:

--- a/tests/test_helm_charts_validation.py
+++ b/tests/test_helm_charts_validation.py
@@ -410,3 +410,186 @@ class TestLiveChartsOnline:
         errors = validator.validate_online([bogus])
         assert errors
         assert any("99.99.99" in e for e in errors)
+
+
+# ── transient-network retry guard (offline) ──────────────────────────────────
+#
+# These pin the behavior added to ride out intermittent registry blips (the
+# kind that used to force a manual rerun of integration:helm:charts-valid)
+# without masking a genuinely bad pin. All offline: _run, time.sleep and
+# random.uniform are monkeypatched so nothing sleeps or touches the network.
+
+
+class TestIsTransientError:
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "Error: dial tcp 140.82.113.3:443: i/o timeout",
+            'Get "https://ghcr.io/v2/": net/http: TLS handshake timeout',
+            "Error: failed to fetch https://.../index.yaml : 503 Service Unavailable",
+            "Error: unexpected status from GET request: 429 Too Many Requests",
+            "read tcp 10.0.0.2:5000->1.2.3.4:443: connection reset by peer",
+            "Error: lookup registry.k8s.io on 10.0.0.2:53: no such host",
+            "Error: context deadline exceeded",
+            "timeout: command exceeded 120s",
+            "Error: Get ...: net/http: request canceled (Client.Timeout exceeded)",
+        ],
+    )
+    def test_transient_signatures_detected(self, stderr: str) -> None:
+        assert validator._is_transient_error(stderr) is True
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            'Error: chart "keda" matching 99.99.99 not found in kedacore index',
+            "Error: no cached repo found. (try 'helm repo update')",
+            "Error: failed to render: template: parse error at line 3",
+            "Error: values do not meet the specifications of the schema",
+            "",
+        ],
+    )
+    def test_deterministic_failures_not_transient(self, stderr: str) -> None:
+        assert validator._is_transient_error(stderr) is False
+
+
+class TestRunWithRetry:
+    @pytest.fixture(autouse=True)
+    def _no_real_sleep(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Retry tests must never actually sleep or jitter.
+        monkeypatch.setattr(validator.time, "sleep", lambda *_a, **_k: None)
+        monkeypatch.setattr(validator.random, "uniform", lambda *_a, **_k: 0.0)
+
+    def _script(self, monkeypatch: pytest.MonkeyPatch, results: list[tuple]) -> dict:
+        """Make validator._run return successive (rc, out, err) tuples, counting calls.
+
+        The last tuple is repeated once the sequence is exhausted, so a
+        single-element list models a persistent failure.
+        """
+        calls = {"n": 0}
+        seq = list(results)
+
+        def fake_run(cmd, env, *, timeout=120):  # noqa: ANN001
+            calls["n"] += 1
+            return seq[min(calls["n"] - 1, len(seq) - 1)]
+
+        monkeypatch.setattr(validator, "_run", fake_run)
+        return calls
+
+    def test_success_first_try_runs_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls = self._script(monkeypatch, [(0, "ok", "")])
+        rc, out, _err = validator._run_with_retry(["helm", "x"], {})
+        assert rc == 0 and out == "ok"
+        assert calls["n"] == 1
+
+    def test_transient_then_success_recovers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The whole point: a blip that clears on a later attempt returns success
+        # rather than propagating a failure that would fail CI.
+        calls = self._script(
+            monkeypatch,
+            [(1, "", "i/o timeout"), (1, "", "TLS handshake timeout"), (0, "ok", "")],
+        )
+        rc, _out, _err = validator._run_with_retry(["helm", "x"], {})
+        assert rc == 0
+        assert calls["n"] == 3
+
+    def test_persistent_transient_uses_transient_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = self._script(monkeypatch, [(1, "", "connection reset by peer")])
+        rc, _out, _err = validator._run_with_retry(
+            ["helm", "x"], {}, attempts=3, transient_attempts=5
+        )
+        assert rc == 1
+        assert calls["n"] == 5  # exhausts the higher transient budget
+
+    def test_persistent_non_transient_uses_base_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A genuinely bad pin isn't transient, so it fails fast on the base
+        # budget instead of burning the full transient retry allowance.
+        calls = self._script(monkeypatch, [(1, "", "chart version 9.9.9 not found")])
+        rc, _out, _err = validator._run_with_retry(
+            ["helm", "x"], {}, attempts=3, transient_attempts=5
+        )
+        assert rc == 1
+        assert calls["n"] == 3
+
+    def test_timeout_is_treated_as_transient(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # _run reports a subprocess timeout as (-1, "", "timeout: ..."); that
+        # must get the transient budget so a stalled pull is retried.
+        calls = self._script(monkeypatch, [(-1, "", "timeout: command exceeded 120s")])
+        validator._run_with_retry(["helm", "x"], {}, attempts=2, transient_attempts=4)
+        assert calls["n"] == 4
+
+    def test_backoff_is_exponential(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._script(monkeypatch, [(1, "", "i/o timeout")])
+        sleeps: list[float] = []
+        monkeypatch.setattr(validator.time, "sleep", lambda s: sleeps.append(s))
+        monkeypatch.setattr(validator.random, "uniform", lambda *_a, **_k: 0.0)
+        validator._run_with_retry(
+            ["helm", "x"], {}, transient_attempts=4, base_delay=2.0, max_delay=100.0
+        )
+        # 3 sleeps between 4 attempts: 2, 4, 8 (jitter stubbed to 0).
+        assert sleeps == [2.0, 4.0, 8.0]
+
+    def test_backoff_capped_at_max_delay(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._script(monkeypatch, [(1, "", "i/o timeout")])
+        sleeps: list[float] = []
+        monkeypatch.setattr(validator.time, "sleep", lambda s: sleeps.append(s))
+        monkeypatch.setattr(validator.random, "uniform", lambda *_a, **_k: 0.0)
+        validator._run_with_retry(
+            ["helm", "x"], {}, transient_attempts=5, base_delay=10.0, max_delay=15.0
+        )
+        assert sleeps == [10.0, 15.0, 15.0, 15.0]
+
+
+class TestRenderChartUsesRetry:
+    def test_render_routes_through_run_with_retry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict = {}
+
+        def fake_retry(cmd, env, **kwargs):  # noqa: ANN001
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            return (0, "rendered", "")
+
+        monkeypatch.setattr(validator, "_run_with_retry", fake_retry)
+        (ref,) = validator.build_refs({"keda": _classic()})
+        err = validator._render_chart(ref, ref.reference(), "helm", {}, verbose=True)
+        assert err is None
+        assert captured["cmd"][:2] == ["helm", "template"]
+        assert "--version" in captured["cmd"]
+        # verbose is threaded so a retry is visible in the CI log.
+        assert captured["kwargs"].get("verbose") is True
+
+
+class TestValidateOnlineRetriesEveryNetworkCall:
+    def test_repo_update_and_show_chart_go_through_retry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # `helm repo update` used to bypass the retry helper via a bare _run;
+        # prove every network call (repo add, repo update, show chart) now
+        # rides the retry path. _render_chart is stubbed so we observe only the
+        # resolve/repo commands here.
+        retried: list[list[str]] = []
+
+        def fake_retry(cmd, env, **kwargs):  # noqa: ANN001
+            retried.append(cmd)
+            return (0, "apiVersion: v2\nname: keda\nversion: 2.20.1\n", "")
+
+        monkeypatch.setattr(validator, "_run_with_retry", fake_retry)
+        monkeypatch.setattr(validator, "_render_chart", lambda *a, **k: None)
+        # If any call slipped past the retry helper to a bare _run, fail loudly.
+        monkeypatch.setattr(
+            validator,
+            "_run",
+            lambda *a, **k: pytest.fail("network call bypassed _run_with_retry"),
+        )
+
+        (ref,) = validator.build_refs({"keda": _classic()})
+        errors = validator.validate_online([ref])
+        assert errors == []
+
+        joined = [" ".join(c) for c in retried]
+        assert any(c.startswith("helm repo add kedacore") for c in joined)
+        assert any(c == "helm repo update" for c in joined)
+        assert any("show chart kedacore/keda" in c for c in joined)

--- a/tests/test_helm_charts_validation.py
+++ b/tests/test_helm_charts_validation.py
@@ -412,52 +412,20 @@ class TestLiveChartsOnline:
         assert any("99.99.99" in e for e in errors)
 
 
-# ── transient-network retry guard (offline) ──────────────────────────────────
+# ── fixed-count network retry guard (offline) ────────────────────────────────
 #
-# These pin the behavior added to ride out intermittent registry blips (the
-# kind that used to force a manual rerun of integration:helm:charts-valid)
-# without masking a genuinely bad pin. All offline: _run, time.sleep and
-# random.uniform are monkeypatched so nothing sleeps or touches the network.
-
-
-class TestIsTransientError:
-    @pytest.mark.parametrize(
-        "stderr",
-        [
-            "Error: dial tcp 140.82.113.3:443: i/o timeout",
-            'Get "https://ghcr.io/v2/": net/http: TLS handshake timeout',
-            "Error: failed to fetch https://.../index.yaml : 503 Service Unavailable",
-            "Error: unexpected status from GET request: 429 Too Many Requests",
-            "read tcp 10.0.0.2:5000->1.2.3.4:443: connection reset by peer",
-            "Error: lookup registry.k8s.io on 10.0.0.2:53: no such host",
-            "Error: context deadline exceeded",
-            "timeout: command exceeded 120s",
-            "Error: Get ...: net/http: request canceled (Client.Timeout exceeded)",
-        ],
-    )
-    def test_transient_signatures_detected(self, stderr: str) -> None:
-        assert validator._is_transient_error(stderr) is True
-
-    @pytest.mark.parametrize(
-        "stderr",
-        [
-            'Error: chart "keda" matching 99.99.99 not found in kedacore index',
-            "Error: no cached repo found. (try 'helm repo update')",
-            "Error: failed to render: template: parse error at line 3",
-            "Error: values do not meet the specifications of the schema",
-            "",
-        ],
-    )
-    def test_deterministic_failures_not_transient(self, stderr: str) -> None:
-        assert validator._is_transient_error(stderr) is False
+# These pin the retry behavior added to ride out intermittent registry blips
+# (the kind that used to force a manual rerun of integration:helm:charts-valid):
+# a network-touching helm call is retried a fixed number of times and the first
+# success wins. All offline: _run and time.sleep are monkeypatched so nothing
+# sleeps or touches the network.
 
 
 class TestRunWithRetry:
     @pytest.fixture(autouse=True)
     def _no_real_sleep(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        # Retry tests must never actually sleep or jitter.
+        # Retry tests must never actually sleep.
         monkeypatch.setattr(validator.time, "sleep", lambda *_a, **_k: None)
-        monkeypatch.setattr(validator.random, "uniform", lambda *_a, **_k: 0.0)
 
     def _script(self, monkeypatch: pytest.MonkeyPatch, results: list[tuple]) -> dict:
         """Make validator._run return successive (rc, out, err) tuples, counting calls.
@@ -481,65 +449,45 @@ class TestRunWithRetry:
         assert rc == 0 and out == "ok"
         assert calls["n"] == 1
 
-    def test_transient_then_success_recovers(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        # The whole point: a blip that clears on a later attempt returns success
-        # rather than propagating a failure that would fail CI.
+    def test_first_success_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Any single successful attempt counts as success, no matter how many
+        # attempts failed before it.
         calls = self._script(
             monkeypatch,
-            [(1, "", "i/o timeout"), (1, "", "TLS handshake timeout"), (0, "ok", "")],
+            [(1, "", "boom"), (1, "", "still boom"), (0, "ok", "")],
         )
-        rc, _out, _err = validator._run_with_retry(["helm", "x"], {})
+        rc, _out, _err = validator._run_with_retry(["helm", "x"], {}, attempts=4)
         assert rc == 0
-        assert calls["n"] == 3
+        assert calls["n"] == 3  # stopped as soon as it succeeded
 
-    def test_persistent_transient_uses_transient_budget(
+    def test_retries_exactly_attempts_times_then_gives_up(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        calls = self._script(monkeypatch, [(1, "", "connection reset by peer")])
-        rc, _out, _err = validator._run_with_retry(
-            ["helm", "x"], {}, attempts=3, transient_attempts=5
-        )
+        # A persistent failure is attempted exactly `attempts` times (regardless
+        # of the failure text) and then the last result is returned.
+        calls = self._script(monkeypatch, [(1, "", "whatever")])
+        rc, _out, _err = validator._run_with_retry(["helm", "x"], {}, attempts=4)
         assert rc == 1
-        assert calls["n"] == 5  # exhausts the higher transient budget
-
-    def test_persistent_non_transient_uses_base_budget(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        # A genuinely bad pin isn't transient, so it fails fast on the base
-        # budget instead of burning the full transient retry allowance.
-        calls = self._script(monkeypatch, [(1, "", "chart version 9.9.9 not found")])
-        rc, _out, _err = validator._run_with_retry(
-            ["helm", "x"], {}, attempts=3, transient_attempts=5
-        )
-        assert rc == 1
-        assert calls["n"] == 3
-
-    def test_timeout_is_treated_as_transient(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        # _run reports a subprocess timeout as (-1, "", "timeout: ..."); that
-        # must get the transient budget so a stalled pull is retried.
-        calls = self._script(monkeypatch, [(-1, "", "timeout: command exceeded 120s")])
-        validator._run_with_retry(["helm", "x"], {}, attempts=2, transient_attempts=4)
         assert calls["n"] == 4
 
+    def test_attempts_one_means_no_retry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls = self._script(monkeypatch, [(1, "", "boom")])
+        validator._run_with_retry(["helm", "x"], {}, attempts=1)
+        assert calls["n"] == 1
+
     def test_backoff_is_exponential(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        self._script(monkeypatch, [(1, "", "i/o timeout")])
+        self._script(monkeypatch, [(1, "", "boom")])
         sleeps: list[float] = []
         monkeypatch.setattr(validator.time, "sleep", lambda s: sleeps.append(s))
-        monkeypatch.setattr(validator.random, "uniform", lambda *_a, **_k: 0.0)
-        validator._run_with_retry(
-            ["helm", "x"], {}, transient_attempts=4, base_delay=2.0, max_delay=100.0
-        )
-        # 3 sleeps between 4 attempts: 2, 4, 8 (jitter stubbed to 0).
+        validator._run_with_retry(["helm", "x"], {}, attempts=4, base_delay=2.0, max_delay=100.0)
+        # 3 sleeps between 4 attempts: 2, 4, 8.
         assert sleeps == [2.0, 4.0, 8.0]
 
     def test_backoff_capped_at_max_delay(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        self._script(monkeypatch, [(1, "", "i/o timeout")])
+        self._script(monkeypatch, [(1, "", "boom")])
         sleeps: list[float] = []
         monkeypatch.setattr(validator.time, "sleep", lambda s: sleeps.append(s))
-        monkeypatch.setattr(validator.random, "uniform", lambda *_a, **_k: 0.0)
-        validator._run_with_retry(
-            ["helm", "x"], {}, transient_attempts=5, base_delay=10.0, max_delay=15.0
-        )
+        validator._run_with_retry(["helm", "x"], {}, attempts=5, base_delay=10.0, max_delay=15.0)
         assert sleeps == [10.0, 15.0, 15.0, 15.0]
 
 


### PR DESCRIPTION
## Summary

The `integration:helm:charts-valid` job intermittently failed on transient registry blips (timeouts, connection resets, 5xx) and had to be re-run by hand. This hardens `.github/scripts/validate_helm_charts.py` so a network blip is ridden out in-process while a genuinely bad chart pin still fails.

- Retry every network-touching helm call a fixed number of times (`_run_with_retry`, `attempts=4`) with exponential backoff (2s → 4s → 8s, capped at 20s). The first successful attempt wins; any failure is retried regardless of cause.
- Route `helm repo update` and `helm template` through the retry helper — they previously bypassed it via a bare `_run`, so a blip in either failed the whole job.
- Thread `verbose` through so a retry is visible in the CI log.

No behavior change for a genuinely bad pin: it fails on every attempt and still surfaces (a few seconds later).

## Type of change

- [x] `fix:` Bug fix (non-breaking)
- [x] `ci:` CI / tooling change

## Testing

- [x] `pytest tests/` passes locally
- [x] New tests added for new behavior

`pytest tests/test_helm_charts_validation.py` -> 45 passed, 2 skipped (the opt-in online tier). `ruff check` and `ruff format --check` are clean on both files. `python3 .github/scripts/validate_helm_charts.py --mode offline` -> exit 0.

New offline tests cover first-success-wins, the fixed retry count, `attempts=1` (no retry), exponential/capped backoff, and that every network call (repo add, repo update, show chart, template) routes through the retry helper (monkeypatched — no sleeps or network).

## Checklist

- [x] Documentation updated (inline docstrings) as needed
- [x] No secrets, credentials, or customer data committed
- [x] Changes align with the architecture described in `docs/ARCHITECTURE.md`
