### PR TITLE
chore: suppress new brace-expansion DoS advisory pending CDK rebuild

### DIFF
--- a/.github/config/.npm-audit-ignore
+++ b/.github/config/.npm-audit-ignore
@@ -19,4 +19,16 @@
 #   package-dir|package|advisory|node-path|exp:YYYY-MM-DD
 # =============================================================================
 
-# (no active suppressions)
+# GHSA-mh99-v99m-4gvg — brace-expansion DoS via unbounded expansion length
+# (out-of-memory crash). Published 2026-07-24; affects <= 5.0.7, patched in
+# 5.0.8. The latest aws-cdk-lib (2.262.1, already in our lock) bundles
+# minimatch -> brace-expansion 5.0.7 inside its immutable npm tarball, so
+# npm audit fix and overrides cannot replace it and no rebuilt aws-cdk-lib
+# exists yet. The affected minimatch calls process synth-time,
+# developer-authored patterns — not untrusted remote input — the same
+# assessment AWS documented for the previous brace-expansion advisory in
+# https://github.com/aws/aws-cdk/issues/38257.
+# Advisory: https://github.com/advisories/GHSA-mh99-v99m-4gvg
+# Remove this entry and refresh package-lock.json as soon as an aws-cdk-lib
+# release bundles brace-expansion >= 5.0.8.
+.|brace-expansion|GHSA-mh99-v99m-4gvg|node_modules/aws-cdk-lib/node_modules/brace-expansion|exp:2026-08-24


### PR DESCRIPTION
## Summary

Fixes the failing `security:npm-audit:all-packages` job. GHSA-mh99-v99m-4gvg (brace-expansion DoS via unbounded expansion length, HIGH, published 2026-07-24) flags `brace-expansion <= 5.0.7`, patched in 5.0.8. The latest `aws-cdk-lib` (2.262.1, already what our lockfile resolves) bundles 5.0.7 inside its immutable npm tarball — `npm audit fix` and `overrides` cannot replace bundled dependencies, and no rebuilt `aws-cdk-lib` exists yet, so there is no pin bump that clears the finding today.

This adds one exact, dated suppression to `.github/config/.npm-audit-ignore`, scoped to the single bundled node path (`node_modules/aws-cdk-lib/node_modules/brace-expansion`) with `exp:2026-08-24`. Risk rationale: the affected minimatch calls process synth-time, developer-authored patterns rather than untrusted remote input — the same assessment AWS documented for the previous brace-expansion advisory (aws/aws-cdk#38257, whose suppression was removed once the 2.262.1 rebuild landed).

Self-cleaning: `check_npm_audit.py` fails closed on stale suppressions, so the moment a rebuilt `aws-cdk-lib` lands in the lock this entry must be deleted in the same change; the monthly deps-scan expiry warning surfaces it before the hard expiry date.

## Type of change

- [x] `chore:` Maintenance (dep bumps, etc.)
- [x] `ci:` CI / tooling change

## Testing

- [x] Ran the exact CI audit path locally on both locked npm graphs (`npm ci` + `npm audit --json` + `check_npm_audit.py` with this ignore file): root graph passes with the expected temporary-suppression warning; `lambda/inference-streaming-proxy` passes clean
- [x] `pytest tests/test_npm_audit_checker.py` passes (30 tests)
- [x] Verified upstream: advisory affects `<= 5.0.7` / patched `5.0.8`; `aws-cdk-lib@2.262.1` (npm latest) still bundles 5.0.7

## Live release validation

- [x] Not required (explain the applicability decision below)

**Applicability rationale:** CI/security-configuration-only change — one suppression-file entry, no code, dependency, or deployed-infrastructure effect.

## Checklist

- [x] Documentation updated (README, `docs/`, inline docstrings) as needed — rationale lives with the entry per the file's own rules
- [x] No secrets, credentials, or customer data committed
- [x] `requirements-lock.txt` regenerated if `pyproject.toml` changed (not applicable)
- [x] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

Unblocks CI on `main` following the 2026-07-24 publication of GHSA-mh99-v99m-4gvg.
