### PR TITLE
Install Node.js from pinned nodejs.org tarballs instead of NodeSource

### DIFF
--- a/.github/scripts/dependency-scan.sh
+++ b/.github/scripts/dependency-scan.sh
@@ -644,15 +644,17 @@ BEDROCK_MODEL_COUNT="$(wc -l < "$BEDROCK_MODEL_RESULTS" 2>/dev/null | tr -d ' ')
 # ---------------------------------------------------------------------------
 # Dockerfile.dev ARG pins
 #
-# Checks the tooling versions pinned in ``Dockerfile.dev`` (Node.js LTS
-# major, AWS CDK CLI, kubectl, AWS CLI v2, Docker CLI, Docker Buildx). These ARGs sit
+# Checks the tooling versions pinned in ``Dockerfile.dev`` (Node.js
+# release, AWS CDK CLI, kubectl, AWS CLI v2, Docker CLI, Docker Buildx). These ARGs sit
 # outside the main dependency surfaces above — Dependabot watches the
 # ``FROM python:…`` base image but not the ARG pins — so drift here has
 # historically gone undetected until someone rebuilt the image.
 #
 # Each pin has its own upstream:
 #
-#   NODE_MAJOR     github://nodejs/Release → schedule.json (LTS majors)
+#   NODE_VERSION   github://nodejs/Release → schedule.json (active LTS
+#                  major) + nodejs.org/dist/index.json (newest release
+#                  on that major)
 #   NPM_VERSION    registry.npmjs.org/npm/latest
 #   CDK_VERSION    registry.npmjs.org/aws-cdk/latest
 #   KUBECTL_VERSION https://dl.k8s.io/release/stable-<minor>.txt
@@ -672,10 +674,16 @@ DOCKERFILE_PIN_FILE="Dockerfile.dev"
 check_dockerfile_pin() {
   local name="$1" current="$2" latest=""
   case "$name" in
-    NODE_MAJOR)
-      # Pick the highest major with an active LTS window:
-      #   lts <= today AND (end missing or end > today).
-      latest="$(curl -fsSL --max-time 15 \
+    NODE_VERSION)
+      # Two drift signals folded into one compare. First pick the
+      # highest major with an active LTS window from the release
+      # schedule (lts <= today AND (end missing or end > today)),
+      # then resolve that major's newest release from the official
+      # dist index — the same origin the Dockerfile downloads from.
+      # A new LTS line and a new patch on the current line both
+      # surface as ``newer``.
+      local lts_major
+      lts_major="$(curl -fsSL --max-time 15 \
         "https://raw.githubusercontent.com/nodejs/Release/main/schedule.json" 2>/dev/null \
         | python3 -c '
 import sys, json, datetime
@@ -699,6 +707,13 @@ for k, v in data.items():
 if candidates:
     print(max(candidates))
 ' 2>/dev/null)" || true
+      [ -z "$lts_major" ] && return
+      # index.json is newest-first per line, so the first entry whose
+      # version sits on the LTS major is that major's latest release.
+      latest="$(curl -fsSL --max-time 15 \
+        "https://nodejs.org/dist/index.json" 2>/dev/null \
+        | jq -r --arg prefix "v${lts_major}." \
+          '[.[].version | select(startswith($prefix))][0] // empty' 2>/dev/null)" || true
       ;;
     CDK_VERSION)
       latest="$(curl -fsSL --max-time 15 \
@@ -707,8 +722,8 @@ if candidates:
       ;;
     NPM_VERSION)
       # ``npm`` is part of the dev container's pinned tooling — the
-      # version that ships bundled inside nodesource's nodejs apt
-      # package isn't pinned to a patch, so the Dockerfile installs a
+      # npm bundled inside the Node dist tarball is fixed per Node
+      # release but lags npm's own line, so the Dockerfile installs a
       # specific ``npm@X.Y.Z`` to keep rebuilds reproducible (same
       # rationale as CDK_VERSION above). The canonical "latest" is the
       # ``latest`` dist-tag on npmjs.org, same source CDK uses.
@@ -756,21 +771,11 @@ if candidates:
 
   [ -z "$latest" ] && return
 
-  # NODE_MAJOR is a bare integer (e.g. ``24``) not a semver. Compare as
-  # integers; everything else goes through compare_semver.
+  # Every pin is a semver, NODE_VERSION included. compare_semver strips
+  # a leading ``v`` on both sides, matching the kubectl and buildx pins
+  # that keep the prefix.
   local relation
-  if [ "$name" = "NODE_MAJOR" ]; then
-    if ! [[ "$current" =~ ^[0-9]+$ ]] || ! [[ "$latest" =~ ^[0-9]+$ ]]; then
-      return
-    fi
-    if [ "$latest" -gt "$current" ]; then
-      relation="newer"
-    else
-      relation="same_or_older"
-    fi
-  else
-    relation="$(compare_semver "$current" "$latest")"
-  fi
+  relation="$(compare_semver "$current" "$latest")"
 
   if [ "$relation" = "newer" ]; then
     echo "  - ${name}: ${current} -> ${latest}"

--- a/.github/scripts/lib_dependency_scan.sh
+++ b/.github/scripts/lib_dependency_scan.sh
@@ -310,7 +310,7 @@ extract_k8s_version() {
 #
 # Example output for Dockerfile.dev:
 #
-#     NODE_MAJOR|24
+#     NODE_VERSION|v24.18.0
 #     NPM_VERSION|11.14.1
 #     CDK_VERSION|2.1120.0
 #     KUBECTL_VERSION|v1.36.1
@@ -323,7 +323,7 @@ extract_dockerfile_pins() {
   python3 -c "
 import re, sys
 allowlist = {
-    'NODE_MAJOR',
+    'NODE_VERSION',
     'NPM_VERSION',
     'CDK_VERSION',
     'KUBECTL_VERSION',
@@ -1171,7 +1171,9 @@ except OSError:
     pass
 try:
     text = resolve(sys.argv[4]).read_text(encoding='utf-8')
-    match = re.search(r'^\s*ARG\s+NODE_MAJOR=(\d+)\s*$', text, re.MULTILINE)
+    # NODE_VERSION pins the exact release (e.g. ``v24.18.0``); emit()
+    # reduces it to the leading major for the cross-source comparison.
+    match = re.search(r'^\s*ARG\s+NODE_VERSION=(v?\d+(?:\.\d+)*)\s*$', text, re.MULTILINE)
     if match:
         emit('Dockerfile.dev', match.group(1))
 except OSError:

--- a/.github/workflows/deps-scan.yml
+++ b/.github/workflows/deps-scan.yml
@@ -19,7 +19,7 @@
 #     model family (AWS creds via OIDC)
 #   - Accelerator catalog and Karpenter NodePool policy (offline), plus live
 #     NVIDIA GPU / AWS Neuron EC2 catalog drift across enabled Regions (OIDC)
-#   - Dockerfile.dev ARG pins (NODE_MAJOR, NPM_VERSION, CDK_VERSION,
+#   - Dockerfile.dev ARG pins (NODE_VERSION, NPM_VERSION, CDK_VERSION,
 #     KUBECTL_VERSION, AWSCLI_VERSION, DOCKER_VERSION, BUILDX_VERSION) — public endpoints,
 #     no AWS creds needed
 #   - Pre-commit hook revisions in .pre-commit-config.yaml compared against

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -102,24 +102,49 @@ RUN echo "apt security epoch ${APT_SECURITY_EPOCH}" \
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Install Node.js (for CDK) — pinned to current LTS major. Bump
-# intentionally when a new LTS line is validated against the CDK version
-# pinned below.
-ARG NODE_MAJOR=24
-RUN curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
-    && rm -rf /var/lib/apt/lists/* \
+# Install Node.js (for CDK) — pinned to an exact release, downloaded as
+# the official nodejs.org dist tarball and verified against the SHA-256
+# published in that release's SHASUMS256.txt.
+#
+# This deliberately does NOT use the NodeSource apt repository. Their
+# setup script was the only third-party-intermediated `curl | bash`
+# install left in this image, it pinned nothing beyond the major, and a
+# NodeSource CDN 403 outage (2026-07-27) broke every dev-container CI
+# job while the official dist endpoint stayed up. The tarball install
+# matches how every other tool below is provisioned: a pinned direct
+# download from the vendor's canonical distribution point — plus a
+# checksum, which the NodeSource path could never offer.
+#
+# Bump procedure (keep the three ARGs in lockstep):
+#   1. Pick the release from https://nodejs.org/dist/index.json
+#      (deps-scan reports drift against the newest active-LTS release).
+#   2. Copy both hashes from
+#      https://nodejs.org/dist/<NODE_VERSION>/SHASUMS256.txt
+#      for node-<NODE_VERSION>-linux-{x64,arm64}.tar.gz.
+# Node's tarballs use x64/arm64 arch tags; amd64 maps to x64 below.
+ARG NODE_VERSION=v24.18.0
+ARG NODE_SHA256_AMD64=783130984963db7ba9cbd01089eaf2c2efb055c7c1693c943174b967b3050cb8
+ARG NODE_SHA256_ARM64=6b4484c2190274175df9aa8f28e2d758a819cb1c1fe6ab481e2f95b463ab8508
+RUN case "${TARGETARCH}" in \
+        amd64)  NODE_ARCH="x64";   NODE_SHA256="${NODE_SHA256_AMD64}" ;; \
+        arm64)  NODE_ARCH="arm64"; NODE_SHA256="${NODE_SHA256_ARM64}" ;; \
+        *)      echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-${NODE_ARCH}.tar.gz" \
+      -o /tmp/node.tar.gz \
+    && echo "${NODE_SHA256}  /tmp/node.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/node.tar.gz -C /usr/local --strip-components=1 --no-same-owner \
+    && rm /tmp/node.tar.gz \
     && node --version
 
 # Pin npm to a specific patch.
 #
-# The npm version that ships bundled inside the nodesource ``nodejs``
-# apt package isn't pinned to a patch — it tracks whatever was current
-# when the apt cache was last refreshed — so without this step the
-# image's tooling drifts every time the build is run. We pin it the
-# same way we pin every other contributor-facing tool below
-# (CDK CLI, kubectl, AWS CLI v2, Docker CLI) so rebuilds are
-# reproducible and Dependency-scan can flag drift cleanly.
+# The npm bundled inside the Node dist tarball is fixed per Node
+# release, but it lags npm's own release line and would silently
+# change whenever NODE_VERSION is bumped. We pin it the same way we
+# pin every other contributor-facing tool below (CDK CLI, kubectl,
+# AWS CLI v2, Docker CLI) so rebuilds are reproducible and
+# Dependency-scan can flag drift cleanly.
 #
 # Bump in lockstep with the deps-scan report; the value flows through
 # as ``NPM_VERSION`` in the Dockerfile.dev pins section.

--- a/tests/BATS/test_dependency_scan.bats
+++ b/tests/BATS/test_dependency_scan.bats
@@ -462,7 +462,7 @@ EOF
     run extract_dockerfile_pins "Dockerfile.dev"
     [ "$status" -eq 0 ]
     # All seven allowlisted pins should be present.
-    [[ "$output" == *"NODE_MAJOR|"* ]]
+    [[ "$output" == *"NODE_VERSION|"* ]]
     [[ "$output" == *"NPM_VERSION|"* ]]
     [[ "$output" == *"CDK_VERSION|"* ]]
     [[ "$output" == *"KUBECTL_VERSION|"* ]]
@@ -484,12 +484,16 @@ EOF
     done <<< "$output"
 }
 
-@test "extract_dockerfile_pins: NODE_MAJOR value is a bare integer" {
+@test "extract_dockerfile_pins: NODE_VERSION keeps the v prefix" {
+    # The Dockerfile pins Node with the leading 'v' because the
+    # nodejs.org dist URL and tarball name both use it
+    # (node-vX.Y.Z-linux-<arch>.tar.gz). Assert we preserve it so the
+    # download URL and the deps-scan compare line up.
     run extract_dockerfile_pins "Dockerfile.dev"
     [ "$status" -eq 0 ]
-    node_line="$(echo "$output" | grep '^NODE_MAJOR|')"
-    value="${node_line#NODE_MAJOR|}"
-    [[ "$value" =~ ^[0-9]+$ ]]
+    node_line="$(echo "$output" | grep '^NODE_VERSION|')"
+    value="${node_line#NODE_VERSION|}"
+    [[ "$value" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
 }
 
 @test "extract_dockerfile_pins: KUBECTL_VERSION keeps the v prefix" {
@@ -529,6 +533,7 @@ EOF
     tmpfile="$(mktemp)"
     cat > "$tmpfile" <<'EOF'
 FROM scratch
+ARG NODE_VERSION=v24.18.0
 ARG NODE_MAJOR=24
 ARG BUILD_DATE=20260501
 ARG UNRELATED_KNOB=hello
@@ -537,9 +542,13 @@ EOF
     run extract_dockerfile_pins "$tmpfile"
     [ "$status" -eq 0 ]
     # Allowlisted pins pass through
-    [[ "$output" == *"NODE_MAJOR|24"* ]]
+    [[ "$output" == *"NODE_VERSION|v24.18.0"* ]]
     [[ "$output" == *"CDK_VERSION|2.1120.0"* ]]
-    # Non-allowlisted ARGs are filtered out
+    # Non-allowlisted ARGs are filtered out. NODE_MAJOR left the
+    # allowlist when the Node install moved off the NodeSource apt
+    # repository onto pinned nodejs.org dist tarballs — a stray
+    # reintroduction must not resurface in the drift report.
+    [[ "$output" != *"NODE_MAJOR"* ]]
     [[ "$output" != *"BUILD_DATE"* ]]
     [[ "$output" != *"UNRELATED_KNOB"* ]]
     rm -f "$tmpfile"
@@ -549,15 +558,15 @@ EOF
     tmpfile="$(mktemp)"
     cat > "$tmpfile" <<'EOF'
 FROM scratch
-# ARG NODE_MAJOR=99
-ARG NODE_MAJOR=24
+# ARG NODE_VERSION=v99.0.0
+ARG NODE_VERSION=v24.18.0
 EOF
     run extract_dockerfile_pins "$tmpfile"
     [ "$status" -eq 0 ]
-    # Only one NODE_MAJOR line, and it's the uncommented 24 value.
-    count="$(echo "$output" | grep -c '^NODE_MAJOR|' || true)"
+    # Only one NODE_VERSION line, and it's the uncommented v24.18.0 value.
+    count="$(echo "$output" | grep -c '^NODE_VERSION|' || true)"
     [ "$count" -eq 1 ]
-    [[ "$output" == *"NODE_MAJOR|24"* ]]
+    [[ "$output" == *"NODE_VERSION|v24.18.0"* ]]
     rm -f "$tmpfile"
 }
 


### PR DESCRIPTION
## Summary

Replaces the NodeSource `curl | bash` Node.js install in `Dockerfile.dev` with a pinned, checksum-verified download of the official nodejs.org dist tarball, and migrates the dependency-scan pin contract from `NODE_MAJOR` to `NODE_VERSION`.

### Why

A NodeSource CDN 403 outage (2026-07-27) failed all five dev-container Integration Tests jobs on `main` (`integration:docker:dev-container` amd64+arm64, `integration:dev-alias:{docker,finch,podman}`). The in-image build retry fired three times and could not help — persistent third-party outages are only fixed by removing the dependency. NodeSource was also the odd one out in this Dockerfile:

| Tool | Install method |
|---|---|
| kubectl, AWS CLI v2, Docker CLI, Buildx | pinned direct download from vendor's canonical endpoint |
| Node.js (before) | third-party `curl \| bash` as root, pinned to major only, no checksum |
| Node.js (after) | pinned nodejs.org tarball, SHA-256 verified against the release's published SHASUMS256.txt, fail-closed |

nodejs.org stayed up throughout the NodeSource outage.

### Changes

- `Dockerfile.dev`: `ARG NODE_VERSION=v24.18.0` + per-arch `NODE_SHA256_{AMD64,ARM64}` pins; downloads `node-<ver>-linux-{x64,arm64}.tar.gz`, verifies with `sha256sum -c` before extraction into `/usr/local`. NodeSource apt repo removed. Bump procedure documented inline.
- `.github/scripts/{dependency-scan.sh,lib_dependency_scan.sh}`: pin allowlist and drift check move `NODE_MAJOR` → `NODE_VERSION`. The drift check folds both prior signals into one compare: active LTS major from the nodejs Release schedule, then that major's newest release from `nodejs.org/dist/index.json` — a new LTS line and a new patch both surface as `newer`. The node-major consistency gate (`.nvmrc` / `gco/stacks/constants.py` / `package.json` engines / Dockerfile) derives the major from the new pin.
- `tests/BATS/test_dependency_scan.bats`: node pin tests rewritten for the new contract, including a regression guard that a stray `ARG NODE_MAJOR` no longer surfaces in the drift report.
- `.github/workflows/deps-scan.yml`: comment-only pin list update.

## Testing

- Native arm64 `finch build` of `Dockerfile.dev` succeeds; checksum gate observed passing (`/tmp/node.tar.gz: OK`) and proven to fail closed against a deliberately wrong hash.
- Toolchain smoke test inside the built image: `node v24.18.0`, `npm 12.0.1`, `cdk 2.1133.0`, `gco 5.1.0`.
- All 164 BATS dependency-scan tests pass.
- Full `dependency-scan.sh` run completes clean end to end with the new `NODE_VERSION` path (reports current, no node drift; node-major consistency across all 5 sources passes). Note: deps-scan runs on schedule/dispatch only, so PR CI does not exercise it — this local run stands in.
- Upstream lookup verified live: schedule.json → LTS major 24; index.json → `v24.18.0` (matches pin, no drift).
- shellcheck, hadolint (same pinned image + ignores as CI), yamllint, actionlint: all clean.

The five previously-failing dev-container CI jobs on this PR are the live proof: they build this Dockerfile without touching NodeSource.

## Blocked / out of scope

- Two follow-up items land in a separate PR next: `destroy-all` cleanup of implicit log groups + bastion IAM, and throttle resilience for the live-validation inventory tag lookups.
- `main`'s red Integration Tests run predates this fix; rerunning it after NodeSource recovers (or merging this) clears it.

Do not merge — for manual review per repo owner.
