### PR TITLE
fix: surface real AWS errors in capacity checks instead of masking as…

### DIFF
--- a/cli/capacity/__init__.py
+++ b/cli/capacity/__init__.py
@@ -29,6 +29,7 @@ from .history import (
 )
 from .models import (
     GPU_INSTANCE_SPECS,
+    CapacityCheckError,
     CapacityEstimate,
     InstanceTypeInfo,
     SpotPriceInfo,
@@ -45,6 +46,7 @@ __all__ = [
     "GPU_INSTANCE_SPECS",
     "BedrockCapacityAdvisor",
     "BedrockCapacityRecommendation",
+    "CapacityCheckError",
     "CapacityChecker",
     "CapacityEstimate",
     "CapacityHistoryStore",

--- a/cli/capacity/checker.py
+++ b/cli/capacity/checker.py
@@ -49,6 +49,7 @@ from cli.config import GCOConfig, get_config
 from . import blocks
 from .models import (
     GPU_INSTANCE_SPECS,
+    CapacityCheckError,
     CapacityEstimate,
     InstanceTypeInfo,
     SpotPriceInfo,
@@ -228,7 +229,15 @@ class CapacityChecker:
         return result
 
     def check_instance_available_in_region(self, instance_type: str, region: str) -> bool:
-        """Check if an instance type is offered in a region."""
+        """Check whether an instance type is offered in a region.
+
+        Returns ``True``/``False`` only from a *successful* offerings lookup, so a
+        ``False`` genuinely means "not offered in this region". If the underlying
+        DescribeInstanceTypeOfferings call fails (throttling, expired/invalid
+        credentials, denied permissions, region not opted in) this raises
+        :class:`CapacityCheckError` instead of silently returning ``False`` — a
+        failed check must not be reported to the user as "not available".
+        """
         cache_key = f"{region}"
         if cache_key not in self._offerings_cache:
             try:
@@ -239,14 +248,13 @@ class CapacityChecker:
                     for offering in page["InstanceTypeOfferings"]:
                         offerings.add(offering["InstanceType"])
                 self._offerings_cache[cache_key] = offerings
-            except ClientError as e:
-                logger.debug("Failed to check instance offerings in %s: %s", region, e)
-                return False  # Assume unavailable if we can't check
-            except Exception as e:
-                logger.warning("Unexpected error checking offerings in %s: %s", region, e)
-                return False
+            except (ClientError, BotoCoreError) as e:
+                logger.warning("Failed to check instance offerings in %s: %s", region, e)
+                raise CapacityCheckError(
+                    f"Could not check instance availability in {region}: {e}"
+                ) from e
 
-        return instance_type in self._offerings_cache.get(cache_key, set())
+        return instance_type in self._offerings_cache[cache_key]
 
     def get_availability_zones(self, region: str) -> list[str]:
         """Get availability zones for a region."""
@@ -257,7 +265,7 @@ class CapacityChecker:
             )
             return [az["ZoneName"] for az in response["AvailabilityZones"]]
         except ClientError as e:
-            logger.debug("Failed to get availability zones for %s: %s", region, e)
+            logger.warning("Failed to get availability zones for %s: %s", region, e)
             return []
         except Exception as e:
             logger.warning("Unexpected error getting AZs for %s: %s", region, e)
@@ -286,7 +294,7 @@ class CapacityChecker:
 
             return len(offering_azs) / len(total_azs) if total_azs else None
         except Exception as e:
-            logger.debug("Failed to get AZ coverage for %s in %s: %s", instance_type, region, e)
+            logger.warning("Failed to get AZ coverage for %s in %s: %s", instance_type, region, e)
             return None
 
     def get_spot_placement_score(
@@ -329,7 +337,7 @@ class CapacityChecker:
                 return {}
             raise
         except Exception as e:
-            logger.debug(
+            logger.warning(
                 "Failed to get spot placement scores for %s in %s: %s", instance_type, region, e
             )
             return {}
@@ -444,7 +452,9 @@ class CapacityChecker:
                         return price
 
         except ClientError as e:
-            logger.debug("Failed to get on-demand price for %s in %s: %s", instance_type, region, e)
+            logger.warning(
+                "Failed to get on-demand price for %s in %s: %s", instance_type, region, e
+            )
         except Exception as e:
             logger.warning(
                 "Unexpected error getting pricing for %s in %s: %s", instance_type, region, e

--- a/cli/capacity/models.py
+++ b/cli/capacity/models.py
@@ -6,6 +6,17 @@ from dataclasses import dataclass, field
 from typing import Any
 
 
+class CapacityCheckError(Exception):
+    """A primary capacity availability check failed at the AWS API level.
+
+    Raised when an availability lookup (e.g. DescribeInstanceTypeOfferings)
+    fails due to throttling, expired/invalid credentials, denied permissions,
+    or a region that isn't opted in. This is distinct from a *successful* lookup
+    that reports an instance type as genuinely not offered — masking such
+    failures as "unavailable" hides real, actionable errors from the caller.
+    """
+
+
 @dataclass
 class InstanceTypeInfo:
     """Information about an EC2 instance type."""
@@ -50,6 +61,7 @@ class CapacityEstimate:
     price_per_hour: float | None = None
     recommendation: str = ""
     details: dict[str, Any] = field(default_factory=dict)
+    error: str | None = None  # Explicit error string for partial/degraded results
 
 
 # GPU instance type specifications (common types)

--- a/cli/capacity/multi_region.py
+++ b/cli/capacity/multi_region.py
@@ -48,6 +48,9 @@ class MultiRegionCapacityChecker:
     def __init__(self, config: GCOConfig | None = None):
         self.config = config or get_config()
         self._session = boto3.Session()
+        # Errors from the most recent get_all_regions_capacity() sweep, so an
+        # empty result can be distinguished as "checks failed" vs "no regions".
+        self._last_region_errors: list[str] = []
 
     def get_region_capacity(self, region: str) -> RegionCapacity:
         """Get capacity information for a single region."""
@@ -137,12 +140,14 @@ class MultiRegionCapacityChecker:
         stacks = aws_client.discover_regional_stacks()
 
         capacities = []
+        self._last_region_errors = []
         for region in stacks:
             try:
                 capacity = self.get_region_capacity(region)
                 capacities.append(capacity)
             except Exception as e:
                 logger.warning("Failed to get capacity for region %s: %s", region, e)
+                self._last_region_errors.append(f"{region}: {e}")
                 continue
 
         return capacities
@@ -174,6 +179,17 @@ class MultiRegionCapacityChecker:
         capacities = self.get_all_regions_capacity()
 
         if not capacities:
+            if self._last_region_errors:
+                # The emptiness is due to underlying AWS failures, not an absence
+                # of configured regions — surface the real error instead of a
+                # benign "no capacity" message that masks it.
+                details = "; ".join(self._last_region_errors)
+                return {
+                    "region": self.config.default_region,
+                    "reason": f"Capacity checks failed for all regions: {details}",
+                    "score": 0,
+                    "error": details,
+                }
             return {
                 "region": self.config.default_region,
                 "reason": "No capacity data available, using default region",

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -2901,9 +2901,7 @@ class TestWeightedRecommendRegion:
                 ]
                 return []
 
-            with patch.object(
-                checker, "get_all_regions_capacity", side_effect=_fail_sweep
-            ):
+            with patch.object(checker, "get_all_regions_capacity", side_effect=_fail_sweep):
                 result = checker.recommend_region_for_job()
 
             assert result["region"] == "us-east-1"

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -744,22 +744,25 @@ class TestCapacityCheckerNewMethods:
                 assert result is False
 
     def test_check_instance_available_in_region_error(self):
-        """Test checking instance availability when API fails."""
-        from cli.capacity import CapacityChecker
+        """An AWS API failure must raise CapacityCheckError, not mask as False."""
+        from botocore.exceptions import ClientError
+
+        from cli.capacity import CapacityChecker, CapacityCheckError
 
         with patch("cli.capacity.checker.get_config") as mock_config:
             mock_config.return_value = MagicMock()
 
             with patch("boto3.Session") as mock_session:
                 mock_ec2 = MagicMock()
-                mock_ec2.get_paginator.side_effect = Exception("API Error")
+                mock_ec2.get_paginator.side_effect = ClientError(
+                    {"Error": {"Code": "RequestLimitExceeded", "Message": "slow"}},
+                    "DescribeInstanceTypeOfferings",
+                )
                 mock_session.return_value.client.return_value = mock_ec2
 
                 checker = CapacityChecker()
-                result = checker.check_instance_available_in_region("g4dn.xlarge", "us-east-1")
-
-                # Should return False when we can't check
-                assert result is False
+                with pytest.raises(CapacityCheckError, match="us-east-1"):
+                    checker.check_instance_available_in_region("g4dn.xlarge", "us-east-1")
 
     def test_get_availability_zones_success(self):
         """Test getting availability zones."""
@@ -2880,6 +2883,33 @@ class TestWeightedRecommendRegion:
 
                 assert result["region"] == "us-east-1"
                 assert "No capacity data" in result["reason"]
+
+    def test_recommend_region_surfaces_underlying_errors(self):
+        """Empty capacities due to AWS failures surface the real error, not a
+        benign 'no capacity' message that masks throttling / auth failures."""
+        from cli.capacity import MultiRegionCapacityChecker
+
+        with patch("cli.capacity.multi_region.get_config") as mock_config:
+            mock_config.return_value = MagicMock(default_region="us-east-1")
+
+            checker = MultiRegionCapacityChecker()
+
+            def _fail_sweep():
+                checker._last_region_errors = [
+                    "us-east-1: RequestLimitExceeded",
+                    "us-west-2: AuthFailure",
+                ]
+                return []
+
+            with patch.object(
+                checker, "get_all_regions_capacity", side_effect=_fail_sweep
+            ):
+                result = checker.recommend_region_for_job()
+
+            assert result["region"] == "us-east-1"
+            assert "failed" in result["reason"].lower()
+            assert "RequestLimitExceeded" in result["reason"]
+            assert result["error"]
 
     def test_weighted_recommend_with_spot_pricing(self):
         """Weighted scoring should factor in spot pricing data."""

--- a/tests/test_capacity_checker_coverage.py
+++ b/tests/test_capacity_checker_coverage.py
@@ -14,7 +14,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 from botocore.exceptions import ClientError
 
-from cli.capacity import CapacityChecker, CapacityEstimate, InstanceTypeInfo, SpotPriceInfo
+from cli.capacity import (
+    CapacityChecker,
+    CapacityCheckError,
+    CapacityEstimate,
+    InstanceTypeInfo,
+    SpotPriceInfo,
+)
 
 
 def _make_checker():
@@ -65,7 +71,8 @@ def test_get_instance_info_client_error_returns_none():
     assert checker.get_instance_info("x9.unknown") is None
 
 
-def test_check_instance_available_client_error_returns_false():
+def test_check_instance_available_client_error_raises():
+    """An API failure must raise CapacityCheckError, not mask itself as False."""
     checker = _make_checker()
     mock_ec2 = MagicMock()
     mock_ec2.get_paginator.side_effect = ClientError(
@@ -73,7 +80,8 @@ def test_check_instance_available_client_error_returns_false():
         "DescribeInstanceTypeOfferings",
     )
     checker._session.client = MagicMock(return_value=mock_ec2)
-    assert checker.check_instance_available_in_region("g5.xlarge", "us-east-1") is False
+    with pytest.raises(CapacityCheckError, match="us-east-1"):
+        checker.check_instance_available_in_region("g5.xlarge", "us-east-1")
 
 
 def test_get_availability_zones_client_error_returns_empty():
@@ -443,3 +451,74 @@ def test_assess_high_az_coverage_no_scarcity():
         "g5.xlarge", None, 1.0, spot_placement_scores={"a": 9}, spot_prices=[], az_coverage=0.8
     )
     assert avail == "high"
+
+
+# ---------------------------------------------------------------------------
+# CapacityCheckError propagation: an AWS API failure in the primary
+# availability check must surface as a typed error, not a benign
+# "unavailable" result that masks throttling / auth / opt-in failures.
+# ---------------------------------------------------------------------------
+
+
+def _offerings_paginator(instance_types):
+    paginator = MagicMock()
+    paginator.paginate.return_value = [
+        {"InstanceTypeOfferings": [{"InstanceType": it} for it in instance_types]}
+    ]
+    return paginator
+
+
+def test_check_instance_available_genuinely_not_offered_returns_false():
+    """A successful lookup that omits the type still returns False (no regression)."""
+    checker = _make_checker()
+    mock_ec2 = MagicMock()
+    mock_ec2.get_paginator.return_value = _offerings_paginator(["m5.large", "c5.large"])
+    checker._session.client = MagicMock(return_value=mock_ec2)
+    assert checker.check_instance_available_in_region("p5.48xlarge", "us-east-1") is False
+
+
+def test_check_instance_available_offered_returns_true():
+    checker = _make_checker()
+    mock_ec2 = MagicMock()
+    mock_ec2.get_paginator.return_value = _offerings_paginator(["g5.xlarge", "m5.large"])
+    checker._session.client = MagicMock(return_value=mock_ec2)
+    assert checker.check_instance_available_in_region("g5.xlarge", "us-east-1") is True
+
+
+@pytest.mark.parametrize("code", ["RequestLimitExceeded", "AuthFailure", "OptInRequired"])
+def test_check_instance_available_raises_on_api_failure(code):
+    checker = _make_checker()
+    mock_ec2 = MagicMock()
+    mock_ec2.get_paginator.side_effect = ClientError(
+        {"Error": {"Code": code, "Message": code}}, "DescribeInstanceTypeOfferings"
+    )
+    checker._session.client = MagicMock(return_value=mock_ec2)
+    with pytest.raises(CapacityCheckError) as exc:
+        checker.check_instance_available_in_region("g5.xlarge", "eu-west-1")
+    # Message carries region and underlying error for a detailed MCP response.
+    assert "eu-west-1" in str(exc.value)
+    assert code in str(exc.value)
+
+
+def test_estimate_capacity_propagates_capacity_check_error():
+    """estimate_capacity must not swallow a raised CapacityCheckError."""
+    checker = _make_checker()
+    mock_ec2 = MagicMock()
+    mock_ec2.get_paginator.side_effect = ClientError(
+        {"Error": {"Code": "RequestLimitExceeded", "Message": "slow"}},
+        "DescribeInstanceTypeOfferings",
+    )
+    checker._session.client = MagicMock(return_value=mock_ec2)
+    with pytest.raises(CapacityCheckError):
+        checker.estimate_capacity("g5.xlarge", "us-east-1")
+
+
+def test_estimate_capacity_genuinely_unavailable_no_regression():
+    """A genuinely not-offered type still yields availability='unavailable'."""
+    checker = _make_checker()
+    mock_ec2 = MagicMock()
+    mock_ec2.get_paginator.return_value = _offerings_paginator(["m5.large"])
+    checker._session.client = MagicMock(return_value=mock_ec2)
+    estimates = checker.estimate_capacity("p5.48xlarge", "us-east-1")
+    assert len(estimates) == 1
+    assert estimates[0].availability == "unavailable"

--- a/tests/test_capacity_cmd_coverage.py
+++ b/tests/test_capacity_cmd_coverage.py
@@ -570,3 +570,32 @@ class TestCapacityCmdCancelReservation:
             cli, ["capacity", "cancel-reservation", "-o", "cr-x", "-r", "us-east-1", "-y"]
         )
         assert result.exit_code == 1
+
+
+class TestCapacityCheckError:
+    """A CapacityCheckError from the checker must become a non-zero CLI exit
+    with a detailed error message (which cli_runner.py turns into an MCP
+    ``{"error": ...}`` response) rather than a silent success."""
+
+    @patch("cli.commands.capacity_cmd.get_capacity_checker")
+    @patch("cli.commands.capacity_cmd.get_output_formatter")
+    def test_check_exits_nonzero_on_capacity_check_error(self, mock_fmt_fn, mock_checker_fn):
+        from cli.capacity import CapacityCheckError
+        from cli.main import cli
+
+        formatter = MagicMock()
+        mock_fmt_fn.return_value = formatter
+        mock_checker_fn.return_value.estimate_capacity.side_effect = CapacityCheckError(
+            "Could not check instance availability in eu-west-1: RequestLimitExceeded"
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["capacity", "check", "-i", "g5.xlarge", "-r", "eu-west-1"]
+        )
+
+        assert result.exit_code == 1
+        # The detailed underlying cause is surfaced to the user.
+        (msg,), _ = formatter.print_error.call_args
+        assert "eu-west-1" in msg
+        assert "RequestLimitExceeded" in msg

--- a/tests/test_capacity_cmd_coverage.py
+++ b/tests/test_capacity_cmd_coverage.py
@@ -590,9 +590,7 @@ class TestCapacityCheckError:
         )
 
         runner = CliRunner()
-        result = runner.invoke(
-            cli, ["capacity", "check", "-i", "g5.xlarge", "-r", "eu-west-1"]
-        )
+        result = runner.invoke(cli, ["capacity", "check", "-i", "g5.xlarge", "-r", "eu-west-1"])
 
         assert result.exit_code == 1
         # The detailed underlying cause is surfaced to the user.


### PR DESCRIPTION
… unavailable

The CLI capacity availability check caught ClientError/BotoCoreError and returned False ("assume unavailable"), so throttling, expired credentials, denied permissions, and non-opted-in regions were reported to users as "not available in region" — indistinguishable from genuine no-capacity, and the CLI exited 0 so the MCP wrapper reported success.

- Add CapacityCheckError (cli/capacity/models.py); raise it from check_instance_available_in_region on a failed offerings lookup. Only a genuinely-successful lookup returns True/False. estimate_capacity lets it propagate; the capacity command handlers' except-Exception turns it into a detailed non-zero exit, which cli_runner.py renders as an MCP {"error": ...}.
- Keep graceful degradation for secondary signals (spot score, AZs, AZ coverage, on-demand price) but log failures at warning so they're visible.
- multi_region.recommend_region_for_job now distinguishes "all region checks failed" (surfaces the underlying errors) from "no regions configured".
- Add CapacityEstimate.error field (default None) for explicit degraded-result errors; serializes via asdict into CLI/MCP JSON.
- Tests: CapacityCheckError propagation (RequestLimitExceeded/AuthFailure/ OptInRequired), no-regression on genuinely not-offered types, non-zero CLI exit with detailed message, and multi-region error surfacing.

<!--
Thanks for contributing to Global Capacity Orchestrator (GCO)! Please fill out the sections below.
Delete any sections that don't apply.
-->

## Summary

<!-- Brief description of what this PR does and why -->

## Type of change

<!-- Check all that apply. The leading token (feat:, fix:, etc.) is used by
.github/release.yml to categorize this PR in the auto-generated release notes. -->

- [ ] `feat:` New feature (non-breaking)
- [ x] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

<!-- How was this change verified? -->

- [x ] `pytest tests/` passes locally
- [x ] `cdk synth` succeeds (if CDK code changed)
- [ x] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

<!-- If deployed to a real account, note what was verified. -->

## Checklist

- [ ] Documentation updated (README, `docs/`, inline docstrings) as needed
- [x ] No secrets, credentials, or customer data committed
- [ ] `requirements-lock.txt` regenerated if `pyproject.toml` changed
- [ ] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

<!-- Link any related issues: "Fixes #123" or "Related to #456" -->
