### PR TITLE
fix: live release validation greenline

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -204,10 +204,10 @@
       "container_max_gpu": "4"
     },
 
-    "_comment_resource_thresholds": "Health monitor thresholds that drive the /api/v1/health regional capacity report. cpu_threshold / memory_threshold / gpu_threshold are utilization percentages above which the region is reported as 'busy'; set any to -1 to disable that dimension. pending_pods_threshold counts pods in Pending state. pending_requested_cpu_vcpus / pending_requested_memory_gb / pending_requested_gpus sum unscheduled resource requests across pending pods.",
+    "_comment_resource_thresholds": "Health monitor thresholds that drive the /api/v1/health regional capacity report. cpu_threshold / memory_threshold / gpu_threshold are utilization percentages above which the region is reported as 'busy'; set any to -1 to disable that dimension. The 80 defaults leave headroom above the platform baseline: on right-sized EKS Auto Mode nodes an idle cluster running the observability stack already sits near 65-70% memory, which a 60 threshold misreported as unhealthy. pending_pods_threshold counts pods in Pending state. pending_requested_cpu_vcpus / pending_requested_memory_gb / pending_requested_gpus sum unscheduled resource requests across pending pods.",
     "resource_thresholds": {
-      "cpu_threshold": 60,
-      "memory_threshold": 60,
+      "cpu_threshold": 80,
+      "memory_threshold": 80,
       "gpu_threshold": -1,
       "pending_pods_threshold": 10,
       "pending_requested_cpu_vcpus": 100,

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -4265,8 +4265,8 @@ Project configuration in `cdk.json`:
       "regional": ["us-east-1", "us-west-2"]
     },
     "resource_thresholds": {
-      "cpu_threshold": 60,
-      "memory_threshold": 60,
+      "cpu_threshold": 80,
+      "memory_threshold": 80,
       "gpu_threshold": -1,
       "pending_pods_threshold": 10,
       "pending_requested_cpu_vcpus": 100,

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -534,8 +534,8 @@ The health monitor compares cluster utilization against configurable thresholds 
 
 ```json
 "resource_thresholds": {
-  "cpu_threshold": 60,
-  "memory_threshold": 60,
+  "cpu_threshold": 80,
+  "memory_threshold": 80,
   "gpu_threshold": -1,
   "pending_pods_threshold": 10,
   "pending_requested_cpu_vcpus": 100,
@@ -546,8 +546,8 @@ The health monitor compares cluster utilization against configurable thresholds 
 
 | Threshold | Default | Description |
 |-----------|---------|-------------|
-| `cpu_threshold` | 60 | CPU utilization % (0-100, or -1 to disable) |
-| `memory_threshold` | 60 | Memory utilization % (0-100, or -1 to disable) |
+| `cpu_threshold` | 80 | CPU utilization % (0-100, or -1 to disable) |
+| `memory_threshold` | 80 | Memory utilization % (0-100, or -1 to disable) |
 | `gpu_threshold` | -1 | GPU utilization % (0-100, or -1 to disable) |
 | `pending_pods_threshold` | 10 | Max pending pods before unhealthy (-1 to disable) |
 | `pending_requested_cpu_vcpus` | 100 | Max vCPUs requested by pending pods (-1 to disable) |

--- a/gco/config/config_loader.py
+++ b/gco/config/config_loader.py
@@ -718,8 +718,8 @@ class ConfigLoader:
     def get_resource_thresholds(self) -> ResourceThresholds:
         """Get resource thresholds configuration"""
         thresholds_config = self.app.node.try_get_context("resource_thresholds") or {
-            "cpu_threshold": 60,
-            "memory_threshold": 60,
+            "cpu_threshold": 80,
+            "memory_threshold": 80,
             "gpu_threshold": -1,
             "pending_pods_threshold": 10,
             "pending_requested_cpu_vcpus": 100,

--- a/gco/services/health_monitor.py
+++ b/gco/services/health_monitor.py
@@ -14,8 +14,8 @@ Environment Variables:
     CLUSTER_NAME: Name of the EKS cluster being monitored
     REGION: AWS region of the cluster
     CPU_THRESHOLD: CPU utilization threshold percentage (default: 80, -1 to disable)
-    MEMORY_THRESHOLD: Memory utilization threshold percentage (default: 85, -1 to disable)
-    GPU_THRESHOLD: GPU utilization threshold percentage (default: 90, -1 to disable)
+    MEMORY_THRESHOLD: Memory utilization threshold percentage (default: 80, -1 to disable)
+    GPU_THRESHOLD: GPU utilization threshold percentage (default: 60, -1 to disable)
 
 Usage:
     health_monitor = create_health_monitor_from_env()
@@ -722,8 +722,8 @@ def create_health_monitor_from_env() -> HealthMonitor:
     region = os.getenv("REGION", "unknown-region")
 
     # Load thresholds from environment (defaults match cdk.json)
-    cpu_threshold = int(os.getenv("CPU_THRESHOLD", "60"))
-    memory_threshold = int(os.getenv("MEMORY_THRESHOLD", "60"))
+    cpu_threshold = int(os.getenv("CPU_THRESHOLD", "80"))
+    memory_threshold = int(os.getenv("MEMORY_THRESHOLD", "80"))
     gpu_threshold = int(os.getenv("GPU_THRESHOLD", "60"))
     pending_pods_threshold = int(os.getenv("PENDING_PODS_THRESHOLD", "10"))
     pending_requested_cpu_vcpus = int(os.getenv("PENDING_REQUESTED_CPU_VCPUS", "100"))

--- a/lambda/api-gateway-proxy/proxy_utils.py
+++ b/lambda/api-gateway-proxy/proxy_utils.py
@@ -253,6 +253,13 @@ def forward_request(
     ):
         raise ValueError("Backend proxy targets must use HTTPS on port 443")
 
+    # Anchor the deadline before acquiring transport: the caller computed the
+    # budget from the Lambda's remaining time, so a cold-start trust-bundle
+    # refresh must consume this budget. Anchoring after it extended the wall
+    # clock past the Lambda timeout, killing the function mid-flight instead
+    # of returning its bounded 504 when the backend black-holed.
+    deadline = time.monotonic() + max(timeout, 0.0)
+
     try:
         transport = _http or get_backend_http_pool()
     except RuntimeError:
@@ -266,7 +273,6 @@ def forward_request(
     method = http_method.upper()
     encoded_body = body.encode("utf-8") if body else None
     max_attempts = _MAX_RETRIES if method in _RETRYABLE_METHODS else 1
-    deadline = time.monotonic() + max(timeout, 0.0)
     last_exception: Exception | None = None
     last_response: urllib3.BaseHTTPResponse | None = None
     attempts_made = 0

--- a/lambda/ga-registration/handler.py
+++ b/lambda/ga-registration/handler.py
@@ -628,6 +628,27 @@ def register_ga_endpoint(
                 normalized_endpoint_group,
                 expected_alb_arn=alb_arn,
             )
+            # AddEndpoints/RemoveEndpoints/UpdateEndpointGroup only submit a
+            # configuration change; the accelerator serves it from its edge
+            # locations only after returning to DEPLOYED. Returning success
+            # earlier reports the deployment as complete while brand-new
+            # connections to the global endpoint still black-hole for several
+            # minutes, which a live release run proved by timing out on the
+            # first health probe after deploy. Wait strictly, within whatever
+            # remains of this handler's wall-clock budget.
+            remaining_budget = min(
+                GA_DEPLOYED_WAIT_SECONDS,
+                int(MAX_WAIT_SECONDS - (time.time() - start_time)),
+            )
+            if remaining_budget <= 0 or not wait_for_accelerator_deployed(
+                ga_client,
+                normalized_endpoint_group,
+                timeout_seconds=remaining_budget,
+                strict=True,
+            ):
+                raise TimeoutError(
+                    "Global Accelerator did not reach DEPLOYED after endpoint registration"
+                )
         else:
             logger.info("EndpointGroupArn is not configured; skipping Global Accelerator")
 

--- a/lambda/helm-installer/charts.yaml
+++ b/lambda/helm-installer/charts.yaml
@@ -582,10 +582,10 @@ charts:
           karpenter.sh/do-not-disrupt: "true"
       # EKS manages the control plane: etcd, the scheduler, and the controller
       # manager are not reachable as pods, and EKS Auto Mode runs no kube-proxy
-      # DaemonSet. Their exporters would render kube-system Services whose
-      # selectors can never have ready endpoints, so release validation (and
-      # scraping) disables them; CoreDNS pods do run in kube-system and stay
-      # monitored.
+      # DaemonSet and provides DNS as a built-in capability (no CoreDNS pods in
+      # kube-system for the k8s-app=kube-dns selector to match). Their exporters
+      # would render kube-system Services whose selectors can never have ready
+      # endpoints, so release validation (and scraping) disables them.
       kubeEtcd:
         enabled: false
       kubeScheduler:
@@ -593,6 +593,8 @@ charts:
       kubeControllerManager:
         enabled: false
       kubeProxy:
+        enabled: false
+      coreDns:
         enabled: false
       # Prometheus: discover ServiceMonitors/PodMonitors cluster-wide (not just
       # ones labeled with this release) so GCO component monitors are scraped.

--- a/lambda/helm-installer/handler.py
+++ b/lambda/helm-installer/handler.py
@@ -998,10 +998,15 @@ def _compare_resource_identities(
             f"{len(actual)} ({detail})"
         )
 
-    # Explicit manifest namespaces must match exactly. A namespace omitted by
-    # a namespaced Helm object is defaulted by ``kubectl -n`` and must return
-    # from the release namespace; a cluster-scoped object legitimately returns
-    # no namespace. Consume counters so duplicate identities are also exact.
+    # Explicit manifest namespaces must match exactly for namespaced kinds. A
+    # namespace omitted by a namespaced Helm object is defaulted by
+    # ``kubectl -n`` and must return from the release namespace; a
+    # cluster-scoped object legitimately returns no namespace even when the
+    # chart templates ``metadata.namespace`` onto it (for example kueue's
+    # MutatingWebhookConfiguration) because the API server discards the field
+    # on cluster-scoped kinds. Namespaced kinds always return with their
+    # namespace, so accepting a cluster-scoped return never weakens the check
+    # for them. Consume counters so duplicate identities are also exact.
     actual_namespaced = Counter(
         (_resource_core_identity(resource, "kubectl output"), _resource_namespace(resource))
         for resource in actual
@@ -1012,12 +1017,22 @@ def _compare_resource_identities(
             continue
         identity = _resource_core_identity(resource, "manifest")
         key = (identity, namespace)
-        if actual_namespaced[key] <= 0:
+        cluster_scoped_key = (identity, None)
+        if actual_namespaced[key] > 0:
+            actual_namespaced[key] -= 1
+        elif actual_namespaced[cluster_scoped_key] > 0:
+            actual_namespaced[cluster_scoped_key] -= 1
+        else:
+            wrong_namespaces = sorted(
+                actual_namespace or "<cluster-scoped>"
+                for (actual_identity, actual_namespace), count in actual_namespaced.items()
+                if actual_identity == identity and count > 0
+            )
             raise RuntimeError(
                 f"release {release!r} returned the wrong namespace for "
-                f"{_display_identity(identity, namespace)}"
+                f"{_display_identity(identity, namespace)}: expected {namespace!r} or "
+                f"cluster scope, got {wrong_namespaces}"
             )
-        actual_namespaced[key] -= 1
 
     for resource in expected:
         if _resource_namespace(resource) is not None:

--- a/lambda/proxy-shared/proxy_utils.py
+++ b/lambda/proxy-shared/proxy_utils.py
@@ -253,6 +253,13 @@ def forward_request(
     ):
         raise ValueError("Backend proxy targets must use HTTPS on port 443")
 
+    # Anchor the deadline before acquiring transport: the caller computed the
+    # budget from the Lambda's remaining time, so a cold-start trust-bundle
+    # refresh must consume this budget. Anchoring after it extended the wall
+    # clock past the Lambda timeout, killing the function mid-flight instead
+    # of returning its bounded 504 when the backend black-holed.
+    deadline = time.monotonic() + max(timeout, 0.0)
+
     try:
         transport = _http or get_backend_http_pool()
     except RuntimeError:
@@ -266,7 +273,6 @@ def forward_request(
     method = http_method.upper()
     encoded_body = body.encode("utf-8") if body else None
     max_attempts = _MAX_RETRIES if method in _RETRYABLE_METHODS else 1
-    deadline = time.monotonic() + max(timeout, 0.0)
     last_exception: Exception | None = None
     last_response: urllib3.BaseHTTPResponse | None = None
     attempts_made = 0

--- a/lambda/regional-api-proxy/proxy_utils.py
+++ b/lambda/regional-api-proxy/proxy_utils.py
@@ -253,6 +253,13 @@ def forward_request(
     ):
         raise ValueError("Backend proxy targets must use HTTPS on port 443")
 
+    # Anchor the deadline before acquiring transport: the caller computed the
+    # budget from the Lambda's remaining time, so a cold-start trust-bundle
+    # refresh must consume this budget. Anchoring after it extended the wall
+    # clock past the Lambda timeout, killing the function mid-flight instead
+    # of returning its bounded 504 when the backend black-holed.
+    deadline = time.monotonic() + max(timeout, 0.0)
+
     try:
         transport = _http or get_backend_http_pool()
     except RuntimeError:
@@ -266,7 +273,6 @@ def forward_request(
     method = http_method.upper()
     encoded_body = body.encode("utf-8") if body else None
     max_attempts = _MAX_RETRIES if method in _RETRYABLE_METHODS else 1
-    deadline = time.monotonic() + max(timeout, 0.0)
     last_exception: Exception | None = None
     last_response: urllib3.BaseHTTPResponse | None = None
     attempts_made = 0

--- a/tests/test_cluster_observability_charts.py
+++ b/tests/test_cluster_observability_charts.py
@@ -322,6 +322,16 @@ def test_chart_entry_defaults(kps_entry) -> None:
     assert kps_entry["wait"] is False
 
 
+def test_unscrapable_control_plane_monitors_disabled(kps_entry) -> None:
+    # EKS owns etcd/scheduler/controller-manager, and Auto Mode runs no
+    # kube-proxy DaemonSet and no CoreDNS pods (DNS is a built-in capability).
+    # Each enabled monitor renders a kube-system Service whose selector can
+    # never have ready endpoints, which fails live release validation.
+    values = kps_entry["values"]
+    for component in ("kubeEtcd", "kubeScheduler", "kubeControllerManager", "kubeProxy", "coreDns"):
+        assert values[component]["enabled"] is False, component
+
+
 def test_grafana_is_private_and_native_auth(kps_entry) -> None:
     grafana = kps_entry["values"]["grafana"]
     assert grafana["service"]["type"] == "ClusterIP"

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -406,8 +406,10 @@ class TestDefaultValues:
         app = MockApp({})
         config = ConfigLoader(app)
         thresholds = config.get_resource_thresholds()
-        assert thresholds.cpu_threshold == 60
-        assert thresholds.memory_threshold == 60
+        # 80/80 leaves headroom above the idle-cluster platform baseline
+        # (observability stack ~65-70% memory on right-sized Auto Mode nodes).
+        assert thresholds.cpu_threshold == 80
+        assert thresholds.memory_threshold == 80
         assert thresholds.gpu_threshold == -1  # disabled by default for inference workloads
         assert thresholds.pending_pods_threshold == 10
         assert thresholds.pending_requested_cpu_vcpus == 100

--- a/tests/test_ga_registration.py
+++ b/tests/test_ga_registration.py
@@ -566,6 +566,11 @@ class TestRegisterGatewayEndpoint:
             patch.object(handler, "register_alb_with_ga") as register,
             patch.object(handler, "scrub_stale_ga_endpoints") as scrub,
             patch.object(handler, "ensure_https_health_check") as health,
+            patch.object(
+                handler,
+                "wait_for_accelerator_deployed",
+                side_effect=lambda *_args, **_kwargs: order.append("deployed") or True,
+            ) as wait,
         ):
             handler.register_ga_endpoint(
                 "test-cluster",
@@ -580,7 +585,78 @@ class TestRegisterGatewayEndpoint:
             ENDPOINT_GROUP_ARN,
             expected_alb_arn=PLATFORM_ALB_ARN,
         )
-        assert order == ["publish"]
+        # AddEndpoints only submits a configuration change: publication (and
+        # therefore deploy success) must wait for the accelerator to serve the
+        # endpoint from its edge locations, strictly and within a bounded wait.
+        wait.assert_called_once_with(ga, ENDPOINT_GROUP_ARN, timeout_seconds=ANY, strict=True)
+        budget = wait.call_args.kwargs["timeout_seconds"]
+        assert 0 < budget <= handler.GA_DEPLOYED_WAIT_SECONDS
+        assert order == ["deployed", "publish"]
+
+    def test_registration_never_deployed_blocks_publication(self, ga_module):
+        # Regression: a live run's first health probe black-holed because
+        # registration returned success while Global Accelerator was still
+        # propagating the new endpoint. A wait that ends without DEPLOYED must
+        # fail the registration instead of publishing a dead endpoint.
+        handler, mock_boto_client, _ = ga_module
+        elb = MagicMock()
+        ga = MagicMock()
+        mock_boto_client.side_effect = lambda service, **_kwargs: (
+            ga if service == "globalaccelerator" else elb
+        )
+        get_k8s, find_alb, publish, remove_ca = self._core_patches(handler)
+        with (
+            get_k8s,
+            find_alb,
+            publish as publish_mock,
+            remove_ca as remove_ca_mock,
+            patch.object(handler, "register_alb_with_ga"),
+            patch.object(handler, "scrub_stale_ga_endpoints"),
+            patch.object(handler, "ensure_https_health_check"),
+            patch.object(handler, "wait_for_accelerator_deployed", return_value=False),
+            pytest.raises(TimeoutError, match="did not reach DEPLOYED"),
+        ):
+            handler.register_ga_endpoint(
+                "test-cluster",
+                "us-east-1",
+                endpoint_group_arn=ENDPOINT_GROUP_ARN,
+            )
+
+        publish_mock.assert_not_called()
+        remove_ca_mock.assert_called_once_with("/tmp/gco-ca.crt")
+
+    def test_registration_with_exhausted_budget_fails_without_waiting(self, ga_module):
+        # When no wall-clock budget remains for the DEPLOYED wait (for example
+        # after a pathologically slow ALB wait), the handler must fail
+        # honestly and immediately rather than wait past its own budget.
+        # Zeroing the wait constant drives remaining_budget to the <= 0 branch.
+        handler, mock_boto_client, _ = ga_module
+        elb = MagicMock()
+        ga = MagicMock()
+        mock_boto_client.side_effect = lambda service, **_kwargs: (
+            ga if service == "globalaccelerator" else elb
+        )
+        get_k8s, find_alb, publish, remove_ca = self._core_patches(handler)
+        with (
+            get_k8s,
+            find_alb,
+            publish as publish_mock,
+            remove_ca,
+            patch.object(handler, "register_alb_with_ga"),
+            patch.object(handler, "scrub_stale_ga_endpoints"),
+            patch.object(handler, "ensure_https_health_check"),
+            patch.object(handler, "wait_for_accelerator_deployed") as wait,
+            patch.object(handler, "GA_DEPLOYED_WAIT_SECONDS", 0),
+            pytest.raises(TimeoutError, match="did not reach DEPLOYED"),
+        ):
+            handler.register_ga_endpoint(
+                "test-cluster",
+                "us-east-1",
+                endpoint_group_arn=ENDPOINT_GROUP_ARN,
+            )
+
+        wait.assert_not_called()
+        publish_mock.assert_not_called()
 
     def test_ga_convergence_failure_blocks_publication(self, ga_module):
         handler, mock_boto_client, _ = ga_module

--- a/tests/test_health_monitor.py
+++ b/tests/test_health_monitor.py
@@ -348,8 +348,8 @@ class TestCreateFromEnv:
 
                 assert monitor.cluster_id == "unknown-cluster"
                 assert monitor.region == "unknown-region"
-                assert monitor.thresholds.cpu_threshold == 60
-                assert monitor.thresholds.memory_threshold == 60
+                assert monitor.thresholds.cpu_threshold == 80
+                assert monitor.thresholds.memory_threshold == 80
                 assert monitor.thresholds.gpu_threshold == 60
                 assert monitor.thresholds.pending_pods_threshold == 10
                 assert monitor.thresholds.pending_requested_cpu_vcpus == 100

--- a/tests/test_health_monitor_extended.py
+++ b/tests/test_health_monitor_extended.py
@@ -538,8 +538,8 @@ class TestCreateHealthMonitorFromEnv:
 
             assert monitor.cluster_id == "unknown-cluster"
             assert monitor.region == "unknown-region"
-            assert monitor.thresholds.cpu_threshold == 60
-            assert monitor.thresholds.memory_threshold == 60
+            assert monitor.thresholds.cpu_threshold == 80
+            assert monitor.thresholds.memory_threshold == 80
             assert monitor.thresholds.gpu_threshold == 60
 
     def test_create_health_monitor_from_env_custom(self, mock_k8s_config):

--- a/tests/test_helm_installer_handler.py
+++ b/tests/test_helm_installer_handler.py
@@ -1456,6 +1456,48 @@ class TestReleaseConvergenceValidation:
             [cluster_object], [cluster_object], self.RELEASE, self.NAMESPACE
         )
 
+    def test_templated_namespace_on_cluster_scoped_object_accepts_cluster_return(self):
+        """Regression: kueue failed live validation on a real cluster.
+
+        The kueue chart templates ``metadata.namespace: kueue-system`` onto its
+        cluster-scoped MutatingWebhookConfiguration. The API server discards
+        the field, so kubectl returns the object without a namespace and the
+        exact ``(identity, namespace)`` match rejected a healthy release.
+        """
+        rendered = {
+            "apiVersion": "admissionregistration.k8s.io/v1",
+            "kind": "MutatingWebhookConfiguration",
+            "metadata": {
+                "name": "kueue-mutating-webhook-configuration",
+                "namespace": "kueue-system",
+            },
+        }
+        live = {
+            "apiVersion": "admissionregistration.k8s.io/v1",
+            "kind": "MutatingWebhookConfiguration",
+            "metadata": {"name": "kueue-mutating-webhook-configuration"},
+        }
+        helm_handler._compare_resource_identities([rendered], [live], "kueue", "kueue-system")
+
+    def test_explicit_namespace_still_rejects_wrong_namespace_return(self):
+        # The cluster-scope fallback must not weaken the namespaced check: a
+        # live object in a different namespace is still a validation failure.
+        rendered = {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": "demo-config", "namespace": "demo-system"},
+        }
+        live = {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": "demo-config", "namespace": "other-system"},
+        }
+        with pytest.raises(RuntimeError, match="wrong namespace") as excinfo:
+            helm_handler._compare_resource_identities(
+                [rendered], [live], self.RELEASE, self.NAMESPACE
+            )
+        assert "other-system" in str(excinfo.value)
+
     def test_cross_namespace_rendered_objects_are_retrieved_per_namespace(self):
         """Regression: one ``-n`` for a mixed-namespace manifest broke live runs.
 

--- a/tests/test_lambda_proxy.py
+++ b/tests/test_lambda_proxy.py
@@ -202,6 +202,41 @@ class TestForwardRequest:
         assert body["message"] == "Upstream failed after 1 attempt(s)"
         assert mock_pool.request.call_count == 1
 
+    def test_trust_bundle_refresh_consumes_the_forward_budget(self, proxy_utils_module):
+        """Regression: a cold-start trust refresh must not extend the deadline.
+
+        The caller derives ``timeout`` from the Lambda's remaining time.
+        Anchoring the deadline after ``get_backend_http_pool()`` let a slow
+        SSM trust-bundle fetch push the total wall clock past the Lambda
+        timeout, so a black-holed backend killed the function at 29s instead
+        of returning its bounded 504.
+        """
+        proxy_utils, _, mock_pool = proxy_utils_module
+        ok_response = MagicMock()
+        ok_response.status = 200
+        ok_response.headers = {"Content-Type": "text/plain"}
+        ok_response.data = b"OK"
+        mock_pool.request.return_value = ok_response
+
+        clock = {"now": 100.0}
+
+        def slow_pool_fetch():
+            clock["now"] += 3.0
+            return mock_pool
+
+        proxy_utils._http = None
+        with (
+            patch.object(proxy_utils, "get_backend_http_pool", side_effect=slow_pool_fetch),
+            patch.object(proxy_utils.time, "monotonic", side_effect=lambda: clock["now"]),
+        ):
+            result = proxy_utils.forward_request(
+                "https://example.com/api", "GET", {}, "", timeout=10.0
+            )
+
+        assert result["statusCode"] == 200
+        request_timeout = mock_pool.request.call_args.kwargs["timeout"]
+        assert request_timeout.total == pytest.approx(7.0)
+
 
 # ============================================================================
 # api-gateway-proxy handler


### PR DESCRIPTION
## Summary

Follow-up to #161: drive the live release validation E2E toward two consecutive all-green reports, fixing the product bugs it surfaces. Three full live deploy/validate/destroy cycles on account `760425982254` each surfaced (and now prove fixed) a distinct product bug; every cycle ended with a clean teardown and a zero-residue final inventory.

### Fix 1: helm release validation vs EKS Auto Mode control plane (`001d727`)

Live run `green1` (v5.0.0) failed topology on the last two of twelve releases:

- **kube-prometheus-stack / coreDns monitor**: on EKS Auto Mode, DNS is a built-in capability with no CoreDNS pods in kube-system, so the monitor's rendered Service (`k8s-app=kube-dns` selector) can never have ready endpoints. `coreDns` is now disabled alongside the already-disabled `kubeEtcd`/`kubeScheduler`/`kubeControllerManager`/`kubeProxy` monitors in `lambda/helm-installer/charts.yaml`.
- **kueue webhook namespace**: the chart templates `metadata.namespace` onto its cluster-scoped `MutatingWebhookConfiguration`; the API server discards the field, so kubectl returns it cluster-scoped and the exact `(identity, namespace)` match in `_compare_resource_identities` rejected a healthy release. The comparator now accepts a cluster-scoped live return for expected objects with an explicit namespace, mirroring the existing omitted-namespace fallback. Wrong-namespace returns for namespaced kinds are still rejected, with observed namespaces named in the error.

### Fix 2: Global Accelerator endpoint propagation gate (`26e715a`)

Live run `green2` (with fix 1, convergence now completing during deploy) failed its first post-deploy health probe: the request black-holed for the proxy Lambda's full 29s. CloudTrail + X-Ray pinned it: `AddEndpoints` at 20:08:53Z, deploy "passed" at 20:11:44Z, probe at 20:11:58Z — inside GA's endpoint propagation window. Deploy was reporting success before the global endpoint was usable.

- **ga-registration**: after the GA mutations, strictly wait for the accelerator to return to `DEPLOYED` (bounded by the handler's remaining wall-clock budget) before reporting success; raise `TimeoutError` otherwise. Idempotent re-runs are unaffected (already-DEPLOYED returns immediately); the Step Functions publication task already allows 16 minutes with retries.
- **proxy-shared**: `forward_request` anchored its deadline after the cold-start trust-bundle fetch using a budget computed before it, so a black-holed backend pushed wall clock past the Lambda timeout and the function was killed at 29s instead of returning its bounded 504. The deadline is now anchored before transport acquisition (synced copies refreshed).

### Fix 3: default health thresholds above the platform baseline (`c38f438`)

Live run `green3` proved the GA gate (the probe traversed API Gateway → proxy → GA → ALB and got a real application response) and surfaced the next layer: `Threshold violations: Memory: 67.3% > 60%`. On right-sized EKS Auto Mode nodes an idle cluster running the observability stack sits near 65-70% memory, so the 60% default permanently misreported a fresh region as unhealthy. Default `cpu_threshold`/`memory_threshold` raised 60 → 80 in `cdk.json`, the config-loader fallback, and the health monitor env fallbacks; the service docstring now states the real defaults; docs and default-value tests updated.

## Testing

- Regression tests accompany every fix (comparator shapes, disabled monitors, DEPLOYED gate ordering and failure modes, proxy budget accounting, threshold defaults); all CI checks green on each commit.
- Live evidence: three full deploy/validate/destroy cycles; deploy, destroy, and final-inventory passed in all three; each topology failure was converted into a product fix above.

## Known remaining issue (next branch)

Live run `green4` (all three fixes in) validated 11/12 releases and failed only on `kube-prometheus-stack: v1/Service monitoring/kube-prometheus-stack-grafana has no ready, non-terminating EndpointSlice endpoint` — a readiness race (Grafana PVC provisioning + image pull vs validation timing). Will be addressed in a follow-up branch continuing toward the two-consecutive-green goal.
