### PR TITLE
fix: restore root README as the GitHub front page

### DIFF
--- a/.github/AUTOMATION.md
+++ b/.github/AUTOMATION.md
@@ -3,6 +3,10 @@
 This directory contains the repository's GitHub governance, CI/CD workflows,
 security configuration, issue templates, and reusable automation.
 
+> **Note:** this file is deliberately *not* named `README.md`. GitHub renders
+> `.github/README.md` as the repository front page in preference to the root
+> `README.md`, which would hide the project README.
+
 ## Table of Contents
 
 - [Directory Map](#directory-map)


### PR DESCRIPTION
## Summary Since #161, the repository front page on GitHub has been rendering the internal `.github/README.md` ("GitHub Project Automation") instead of the project README. GitHub picks the displayed README in the order `.github/` > root > `docs/`, so the new `.github/README.md` silently shadowed the root one. This renames it to `.github/AUTOMATION.md` (content unchanged apart from a short note documenting the naming constraint so it doesn't regress). Nothing in the repo referenced the old path, and the file's own relative links still resolve since it stays in `.github/`. ## Testing - `pytest tests/test_ci_config_paths.py tests/test_doc_hygiene.py` — 8 passed - `markdownlint-cli2` with the repo config across all Markdown — 0 issues - Verified via live fetch that github.com currently renders the automation doc as the front page, and `git grep` on `origin/main` shows no inbound references to `.github/README.md`