### PR TITLE
fix: live release validation greenline (part 2)

### DIFF
--- a/lambda/helm-installer/charts.yaml
+++ b/lambda/helm-installer/charts.yaml
@@ -572,6 +572,22 @@ charts:
           type: pvc
           accessModes:
             - ReadWriteOnce
+        # First-boot tolerance: Grafana runs its full database migration set
+        # (plus the unified-storage search index build) against the fresh PVC
+        # before it listens on 3000. A live deployment measured 7+ minutes,
+        # which the subchart's default liveness budget (60s initial delay +
+        # 10 failures x 10s) cut short: kubelet killed Grafana mid-migration,
+        # every restart redid the work, and the pod crash-looped. Allow ~11
+        # minutes before liveness kills it; readiness stays on the subchart
+        # default so traffic only flows once /api/health actually answers.
+        livenessProbe:
+          httpGet:
+            path: /api/health
+            port: 3000
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 30
+          failureThreshold: 60
         sidecar:
           dashboards:
             enabled: true

--- a/lambda/helm-installer/handler.py
+++ b/lambda/helm-installer/handler.py
@@ -98,6 +98,9 @@ KEDA_CUSTOM_RESOURCE_DISCOVERY_TIMEOUT_SECONDS = 10
 HELM_VALIDATION_COMMAND_TIMEOUT_SECONDS = 120
 HELM_VALIDATION_TOTAL_TIMEOUT_SECONDS = 780
 KUBECTL_VALIDATION_COMMAND_TIMEOUT_SECONDS = 120
+# Service endpoint readiness is polled (it is a convergence condition); every
+# other validation dimension stays single-shot within the shared deadline.
+ENDPOINT_READINESS_POLL_SECONDS = 10.0
 KUBECTL_VALIDATION_REQUEST_TIMEOUT = "30s"
 MAX_VALIDATION_DIAGNOSTIC_CHARS = 2048
 _HELM_RELEASE_NOT_FOUND = "Error: release: not found"
@@ -1224,20 +1227,14 @@ def _validate_resource_readiness(resource: dict[str, Any]) -> None:
                 )
 
 
-def _validate_service_endpoints(
-    resource: dict[str, Any],
+def _service_has_ready_endpoint(
+    name: str,
+    namespace: str,
+    display: str,
     kubeconfig: str,
-    release_namespace: str,
     deadline: float,
-) -> None:
-    spec = resource.get("spec", {})
-    selector = spec.get("selector") if isinstance(spec, dict) else None
-    if resource.get("kind") != "Service" or not isinstance(selector, dict) or not selector:
-        return
-
-    identity = _resource_core_identity(resource, "kubectl output")
-    name = identity[2]
-    namespace = _resource_namespace(resource) or release_namespace
+) -> bool:
+    """Return whether one ready, non-terminating endpoint backs the Service."""
     code, stdout, stderr = run_kubectl(
         [
             "get",
@@ -1255,7 +1252,6 @@ def _validate_service_endpoints(
         ),
         log_output=False,
     )
-    display = _display_identity(identity, namespace)
     if code == -1:
         raise _ValidationTimeout(f"{display} EndpointSlice query timed out")
     if code != 0:
@@ -1284,8 +1280,42 @@ def _validate_service_endpoints(
             if not isinstance(conditions, dict):
                 continue
             if _is_true(conditions.get("ready")) and not _is_true(conditions.get("terminating")):
-                return
-    raise RuntimeError(f"{display} has no ready, non-terminating EndpointSlice endpoint")
+                return True
+    return False
+
+
+def _validate_service_endpoints(
+    resource: dict[str, Any],
+    kubeconfig: str,
+    release_namespace: str,
+    deadline: float,
+) -> None:
+    """Wait, within the validation deadline, for one ready Service endpoint.
+
+    Endpoint readiness is a convergence condition, not an instant contract:
+    slow-starting workloads (for example Grafana running its first-boot
+    database migrations on a fresh PersistentVolume) legitimately publish
+    their ready endpoint minutes after installation. A single-shot check
+    failed a healthy live deployment for exactly that reason, so poll until
+    the shared validation deadline; a Service that never converges still
+    fails with the exact object named. Query and parse failures are not
+    convergence conditions and surface immediately.
+    """
+    spec = resource.get("spec", {})
+    selector = spec.get("selector") if isinstance(spec, dict) else None
+    if resource.get("kind") != "Service" or not isinstance(selector, dict) or not selector:
+        return
+
+    identity = _resource_core_identity(resource, "kubectl output")
+    name = identity[2]
+    namespace = _resource_namespace(resource) or release_namespace
+    display = _display_identity(identity, namespace)
+
+    while not _service_has_ready_endpoint(name, namespace, display, kubeconfig, deadline):
+        if deadline - time.monotonic() <= ENDPOINT_READINESS_POLL_SECONDS:
+            raise RuntimeError(f"{display} has no ready, non-terminating EndpointSlice endpoint")
+        # nosemgrep: arbitrary-sleep - bounded convergence polling within the validation deadline
+        time.sleep(ENDPOINT_READINESS_POLL_SECONDS)
 
 
 def _remove_validation_file(path: str) -> None:

--- a/tests/test_cluster_observability_charts.py
+++ b/tests/test_cluster_observability_charts.py
@@ -381,6 +381,23 @@ def test_no_credential_literal_anywhere_in_entry(kps_entry) -> None:
         assert needle not in blob, needle
 
 
+def test_grafana_liveness_tolerates_first_boot_migrations(kps_entry) -> None:
+    # Regression: Grafana's first-boot database migrations on a fresh PVC ran
+    # past the subchart's default liveness budget (~2.5 min) on a live
+    # cluster; kubelet killed it mid-migration and the pod crash-looped.
+    # Liveness must allow >= 10 minutes before the first kill, and readiness
+    # must stay on the subchart default (no override here).
+    grafana = kps_entry["values"]["grafana"]
+    liveness = grafana["livenessProbe"]
+    assert liveness["httpGet"]["path"] == "/api/health"
+    assert liveness["httpGet"]["port"] == 3000
+    tolerance = (
+        liveness["initialDelaySeconds"] + liveness["failureThreshold"] * liveness["periodSeconds"]
+    )
+    assert tolerance >= 600
+    assert "readinessProbe" not in grafana
+
+
 def test_grafana_persistence_enabled(kps_entry) -> None:
     assert kps_entry["values"]["grafana"]["persistence"]["enabled"] is True
 

--- a/tests/test_helm_installer_handler.py
+++ b/tests/test_helm_installer_handler.py
@@ -1190,6 +1190,9 @@ class TestReleaseConvergenceValidation:
             patch.object(helm_handler, "load_charts_config", return_value=self._charts()),
             patch.object(helm_handler, "run_helm", side_effect=self._helm_success(manifest)),
             patch.object(helm_handler, "run_kubectl", side_effect=kubectl_results) as mock_kubectl,
+            # An infinite poll interval exceeds any remaining budget, so the
+            # readiness poll degenerates to the single observation under test.
+            patch.object(helm_handler, "ENDPOINT_READINESS_POLL_SECONDS", float("inf")),
             pytest.raises(RuntimeError, match="no ready, non-terminating EndpointSlice endpoint"),
         ):
             helm_handler.validate_releases(self._event(), "/tmp/kubeconfig")
@@ -1197,6 +1200,54 @@ class TestReleaseConvergenceValidation:
         endpoint_args = mock_kubectl.call_args_list[1].args[0]
         assert "endpointslices.discovery.k8s.io" in endpoint_args
         assert f"kubernetes.io/service-name={service['metadata']['name']}" in endpoint_args
+
+    def test_slow_starting_service_endpoint_converges_within_deadline(self):
+        """Regression: Grafana's first-boot migrations outlived a one-shot check.
+
+        A live run crash-looped Grafana because its fresh-PVC migrations ran
+        past the probe budget; even after that was fixed, endpoint readiness
+        arrives minutes after installation. The validator polls until the
+        shared deadline, so a not-ready-then-ready Service must pass.
+        """
+        service = self._service()
+        manifest = self._manifest(service)
+        not_ready = json.dumps(
+            {
+                "apiVersion": "discovery.k8s.io/v1",
+                "kind": "EndpointSliceList",
+                "items": [{"endpoints": [{"conditions": {"ready": False}}]}],
+            }
+        )
+        ready = json.dumps(
+            {
+                "apiVersion": "discovery.k8s.io/v1",
+                "kind": "EndpointSliceList",
+                "items": [{"endpoints": [{"conditions": {"ready": True}}]}],
+            }
+        )
+        kubectl_results = [
+            (0, self._live_list(service), ""),
+            (0, not_ready, ""),
+            (0, not_ready, ""),
+            (0, ready, ""),
+        ]
+        sleeps: list[float] = []
+        with (
+            patch.object(helm_handler, "load_charts_config", return_value=self._charts()),
+            patch.object(helm_handler, "run_helm", side_effect=self._helm_success(manifest)),
+            patch.object(helm_handler, "run_kubectl", side_effect=kubectl_results) as mock_kubectl,
+            patch.object(helm_handler.time, "sleep", side_effect=sleeps.append),
+        ):
+            result = helm_handler.validate_releases(self._event(), "/tmp/kubeconfig")
+
+        assert result["status"] == "validated"
+        assert result["validated_release_count"] == 1
+        assert sleeps == [helm_handler.ENDPOINT_READINESS_POLL_SECONDS] * 2
+        endpoint_queries = sum(
+            "endpointslices.discovery.k8s.io" in call.args[0]
+            for call in mock_kubectl.call_args_list
+        )
+        assert endpoint_queries == 3
 
     @pytest.mark.parametrize(
         "conditions",
@@ -1226,6 +1277,7 @@ class TestReleaseConvergenceValidation:
             patch.object(helm_handler, "load_charts_config", return_value=self._charts()),
             patch.object(helm_handler, "run_helm", side_effect=self._helm_success(manifest)),
             patch.object(helm_handler, "run_kubectl", side_effect=kubectl_results),
+            patch.object(helm_handler, "ENDPOINT_READINESS_POLL_SECONDS", float("inf")),
             pytest.raises(RuntimeError, match="no ready, non-terminating EndpointSlice endpoint"),
         ):
             helm_handler.validate_releases(self._event(), "/tmp/kubeconfig")


### PR DESCRIPTION
## Summary

Continuation of #171, branched from v5.0.2. This PR fixes the last live-validation bug and carries the evidence for the goal: **two consecutive all-green live release validation reports** at this commit.

Live run `green4` (v5.0.2 content) validated 11/12 releases and failed only on the Grafana Service having no ready EndpointSlice endpoint. Container Insights evidence from the live cluster: the image pulled in 26 seconds and Grafana started, but its first-boot database migrations (plus the unified-storage search index build) on the fresh PVC were still running six minutes in. The grafana subchart's default liveness budget (~2.5 minutes) expired mid-migration, kubelet killed the container, each restart redid the work, and the pod crash-looped, so the Service never gained a ready endpoint. The same chart converged in time on the previous run — a nondeterministic race, not a bad image or PVC.

## Changes

- **charts.yaml**: first-boot-tolerant Grafana liveness probe (~11 minutes before the first kill) so migrations are never killed mid-flight; readiness stays on the subchart default so traffic only flows once `/api/health` answers.
- **helm-installer**: `_validate_service_endpoints` now treats endpoint readiness as a convergence condition — polling every 10s within the shared validation deadline instead of failing on the first observation. Query/parse failures still surface immediately; a Service that never converges still fails with the exact object named.

## Live E2E evidence: two consecutive all-green runs

Both runs at this PR's commit (`0ed339ae`), account 760425982254, full deploy → validate → destroy cycles:

| Run | Result | Notes |
|-----|--------|-------|
| `green5-0ed339ae` | **PASSED** — all 10 actions | topology 359s; teardown clean, zero residue |
| `green6-0ed339ae` | **PASSED** — all 10 actions | topology 658s (endpoint poll absorbed Grafana's slower first boot); teardown clean, zero residue |

All 10 actions green in both: preflight, baseline, deploy, topology, api, sqs, central-queue, convergence, destroy, final-inventory. Report artifacts: `.live-release-validation/green5-0ed339ae/` and `.live-release-validation/green6-0ed339ae/` (JSON + Markdown) in the local run workspace.

The two runs' differing topology durations are the fix working as designed: run 6's Grafana took longer to finish first-boot migrations, the liveness budget let it live, and the validator's bounded endpoint poll waited it out instead of failing the release.

## Testing

- Regression tests: not-ready-then-ready convergence path, preserved single-observation failure semantics, probe budget assertion on the chart values.
- ruff format/check, mypy (helm-installer), yamllint (charts.yaml) clean; all CI checks green.
