### PR TITLE
Harden ephemeral SSM bastions and destroy cleanup

### DIFF
--- a/cli/ephemeral_bastion.py
+++ b/cli/ephemeral_bastion.py
@@ -16,10 +16,11 @@ teardown must never leave a paid instance running):
 * the CLI tears it down in a ``finally:`` block.
 
 Network posture: the instance reuses the cluster's own security group (which is
-self-referencing, so it can reach the private API endpoint) and is placed in a
-public subnet with a public IP purely so the SSM agent can reach the Systems
-Manager service. **No inbound ports are opened** — SSM is agent-initiated
-outbound only — so the public IP is not an ingress surface.
+self-referencing, so it can reach the private API endpoint) and is placed in one
+of the cluster's private subnets **without a public IP**. GCO private subnets
+have NAT egress, which lets the SSM agent reach Systems Manager over HTTPS while
+keeping the instance unreachable from the internet. No inbound ports are opened;
+SSM is agent-initiated outbound only.
 
 Style matches :mod:`cli.ssm_tunnel`: pure, validated argv builders (list form,
 never a shell string) that are fully unit-testable, plus thin runtime wrappers
@@ -69,6 +70,7 @@ AL2023_AMI_SSM_PARAMETER = "/aws/service/ami-amazon-linux-latest/al2023-ami-kern
 #               Name=instance-state-name,Values=running,pending
 TAG_EPHEMERAL_KEY = "gco:ephemeral"
 TAG_PURPOSE_KEY = "gco:purpose"
+TAG_PROJECT_KEY = "gco:project"
 TAG_TTL_KEY = "gco:ttl-minutes"
 BASTION_PURPOSE = "cluster-observability"
 
@@ -154,13 +156,11 @@ BASTION_NAME = bastion_instance_name()
 
 @dataclass(frozen=True)
 class BastionNetwork:
-    """The VPC placement an ephemeral bastion needs to reach the private API."""
+    """Private VPC placement for an ephemeral bastion."""
 
     vpc_id: str
     subnet_id: str
     security_group_id: str
-    # True when ``subnet_id`` auto-assigns public IPs (SSM egress over the IGW).
-    public_subnet: bool
 
 
 # --------------------------------------------------------------------------
@@ -218,9 +218,13 @@ def build_describe_cluster_network_command(cluster: str, region: str) -> list[st
     ]
 
 
-def build_describe_public_subnet_command(vpc_id: str, region: str) -> list[str]:
-    """``aws ec2 describe-subnets`` argv for the first public subnet in ``vpc_id``."""
-    _validate(vpc_id, _VPC_RE, "vpc id")
+def build_describe_private_cluster_subnet_command(subnet_ids: list[str], region: str) -> list[str]:
+    """Find the first private subnet among the EKS control-plane subnets."""
+    if not subnet_ids:
+        raise ValueError("At least one cluster subnet id is required")
+    validated_subnets = [
+        _validate(subnet_id, _SUBNET_RE, "cluster subnet id") for subnet_id in subnet_ids
+    ]
     _validate(region, _REGION_RE, "region")
     return [
         "aws",
@@ -228,9 +232,10 @@ def build_describe_public_subnet_command(vpc_id: str, region: str) -> list[str]:
         "describe-subnets",
         "--region",
         region,
+        "--subnet-ids",
+        *validated_subnets,
         "--filters",
-        f"Name=vpc-id,Values={vpc_id}",
-        "Name=map-public-ip-on-launch,Values=true",
+        "Name=map-public-ip-on-launch,Values=false",
         "--query",
         "Subnets[0].SubnetId",
         "--output",
@@ -300,12 +305,18 @@ def build_add_role_to_profile_command(
     ]
 
 
-def _tag_specification(ttl_minutes: int, instance_name: str = BASTION_NAME) -> str:
+def _tag_specification(
+    ttl_minutes: int,
+    instance_name: str = BASTION_NAME,
+    project_name: str = DEFAULT_PROJECT_NAME,
+) -> str:
     """Build the ``--tag-specifications`` value stamping the ephemeral markers."""
+    project = _validate_project(project_name)
     tags = (
         f"{{Key=Name,Value={instance_name}}},"
         f"{{Key={TAG_EPHEMERAL_KEY},Value=true}},"
         f"{{Key={TAG_PURPOSE_KEY},Value={BASTION_PURPOSE}}},"
+        f"{{Key={TAG_PROJECT_KEY},Value={project}}},"
         f"{{Key={TAG_TTL_KEY},Value={ttl_minutes}}}"
     )
     return f"ResourceType=instance,Tags=[{tags}]"
@@ -321,8 +332,8 @@ def build_run_instances_command(
     region: str,
     user_data: str,
     ttl_minutes: int = DEFAULT_TTL_MINUTES,
-    associate_public_ip: bool = True,
     instance_name: str = BASTION_NAME,
+    project_name: str = DEFAULT_PROJECT_NAME,
 ) -> list[str]:
     """Build the validated ``aws ec2 run-instances`` argv, safeguards included.
 
@@ -368,12 +379,9 @@ def build_run_instances_command(
         user_data,
         # Orphan safeguard #3: greppable ephemeral tags.
         "--tag-specifications",
-        _tag_specification(ttl, instance_name),
+        _tag_specification(ttl, instance_name, project_name),
     ]
-    if associate_public_ip:
-        cmd.append("--associate-public-ip-address")
-    else:
-        cmd.append("--no-associate-public-ip-address")
+    cmd.append("--no-associate-public-ip-address")
     # Ask only for the instance id back.
     cmd += ["--query", "Instances[0].InstanceId", "--output", "text"]
     return cmd
@@ -493,7 +501,13 @@ def _run_aws(cmd: list[str], *, allow_exists: bool = False) -> str:
         ) from exc
     if result.returncode != 0:
         stderr = result.stderr or ""
-        if allow_exists and ("EntityAlreadyExists" in stderr or "already exists" in stderr):
+        if allow_exists and (
+            "EntityAlreadyExists" in stderr
+            or "already exists" in stderr
+            # IAM reports an idempotent add-role-to-instance-profile call as
+            # this quota error when the profile already contains its one role.
+            or "Cannot exceed quota for InstanceSessionsPerInstanceProfile" in stderr
+        ):
             return result.stdout or ""
         raise RuntimeError(f"AWS CLI command failed ({' '.join(cmd[:3])}): {stderr.strip()}")
     return result.stdout or ""
@@ -506,11 +520,12 @@ def resolve_bastion_ami(region: str) -> str:
 
 
 def resolve_bastion_network(cluster: str, region: str) -> BastionNetwork:
-    """Discover the VPC, a usable subnet, and the cluster SG for the bastion.
+    """Discover private VPC placement for the bastion.
 
-    Prefers a public subnet (auto-assigned public IP for SSM egress). Falls back
-    to the first cluster subnet (assumes NAT or SSM VPC endpoints) when the VPC
-    exposes no public subnet.
+    GCO gives EKS private control-plane subnets with NAT egress. We select one
+    of those subnets and refuse a public-subnet fallback, ensuring the bastion
+    never receives a public IP. A deployment without NAT can provide Systems
+    Manager interface VPC endpoints instead.
     """
     vpc, sg, subnets = parse_cluster_network(
         _run_aws(build_describe_cluster_network_command(cluster, region))
@@ -518,24 +533,22 @@ def resolve_bastion_network(cluster: str, region: str) -> BastionNetwork:
     _validate(vpc, _VPC_RE, "cluster vpc id")
     _validate(sg, _SG_RE, "cluster security group id")
 
-    public_subnet = _clean_scalar(_run_aws(build_describe_public_subnet_command(vpc, region)))
-    if public_subnet:
-        return BastionNetwork(
-            vpc, _validate(public_subnet, _SUBNET_RE, "public subnet id"), sg, True
-        )
-
     if not subnets:
         raise RuntimeError(
-            f"No public subnet and no cluster subnets found in VPC {vpc}; cannot place a bastion."
+            f"No cluster subnets found in VPC {vpc}; cannot place a private bastion."
         )
-    fallback = _validate(str(subnets[0]), _SUBNET_RE, "fallback subnet id")
-    logger.warning(
-        "No public subnet in %s; using cluster subnet %s without a public IP "
-        "(requires NAT or SSM VPC endpoints for the agent to connect).",
-        vpc,
-        fallback,
+    private_subnet = _clean_scalar(
+        _run_aws(build_describe_private_cluster_subnet_command(list(subnets), region))
     )
-    return BastionNetwork(vpc, fallback, sg, False)
+    if not private_subnet:
+        raise RuntimeError(
+            f"No private EKS subnet found in VPC {vpc}; refusing to launch a public bastion."
+        )
+    return BastionNetwork(
+        vpc,
+        _validate(private_subnet, _SUBNET_RE, "private cluster subnet id"),
+        sg,
+    )
 
 
 def ensure_bastion_iam(project_name: str = DEFAULT_PROJECT_NAME) -> None:
@@ -567,8 +580,8 @@ def launch_bastion(
         region=region,
         user_data=render_user_data(ttl_minutes),
         ttl_minutes=ttl_minutes,
-        associate_public_ip=network.public_subnet,
         instance_name=bastion_instance_name(project_name),
+        project_name=project_name,
     )
     last_error: Exception | None = None
     for attempt in range(_PROFILE_PROPAGATION_RETRIES):
@@ -610,8 +623,8 @@ def wait_until_ssm_online(
         time.sleep(poll_interval_seconds)
     raise RuntimeError(
         f"Instance {instance_id} did not come Online in SSM within "
-        f"{int(timeout_seconds)}s. Check that the instance can reach the SSM service "
-        "(public subnet with egress, or SSM VPC endpoints)."
+        f"{int(timeout_seconds)}s. Check that the private subnet can reach the SSM service "
+        "through NAT egress or Systems Manager interface VPC endpoints."
     )
 
 

--- a/cli/stacks.py
+++ b/cli/stacks.py
@@ -1924,7 +1924,14 @@ class StackManager:
         if not self._image_registry_destroy_preflight(force=force):
             return False, [], list(stacks)
 
-        # Phase 0: Clean up backup vault recovery points so the global stack
+        # Phase 0a: The CLI creates SSM bastions outside CloudFormation. A
+        # crashed tunnel process can therefore leave an instance (and its
+        # primary ENI) in a regional VPC, which blocks VPC deletion. Terminate
+        # every project-scoped ephemeral bastion and wait for its ENIs before
+        # asking CloudFormation to delete anything.
+        self.cleanup_orphaned_bastions(stacks)
+
+        # Phase 0b: Clean up backup vault recovery points so the global stack
         # can be deleted cleanly by CloudFormation.
         self._cleanup_backup_vault()
 
@@ -2145,6 +2152,221 @@ class StackManager:
 
         except Exception as e:
             print(f"  Warning: Backup vault cleanup failed (non-fatal): {e}")
+
+    def cleanup_orphaned_bastions(self, stacks: list[str] | None = None) -> int:
+        """Terminate CLI-managed ephemeral bastions before regional teardown.
+
+        The bastion is intentionally outside CloudFormation, so a crashed
+        tunnel process can leave its EC2 instance and primary ENI in a stack's
+        VPC. This sweep is scoped by the regional stack's VPC plus the
+        ``gco:ephemeral`` / purpose / project tags. It runs before every
+        ``destroy-all`` attempt and waits for both instance termination and ENI
+        release so VPC deletion does not race EC2 cleanup.
+
+        Returns the number of instances for which termination was requested.
+        All AWS errors are non-fatal: CloudFormation still gets a chance to
+        delete the stack and the destroy-all retry loop will run this sweep
+        again if necessary.
+        """
+        if stacks is None:
+            stacks = self.list_stacks()
+        regional_stacks = [
+            stack
+            for stack in stacks
+            if not stack.endswith(("-global", "-api-gateway", "-monitoring", "-analytics"))
+        ]
+
+        if not regional_stacks:
+            return 0
+        if len(regional_stacks) == 1:
+            terminated = self._cleanup_orphaned_bastions(regional_stacks[0])
+        else:
+            # Each region has independent EC2 waiters. Run them concurrently so
+            # one slow termination does not add its full timeout to every other
+            # region before CloudFormation can start deleting stacks.
+            with ThreadPoolExecutor(max_workers=min(4, len(regional_stacks))) as executor:
+                terminated = sum(executor.map(self._cleanup_orphaned_bastions, regional_stacks))
+        if terminated:
+            print(
+                f"  Requested termination for {terminated} orphaned ephemeral "
+                "SSM bastion(s) before stack deletion."
+            )
+        return terminated
+
+    def _cleanup_orphaned_bastions(self, stack_name: str) -> int:
+        """Terminate this regional stack's tagged bastions and release their ENIs."""
+        import boto3
+
+        from .ephemeral_bastion import (
+            BASTION_PURPOSE,
+            TAG_EPHEMERAL_KEY,
+            TAG_PROJECT_KEY,
+            TAG_PURPOSE_KEY,
+            bastion_instance_name,
+        )
+
+        region = self._get_deploy_region(stack_name)
+        if not region:
+            return 0
+
+        project_name = str(self.config.project_name)
+        expected_name = bastion_instance_name(project_name)
+        try:
+            ec2 = boto3.client("ec2", region_name=region)
+            vpcs = ec2.describe_vpcs(
+                Filters=[{"Name": "tag:aws:cloudformation:stack-name", "Values": [stack_name]}]
+            ).get("Vpcs", [])
+        except Exception as exc:  # noqa: BLE001 - destroy cleanup is best-effort
+            print(f"  Warning: Bastion cleanup could not inspect {stack_name}: {exc}")
+            return 0
+
+        instance_ids: list[str] = []
+        eni_ids: list[str] = []
+        for vpc in vpcs:
+            vpc_id = vpc.get("VpcId")
+            if not vpc_id:
+                continue
+            try:
+                reservations = ec2.describe_instances(
+                    Filters=[
+                        {"Name": "vpc-id", "Values": [vpc_id]},
+                        {"Name": f"tag:{TAG_EPHEMERAL_KEY}", "Values": ["true"]},
+                        {"Name": f"tag:{TAG_PURPOSE_KEY}", "Values": [BASTION_PURPOSE]},
+                        {
+                            "Name": "instance-state-name",
+                            "Values": [
+                                "pending",
+                                "running",
+                                "stopping",
+                                "stopped",
+                                "shutting-down",
+                            ],
+                        },
+                    ]
+                ).get("Reservations", [])
+            except Exception as exc:  # noqa: BLE001 - continue with other VPCs
+                logger.warning("Bastion lookup failed in %s (%s): %s", stack_name, vpc_id, exc)
+                continue
+
+            for reservation in reservations:
+                for instance in reservation.get("Instances", []):
+                    tags = {
+                        str(tag.get("Key")): str(tag.get("Value"))
+                        for tag in instance.get("Tags", [])
+                        if tag.get("Key") is not None
+                    }
+                    tagged_project = tags.get(TAG_PROJECT_KEY)
+                    # New bastions carry gco:project. For bastions created by an
+                    # older CLI, use the project-scoped Name tag as the safe
+                    # backwards-compatible ownership check.
+                    if tagged_project != project_name and not (
+                        tagged_project is None and tags.get("Name") == expected_name
+                    ):
+                        continue
+                    instance_id = instance.get("InstanceId")
+                    if instance_id:
+                        instance_ids.append(str(instance_id))
+                    for interface in instance.get("NetworkInterfaces", []):
+                        attachment = interface.get("Attachment") or {}
+                        # Only the primary ENI is owned by the ephemeral
+                        # instance lifecycle. Never delete an operator-attached
+                        # secondary ENI, even if it later becomes detached.
+                        if not (
+                            attachment.get("DeviceIndex") == 0
+                            and attachment.get("DeleteOnTermination") is True
+                        ):
+                            continue
+                        eni_id = interface.get("NetworkInterfaceId")
+                        if eni_id:
+                            eni_ids.append(str(eni_id))
+
+        instance_ids = list(dict.fromkeys(instance_ids))
+        eni_ids = list(dict.fromkeys(eni_ids))
+        if not instance_ids:
+            return 0
+
+        try:
+            ec2.terminate_instances(InstanceIds=instance_ids)
+        except Exception as exc:  # noqa: BLE001 - report and let destroy retry
+            print(f"  Warning: Failed to terminate ephemeral bastion(s) in {stack_name}: {exc}")
+            return 0
+
+        print(
+            f"  Terminating {len(instance_ids)} ephemeral SSM bastion(s) in "
+            f"{stack_name}: {', '.join(instance_ids)}"
+        )
+        try:
+            ec2.get_waiter("instance_terminated").wait(
+                InstanceIds=instance_ids,
+                WaiterConfig={"Delay": 5, "MaxAttempts": 60},
+            )
+        except Exception as exc:  # noqa: BLE001 - ENI polling below may still succeed
+            logger.warning("Timed out waiting for bastion termination in %s: %s", stack_name, exc)
+
+        remaining_enis = self._wait_for_bastion_network_interfaces(ec2, eni_ids)
+        if remaining_enis:
+            print(
+                f"  Warning: {len(remaining_enis)} bastion network interface(s) in "
+                f"{stack_name} have not released yet: {', '.join(sorted(remaining_enis))}. "
+                "The destroy retry will check again."
+            )
+        return len(instance_ids)
+
+    @staticmethod
+    def _wait_for_bastion_network_interfaces(
+        ec2: Any,
+        eni_ids: list[str],
+        *,
+        timeout_seconds: float = 120.0,
+        poll_interval_seconds: float = 2.0,
+    ) -> set[str]:
+        """Wait for terminated bastion ENIs, deleting detached leftovers.
+
+        EC2 normally deletes a primary ENI with its instance. If it becomes
+        detached instead, it is safe to delete here because its owning instance
+        was selected by the project/VPC bastion filters and termination has
+        already been requested.
+        """
+        import time as _time
+
+        remaining = set(eni_ids)
+        deadline = _time.monotonic() + timeout_seconds
+        while remaining:
+            for eni_id in tuple(remaining):
+                try:
+                    response = ec2.describe_network_interfaces(NetworkInterfaceIds=[eni_id])
+                except ClientError as exc:
+                    code = exc.response.get("Error", {}).get("Code")
+                    if code == "InvalidNetworkInterfaceID.NotFound":
+                        remaining.discard(eni_id)
+                        continue
+                    logger.warning("Could not inspect bastion ENI %s: %s", eni_id, exc)
+                    return remaining
+                except Exception as exc:  # noqa: BLE001 - cleanup is best-effort
+                    logger.warning("Could not inspect bastion ENI %s: %s", eni_id, exc)
+                    return remaining
+
+                interfaces = response.get("NetworkInterfaces", [])
+                if not interfaces:
+                    remaining.discard(eni_id)
+                    continue
+                if interfaces[0].get("Status") == "available":
+                    try:
+                        ec2.delete_network_interface(NetworkInterfaceId=eni_id)
+                        remaining.discard(eni_id)
+                    except ClientError as exc:
+                        code = exc.response.get("Error", {}).get("Code")
+                        if code == "InvalidNetworkInterfaceID.NotFound":
+                            remaining.discard(eni_id)
+                        else:
+                            logger.debug("Delete of bastion ENI %s failed: %s", eni_id, exc)
+                    except Exception as exc:  # noqa: BLE001 - retry until timeout
+                        logger.debug("Delete of bastion ENI %s failed: %s", eni_id, exc)
+
+            if not remaining or _time.monotonic() >= deadline:
+                break
+            _time.sleep(poll_interval_seconds)
+        return remaining
 
     def cleanup_eks_security_groups(self) -> None:
         """Clean up EKS-managed security groups across all regional stacks.

--- a/tests/test_ephemeral_bastion.py
+++ b/tests/test_ephemeral_bastion.py
@@ -80,11 +80,13 @@ class TestBuilders:
         query = cmd[cmd.index("--query") + 1]
         assert "vpcId" in query and "clusterSecurityGroupId" in query and "subnetIds" in query
 
-    def test_describe_public_subnet_command(self) -> None:
-        cmd = eb.build_describe_public_subnet_command("vpc-0123456789abcdef0", "us-east-1")
+    def test_describe_private_cluster_subnet_command(self) -> None:
+        cmd = eb.build_describe_private_cluster_subnet_command(
+            ["subnet-0123456789abcdef0"], "us-east-1"
+        )
         assert cmd[:3] == ["aws", "ec2", "describe-subnets"]
-        assert "Name=vpc-id,Values=vpc-0123456789abcdef0" in cmd
-        assert "Name=map-public-ip-on-launch,Values=true" in cmd
+        assert "subnet-0123456789abcdef0" in cmd
+        assert "Name=map-public-ip-on-launch,Values=false" in cmd
 
     def test_create_role_command_has_trust_and_tags(self) -> None:
         cmd = eb.build_create_role_command()
@@ -117,7 +119,6 @@ class TestBuilders:
             region="us-east-1",
             user_data=eb.render_user_data(120),
             ttl_minutes=120,
-            associate_public_ip=True,
         )
         assert cmd[:3] == ["aws", "ec2", "run-instances"]
         # IMDSv2 required.
@@ -133,12 +134,14 @@ class TestBuilders:
         assert "ResourceType=instance" in tagspec
         assert f"Key={eb.TAG_EPHEMERAL_KEY},Value=true" in tagspec
         assert f"Key={eb.TAG_PURPOSE_KEY},Value={eb.BASTION_PURPOSE}" in tagspec
+        assert f"Key={eb.TAG_PROJECT_KEY},Value={eb.DEFAULT_PROJECT_NAME}" in tagspec
         assert f"Key={eb.TAG_TTL_KEY},Value=120" in tagspec
         # Network placement.
         assert cmd[cmd.index("--iam-instance-profile") + 1] == f"Name={eb.BASTION_PROFILE_NAME}"
         assert "subnet-0123456789abcdef0" in cmd
         assert "sg-0123456789abcdef0" in cmd
-        assert "--associate-public-ip-address" in cmd
+        assert "--no-associate-public-ip-address" in cmd
+        assert "--associate-public-ip-address" not in cmd
         assert cmd[-2:] == ["--output", "text"]
 
     def test_run_instances_no_public_ip_variant(self) -> None:
@@ -150,7 +153,6 @@ class TestBuilders:
             profile_name=eb.BASTION_PROFILE_NAME,
             region="us-east-1",
             user_data="x",
-            associate_public_ip=False,
         )
         assert "--no-associate-public-ip-address" in cmd
         assert "--associate-public-ip-address" not in cmd
@@ -257,6 +259,20 @@ class TestRunAws:
         # Does not raise; returns (empty) stdout.
         assert eb._run_aws(["aws", "iam", "create-role"], allow_exists=True) == ""
 
+    def test_allow_exists_swallows_attached_role_quota_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            eb.subprocess,
+            "run",
+            lambda *a, **k: _FakeCompleted(
+                255,
+                "",
+                "LimitExceeded: Cannot exceed quota for InstanceSessionsPerInstanceProfile: 1",
+            ),
+        )
+        assert eb._run_aws(["aws", "iam", "add-role-to-instance-profile"], allow_exists=True) == ""
+
     def test_missing_cli_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         def _boom(*a: object, **k: object) -> None:
             raise FileNotFoundError
@@ -271,27 +287,7 @@ class TestResolveHelpers:
         monkeypatch.setattr(eb, "_run_aws", lambda cmd, **k: "ami-0fd6240f599091088\n")
         assert eb.resolve_bastion_ami("us-east-1") == "ami-0fd6240f599091088"
 
-    def test_resolve_network_prefers_public_subnet(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        def _fake(cmd: list[str], **k: object) -> str:
-            if "describe-cluster" in cmd:
-                return json.dumps(
-                    {
-                        "vpc": "vpc-0123456789abcdef0",
-                        "sg": "sg-0123456789abcdef0",
-                        "subnets": ["subnet-0aaaaaaaaaaaaaaaa"],
-                    }
-                )
-            if "describe-subnets" in cmd:
-                return "subnet-0bbbbbbbbbbbbbbbb"
-            raise AssertionError(cmd)
-
-        monkeypatch.setattr(eb, "_run_aws", _fake)
-        net = eb.resolve_bastion_network("gco-us-east-1", "us-east-1")
-        assert net.subnet_id == "subnet-0bbbbbbbbbbbbbbbb"
-        assert net.public_subnet is True
-        assert net.security_group_id == "sg-0123456789abcdef0"
-
-    def test_resolve_network_falls_back_to_cluster_subnet(
+    def test_resolve_network_uses_private_cluster_subnet(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         def _fake(cmd: list[str], **k: object) -> str:
@@ -303,12 +299,32 @@ class TestResolveHelpers:
                         "subnets": ["subnet-0aaaaaaaaaaaaaaaa"],
                     }
                 )
-            return "None"  # no public subnet
+            if "describe-subnets" in cmd:
+                return "subnet-0aaaaaaaaaaaaaaaa"
+            raise AssertionError(cmd)
 
         monkeypatch.setattr(eb, "_run_aws", _fake)
         net = eb.resolve_bastion_network("gco-us-east-1", "us-east-1")
         assert net.subnet_id == "subnet-0aaaaaaaaaaaaaaaa"
-        assert net.public_subnet is False
+        assert net.security_group_id == "sg-0123456789abcdef0"
+
+    def test_resolve_network_refuses_public_only_subnets(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _fake(cmd: list[str], **k: object) -> str:
+            if "describe-cluster" in cmd:
+                return json.dumps(
+                    {
+                        "vpc": "vpc-0123456789abcdef0",
+                        "sg": "sg-0123456789abcdef0",
+                        "subnets": ["subnet-0aaaaaaaaaaaaaaaa"],
+                    }
+                )
+            return "None"
+
+        monkeypatch.setattr(eb, "_run_aws", _fake)
+        with pytest.raises(RuntimeError, match="refusing to launch a public bastion"):
+            eb.resolve_bastion_network("gco-us-east-1", "us-east-1")
 
     def test_resolve_network_no_subnets_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         def _fake(cmd: list[str], **k: object) -> str:
@@ -319,7 +335,7 @@ class TestResolveHelpers:
             return "None"
 
         monkeypatch.setattr(eb, "_run_aws", _fake)
-        with pytest.raises(RuntimeError, match="cannot place a bastion"):
+        with pytest.raises(RuntimeError, match="cannot place a private bastion"):
             eb.resolve_bastion_network("gco-us-east-1", "us-east-1")
 
     def test_ensure_iam_runs_four_idempotent_steps(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -349,7 +365,6 @@ class TestLaunchBastion:
             vpc_id="vpc-0123456789abcdef0",
             subnet_id="subnet-0123456789abcdef0",
             security_group_id="sg-0123456789abcdef0",
-            public_subnet=True,
         )
 
     def test_launch_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -413,7 +428,7 @@ class TestCreateDestroyLifecycle:
             eb,
             "resolve_bastion_network",
             lambda c, r: eb.BastionNetwork(
-                "vpc-0123456789abcdef0", "subnet-0123456789abcdef0", "sg-0123456789abcdef0", True
+                "vpc-0123456789abcdef0", "subnet-0123456789abcdef0", "sg-0123456789abcdef0"
             ),
         )
         monkeypatch.setattr(eb, "ensure_bastion_iam", lambda *a, **k: None)
@@ -427,7 +442,7 @@ class TestCreateDestroyLifecycle:
             eb,
             "resolve_bastion_network",
             lambda c, r: eb.BastionNetwork(
-                "vpc-0123456789abcdef0", "subnet-0123456789abcdef0", "sg-0123456789abcdef0", True
+                "vpc-0123456789abcdef0", "subnet-0123456789abcdef0", "sg-0123456789abcdef0"
             ),
         )
         monkeypatch.setattr(eb, "ensure_bastion_iam", lambda *a, **k: None)
@@ -452,7 +467,7 @@ class TestCreateDestroyLifecycle:
             eb,
             "resolve_bastion_network",
             lambda c, r: eb.BastionNetwork(
-                "vpc-0123456789abcdef0", "subnet-0123456789abcdef0", "sg-0123456789abcdef0", True
+                "vpc-0123456789abcdef0", "subnet-0123456789abcdef0", "sg-0123456789abcdef0"
             ),
         )
         monkeypatch.setattr(eb, "ensure_bastion_iam", lambda *a, **k: None)
@@ -542,9 +557,11 @@ class TestProjectScopedNaming:
             region="us-east-1",
             user_data="x",
             instance_name="acme-ephemeral-ssm-bastion",
+            project_name="acme",
         )
         tagspec = cmd[cmd.index("--tag-specifications") + 1]
         assert "Key=Name,Value=acme-ephemeral-ssm-bastion" in tagspec
+        assert f"Key={eb.TAG_PROJECT_KEY},Value=acme" in tagspec
 
     def test_destroy_deletes_project_scoped_role(self, monkeypatch: pytest.MonkeyPatch) -> None:
         calls: list[list[str]] = []
@@ -561,7 +578,7 @@ class TestProjectScopedNaming:
             eb,
             "resolve_bastion_network",
             lambda c, r: eb.BastionNetwork(
-                "vpc-0123456789abcdef0", "subnet-0123456789abcdef0", "sg-0123456789abcdef0", True
+                "vpc-0123456789abcdef0", "subnet-0123456789abcdef0", "sg-0123456789abcdef0"
             ),
         )
         seen: dict[str, object] = {}

--- a/tests/test_stacks_destroy_hardening.py
+++ b/tests/test_stacks_destroy_hardening.py
@@ -24,6 +24,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from botocore.exceptions import ClientError
+
 
 class TestDeploySuccessStateVerification:
     """deploy() reconciles a cdk 'success' against the real CloudFormation status."""
@@ -474,3 +476,187 @@ class TestCleanupOrphanedNetworkInterfaces:
         for stack in ("gco-us-east-1", "gco-eu-west-1"):
             mock_sg.assert_any_call(stack)
             mock_summarize.assert_any_call(stack)
+
+
+class TestCleanupOrphanedBastions:
+    """Destroy-all removes CLI-managed bastions before CloudFormation runs."""
+
+    @staticmethod
+    def _manager():
+        from cli.stacks import StackManager
+
+        manager = StackManager.__new__(StackManager)
+        manager.config = MagicMock(project_name="gco")
+        manager.project_root = Path(".")
+        return manager
+
+    @staticmethod
+    def _tags(**overrides):
+        tags = {
+            "gco:ephemeral": "true",
+            "gco:purpose": "cluster-observability",
+            "gco:project": "gco",
+            "Name": "gco-ephemeral-ssm-bastion",
+        }
+        tags.update(overrides)
+        return [{"Key": key, "Value": value} for key, value in tags.items()]
+
+    def test_terminates_current_and_legacy_project_bastions(self):
+        from cli.stacks import StackManager
+
+        manager = self._manager()
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_vpcs.return_value = {"Vpcs": [{"VpcId": "vpc-1"}]}
+        legacy_tags = [tag for tag in self._tags() if tag["Key"] != "gco:project"]
+        mock_ec2.describe_instances.return_value = {
+            "Reservations": [
+                {
+                    "Instances": [
+                        {
+                            "InstanceId": "i-current",
+                            "Tags": self._tags(),
+                            "NetworkInterfaces": [
+                                {
+                                    "NetworkInterfaceId": "eni-current",
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "DeleteOnTermination": True,
+                                    },
+                                },
+                                {
+                                    "NetworkInterfaceId": "eni-secondary",
+                                    "Attachment": {
+                                        "DeviceIndex": 1,
+                                        "DeleteOnTermination": False,
+                                    },
+                                },
+                            ],
+                        },
+                        {
+                            "InstanceId": "i-legacy",
+                            "Tags": legacy_tags,
+                            "NetworkInterfaces": [
+                                {
+                                    "NetworkInterfaceId": "eni-legacy",
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "DeleteOnTermination": True,
+                                    },
+                                }
+                            ],
+                        },
+                        {
+                            "InstanceId": "i-other-project",
+                            "Tags": self._tags(**{"gco:project": "other"}),
+                            "NetworkInterfaces": [
+                                {
+                                    "NetworkInterfaceId": "eni-other",
+                                    "Attachment": {
+                                        "DeviceIndex": 0,
+                                        "DeleteOnTermination": True,
+                                    },
+                                }
+                            ],
+                        },
+                    ]
+                }
+            ]
+        }
+
+        with (
+            patch("boto3.client", return_value=mock_ec2),
+            patch.object(
+                StackManager, "_wait_for_bastion_network_interfaces", return_value=set()
+            ) as wait_for_enis,
+        ):
+            count = manager._cleanup_orphaned_bastions("gco-us-east-1")
+
+        assert count == 2
+        mock_ec2.terminate_instances.assert_called_once_with(InstanceIds=["i-current", "i-legacy"])
+        mock_ec2.get_waiter.return_value.wait.assert_called_once_with(
+            InstanceIds=["i-current", "i-legacy"],
+            WaiterConfig={"Delay": 5, "MaxAttempts": 60},
+        )
+        wait_for_enis.assert_called_once_with(mock_ec2, ["eni-current", "eni-legacy"])
+        filters = mock_ec2.describe_instances.call_args.kwargs["Filters"]
+        assert {"Name": "vpc-id", "Values": ["vpc-1"]} in filters
+        assert {"Name": "tag:gco:ephemeral", "Values": ["true"]} in filters
+
+    def test_no_stack_vpc_is_a_noop(self):
+        manager = self._manager()
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_vpcs.return_value = {"Vpcs": []}
+
+        with patch("boto3.client", return_value=mock_ec2):
+            assert manager._cleanup_orphaned_bastions("gco-us-east-1") == 0
+
+        mock_ec2.describe_instances.assert_not_called()
+        mock_ec2.terminate_instances.assert_not_called()
+
+    def test_public_sweep_only_visits_regional_stacks(self):
+        from cli.stacks import StackManager
+
+        manager = self._manager()
+        stacks = [
+            "gco-global",
+            "gco-api-gateway",
+            "gco-monitoring",
+            "gco-analytics",
+            "gco-us-east-1",
+            "gco-eu-west-1",
+        ]
+        with patch.object(StackManager, "_cleanup_orphaned_bastions", return_value=1) as cleanup:
+            assert manager.cleanup_orphaned_bastions(stacks) == 2
+
+        assert cleanup.call_count == 2
+        cleanup.assert_any_call("gco-us-east-1")
+        cleanup.assert_any_call("gco-eu-west-1")
+
+
+class TestWaitForBastionNetworkInterfaces:
+    """Bastion ENI release waits for EC2 and clears detached leftovers."""
+
+    def test_deletes_available_interface(self):
+        from cli.stacks import StackManager
+
+        ec2 = MagicMock()
+        ec2.describe_network_interfaces.return_value = {
+            "NetworkInterfaces": [{"NetworkInterfaceId": "eni-1", "Status": "available"}]
+        }
+
+        remaining = StackManager._wait_for_bastion_network_interfaces(
+            ec2, ["eni-1"], timeout_seconds=0
+        )
+
+        assert remaining == set()
+        ec2.delete_network_interface.assert_called_once_with(NetworkInterfaceId="eni-1")
+
+    def test_not_found_means_interface_is_released(self):
+        from cli.stacks import StackManager
+
+        ec2 = MagicMock()
+        ec2.describe_network_interfaces.side_effect = ClientError(
+            {"Error": {"Code": "InvalidNetworkInterfaceID.NotFound", "Message": "gone"}},
+            "DescribeNetworkInterfaces",
+        )
+
+        remaining = StackManager._wait_for_bastion_network_interfaces(
+            ec2, ["eni-gone"], timeout_seconds=0
+        )
+
+        assert remaining == set()
+
+    def test_in_use_interface_remains_at_timeout(self):
+        from cli.stacks import StackManager
+
+        ec2 = MagicMock()
+        ec2.describe_network_interfaces.return_value = {
+            "NetworkInterfaces": [{"NetworkInterfaceId": "eni-1", "Status": "in-use"}]
+        }
+
+        remaining = StackManager._wait_for_bastion_network_interfaces(
+            ec2, ["eni-1"], timeout_seconds=0
+        )
+
+        assert remaining == {"eni-1"}
+        ec2.delete_network_interface.assert_not_called()


### PR DESCRIPTION
## Summary

- terminate project-scoped ephemeral SSM bastions before `destroy-all` starts deleting regional stacks
- wait for EC2 termination and primary ENI release, deleting only a detached primary ENI that was marked delete-on-termination
- place newly launched bastions in an EKS private subnet and always disable public IP assignment
- add a `gco:project` tag for project ownership and IAM resource-tag conditions
- handle the IAM response returned when an existing role is already attached to the reusable instance profile

## Security posture

- The bastion has no public IP and opens no inbound ports; SSM remains outbound-only.
- GCO private subnets already have NAT egress. Deployments without NAT can use Systems Manager interface VPC endpoints.
- The instance keeps IMDSv2-required, terminate-on-shutdown, TTL shutdown, and `AmazonSSMManagedInstanceCore` safeguards.
- Caller access remains controlled by IAM. The new project tag allows policies to scope `ssm:StartSession` to the intended GCO deployment.

## Validation

- `python3 -m pytest tests/test_ephemeral_bastion.py tests/test_stacks_destroy_hardening.py -q` — 99 passed
- live AWS test: launched a private bastion, confirmed no public IP, private subnet, SSM Online, IMDSv2 required, terminate-on-shutdown, and project tag
- live AWS cleanup: discovered and terminated a deliberately orphaned bastion and confirmed its primary ENI was gone before starting CloudFormation deletion
- full CI was not run locally; PR checks are the CI source of truth

## Live-test note

The local `gco stacks destroy-all` command was blocked during its initial `cdk list` by a pre-existing cdk-nag v3 synthesis error before orchestration reached this feature. The phase-0 cleanup was therefore invoked directly, then the disposable regional stack was deleted through CloudFormation. The cdk-nag issue is unrelated and is not included in this PR.
