### PR TITLE
Teardown hardening: sweep implicit orphans, retry inventory throttles

### DIFF
--- a/cli/stacks.py
+++ b/cli/stacks.py
@@ -4214,6 +4214,13 @@ class StackManager:
         )
         record_cleanup("bastions", {"terminated_instances": bastions})
 
+        # Non-strict teardowns also retire the bastion's standing IAM
+        # role/profile and, below, the implicit log groups CloudFormation
+        # never modeled. Strict (live-validation) teardowns skip both: the
+        # harness owns fenced log-group deletion and audits IAM itself.
+        if not strict_identity:
+            record_cleanup("bastion-iam", self._cleanup_bastion_iam())
+
         global_stack_name = f"{project_name}-global"
         backup = self._cleanup_backup_vault(
             expected_stack_id=(expected_stack_ids or {}).get(global_stack_name),
@@ -4229,6 +4236,28 @@ class StackManager:
 
         successful: list[str] = []
         failed: list[str] = []
+
+        # Capture implicit log-group names while the source stacks still
+        # exist; the exact derived names are deleted by ``finish`` below
+        # once their stacks are gone. Strict teardowns collect nothing —
+        # the live-validation harness owns fenced log-group deletion.
+        implicit_log_groups: dict[str, dict[str, Any]] = {}
+        if not strict_identity:
+            implicit_log_groups = self._collect_implicit_log_groups(stacks)
+
+        def finish(overall: bool) -> tuple[bool, list[str], list[str]]:
+            """Funnel every exit through the implicit log-group sweep.
+
+            Called at each return point so a partially failed teardown
+            still cleans up the stacks that DID delete. New exit paths
+            must return through here as well.
+            """
+            if implicit_log_groups:
+                record_cleanup(
+                    "implicit-log-groups",
+                    self._cleanup_implicit_log_groups(implicit_log_groups, successful),
+                )
+            return overall, successful, failed
 
         for stack_name in post_regional_stacks:
             if on_stack_start:
@@ -4252,7 +4281,7 @@ class StackManager:
             if stack_name not in failed:
                 failed.append(stack_name)
         if any(stack in failed for stack in post_regional_stacks) or phase_remaining:
-            return False, successful, failed
+            return finish(False)
 
         if regional_api_stacks:
             if parallel and len(regional_api_stacks) > 1:
@@ -4295,7 +4324,7 @@ class StackManager:
                 if stack_name not in failed:
                     failed.append(stack_name)
             if any(stack in failed for stack in regional_api_stacks) or phase_remaining:
-                return False, successful, failed
+                return finish(False)
 
         watchdog_stops: dict[str, Event] = {}
         watchdog_threads: dict[str, Thread] = {}
@@ -4398,7 +4427,7 @@ class StackManager:
             if stack_name not in failed:
                 failed.append(stack_name)
         if any(stack in failed for stack in regional_stacks) or phase_remaining:
-            return False, successful, failed
+            return finish(False)
 
         for stack_name in pre_regional_stacks:
             if on_stack_start:
@@ -4422,9 +4451,9 @@ class StackManager:
                 if remaining_stack not in failed:
                     failed.append(remaining_stack)
             if not success or phase_remaining:
-                return False, successful, failed
+                return finish(False)
 
-        return len(failed) == 0, successful, failed
+        return finish(len(failed) == 0)
 
     def _destroy_stacks_parallel(
         self,
@@ -4887,6 +4916,169 @@ class StackManager:
                 break
             _time.sleep(poll_interval_seconds)
         return remaining
+
+    # ------------------------------------------------------------------
+    # Implicit log-group + bastion IAM cleanup (non-strict destroy only)
+    # ------------------------------------------------------------------
+    #
+    # CloudFormation only deletes the log groups it modeled. Lambda default
+    # groups (``/aws/lambda/<function>``), the EKS control-plane group
+    # (``/aws/eks/<cluster>/cluster``), and the Container Insights groups
+    # (``/aws/containerinsights/<cluster>/…``) are created out-of-band by
+    # the services themselves, so ``destroy-all`` used to report success
+    # while leaving them behind — a real teardown orphaned 22 of them plus
+    # the ephemeral-bastion IAM role/profile, which then failed the live
+    # release validation's clean-account baseline gate.
+    #
+    # The cleanup below deletes ONLY exact names derived from the project's
+    # own stack resources, captured while the stacks still exist, and only
+    # for stacks whose deletion actually succeeded. It never runs in strict
+    # (live-validation) teardowns: the harness checkpoints, tags, and
+    # fences its own log-group generations and must remain the single
+    # owner of that deletion authority.
+
+    # The service-side patterns implicit log groups follow. An explicit
+    # ``AWS::Logs::LogGroup`` resource is deliberately absent here —
+    # CloudFormation owns those directly.
+    _EKS_CONTAINER_INSIGHTS_SUFFIXES = ("application", "dataplane", "host", "performance")
+
+    @staticmethod
+    def _implicit_log_group_names(resource_type: str, physical_id: str) -> tuple[str, ...]:
+        """Exact implicit log-group names a stack resource creates out-of-band."""
+        if resource_type == "AWS::Lambda::Function":
+            return (f"/aws/lambda/{physical_id}",)
+        if resource_type == "AWS::EKS::Cluster":
+            return (
+                f"/aws/eks/{physical_id}/cluster",
+                *(
+                    f"/aws/containerinsights/{physical_id}/{suffix}"
+                    for suffix in StackManager._EKS_CONTAINER_INSIGHTS_SUFFIXES
+                ),
+            )
+        return ()
+
+    def _collect_implicit_log_groups(self, stacks: Collection[str]) -> dict[str, dict[str, Any]]:
+        """Derive per-stack implicit log-group names while the stacks are live.
+
+        Best-effort: a stack that cannot be described or listed is skipped
+        with a warning — collection must never block the destroy itself.
+        """
+        collected: dict[str, dict[str, Any]] = {}
+        for stack_name in stacks:
+            try:
+                target = self._describe_stack_target(stack_name)
+                if target is None:
+                    continue
+                region, cloudformation, stack = target
+                names: list[str] = []
+                paginator = cloudformation.get_paginator("list_stack_resources")
+                for page in paginator.paginate(StackName=str(stack["StackId"])):
+                    for item in page.get("StackResourceSummaries", []):
+                        resource_type = str(item.get("ResourceType") or "")
+                        physical_id = str(item.get("PhysicalResourceId") or "")
+                        if not physical_id:
+                            continue
+                        names.extend(self._implicit_log_group_names(resource_type, physical_id))
+                if names:
+                    collected[stack_name] = {"region": region, "log_groups": sorted(set(names))}
+            except Exception as exc:  # noqa: BLE001 - best-effort collection
+                logger.warning("Could not derive implicit log groups for %s: %s", stack_name, exc)
+        return collected
+
+    def _cleanup_implicit_log_groups(
+        self,
+        collected: Mapping[str, Mapping[str, Any]],
+        successful_stacks: Collection[str],
+    ) -> dict[str, Any]:
+        """Delete the exact derived log groups of successfully destroyed stacks.
+
+        A missing group is normal (a Lambda that never logged, or a custom
+        ``LoggingConfig`` pointing elsewhere) and is recorded, not retried.
+        Every error is recorded and swallowed: cleanup never converts a
+        successful destroy into a failure.
+        """
+        import boto3
+
+        outcome: dict[str, Any] = {"deleted": [], "missing": [], "errors": []}
+        clients: dict[str, Any] = {}
+        for stack_name in sorted(successful_stacks):
+            details = collected.get(stack_name)
+            if not details:
+                continue
+            region = str(details.get("region") or "")
+            for name in details.get("log_groups", []):
+                try:
+                    client = clients.get(region)
+                    if client is None:
+                        client = boto3.client("logs", region_name=region)
+                        clients[region] = client
+                    client.delete_log_group(logGroupName=name)
+                    outcome["deleted"].append(f"{region}:{name}")
+                except ClientError as exc:
+                    code = str(exc.response.get("Error", {}).get("Code") or "")
+                    if code == "ResourceNotFoundException":
+                        outcome["missing"].append(f"{region}:{name}")
+                    else:
+                        outcome["errors"].append(f"{region}:{name}: {code}")
+                except Exception as exc:  # noqa: BLE001 - best-effort cleanup
+                    outcome["errors"].append(f"{region}:{name}: {type(exc).__name__}: {exc}")
+        if outcome["deleted"]:
+            print(
+                f"  Deleted {len(outcome['deleted'])} implicit CloudWatch log group(s) "
+                "left behind by Lambda/EKS/Container Insights."
+            )
+        for failure in outcome["errors"]:
+            logger.warning("Implicit log-group cleanup failed for %s", failure)
+        return outcome
+
+    def _cleanup_bastion_iam(self) -> dict[str, Any]:
+        """Best-effort teardown of the ephemeral-bastion IAM role + profile.
+
+        ``destroy_ephemeral_bastion`` already attempts this when a tunnel
+        closes normally, but a killed process leaves the pair behind (they
+        cost nothing, yet fail any clean-account audit). Deletion is by the
+        exact project-scoped names from the bastion naming contract; a
+        ``NoSuchEntity`` response simply means there was nothing to clean.
+        """
+        from .ephemeral_bastion import (
+            _run_aws,
+            bastion_profile_name,
+            bastion_role_name,
+            build_iam_teardown_commands,
+        )
+
+        outcome: dict[str, Any] = {
+            "completed_steps": 0,
+            "absent_steps": 0,
+            "errors": [],
+        }
+        try:
+            role_name = bastion_role_name(self.config.project_name)
+            profile_name = bastion_profile_name(self.config.project_name)
+            outcome["role"] = role_name
+            outcome["profile"] = profile_name
+            steps = build_iam_teardown_commands(
+                role_name,
+                profile_name,
+                self.config.global_region,
+            )
+        except Exception as exc:  # noqa: BLE001 - best-effort cleanup
+            outcome["errors"].append(f"{type(exc).__name__}: {exc}")
+            return outcome
+        for step in steps:
+            try:
+                _run_aws(step)
+                outcome["completed_steps"] += 1
+            except RuntimeError as exc:
+                if "NoSuchEntity" in str(exc):
+                    outcome["absent_steps"] += 1
+                    continue
+                outcome["errors"].append(f"{' '.join(step[:3])}: {exc}")
+        if outcome["completed_steps"] and not outcome["errors"]:
+            print("  Removed the ephemeral-bastion IAM role and instance profile.")
+        for failure in outcome["errors"]:
+            logger.warning("Bastion IAM teardown step failed: %s", failure)
+        return outcome
 
     def cleanup_eks_security_groups(self) -> None:
         """Clean up EKS-managed security groups across all regional stacks.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1043,6 +1043,18 @@ gco stacks destroy-all [OPTIONS]
 | `--parallel` | `-p` | Destroy regional stacks in parallel |
 | `--max-workers` | `-w` | Max parallel workers (default: 4) |
 
+After the stacks are gone, `destroy-all` also sweeps the resources
+CloudFormation never modeled, so a full teardown leaves the account
+genuinely clean: the implicit CloudWatch log groups created out-of-band by
+Lambda (`/aws/lambda/<function>`), the EKS control plane
+(`/aws/eks/<cluster>/cluster`), and Container Insights
+(`/aws/containerinsights/<cluster>/...`), plus the ephemeral SSM bastion's
+IAM role and instance profile if a killed tunnel session left them behind.
+Only exact names derived from the destroyed stacks' own resources (captured
+before deletion) are removed, and only for stacks whose deletion succeeded;
+the sweep is best-effort and never fails the destroy. Log groups belonging
+to stacks that failed to delete are left untouched.
+
 #### `gco stacks bootstrap`
 
 Bootstrap CDK in a region. This is run automatically by `deploy` and `deploy-all` when needed, so manual bootstrapping is optional.

--- a/scripts/live_release_validation/aws_session.py
+++ b/scripts/live_release_validation/aws_session.py
@@ -1,0 +1,73 @@
+"""Throttle-resilient boto3 session facade for the live-validation harness.
+
+Every inventory scanner fans out across all enabled Regions and issues one
+metadata read per resource (``ListTagsForResource`` on each CloudWatch log
+group, per-role IAM tag lookups, and so on). Under botocore's default retry
+budget a Regional TPS squeeze surfaces as a hard failure — a real
+``final-inventory`` run died with ``ThrottlingException … reached max
+retries: 4`` while scanning 17 Regions even though the account state was
+clean.
+
+The facade below gives every client the harness creates botocore's
+``adaptive`` retry mode: client-side rate limiting that paces request bursts
+before they trip the service, plus a much deeper retry budget for the
+throttling errors that still get through. Correctness is unchanged — after
+the budget is exhausted the original ``ClientError`` still propagates, so
+every fail-closed path behaves exactly as before; the run just no longer
+fails on a transient rate spike that a bounded wait absorbs.
+
+Callers that pass their own ``config`` keep every field they set — the
+retry defaults only fill the gaps (``botocore.config.Config.merge`` gives
+the *other* config precedence on conflicts).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import boto3
+from botocore.config import Config
+
+# ``adaptive`` includes everything ``standard`` retries (throttling errors,
+# transient 5xx, timeouts) and adds client-side rate limiting. The attempt
+# budget is deliberately deep: with exponential backoff it absorbs a
+# sustained Regional throttle window, while a genuine outage still fails
+# within a bounded, observable number of attempts.
+_RETRY_MAX_ATTEMPTS = 12
+
+_ADAPTIVE_RETRY_CONFIG = Config(
+    retries={
+        "mode": "adaptive",
+        "max_attempts": _RETRY_MAX_ATTEMPTS,
+    }
+)
+
+
+class ThrottleResilientSession:
+    """Delegate to a real ``boto3.Session``, injecting adaptive retries.
+
+    Only ``client`` and ``resource`` construction is intercepted; every other
+    attribute (``get_credentials``, ``get_available_regions``,
+    ``get_partition_for_region``, ``region_name``, …) resolves on the wrapped
+    session unchanged.
+    """
+
+    def __init__(self, session: Any | None = None) -> None:
+        self._session = session if session is not None else boto3.Session()
+
+    @staticmethod
+    def _merged_config(config: Any | None) -> Any:
+        if config is None:
+            return _ADAPTIVE_RETRY_CONFIG
+        # ``merge`` returns a new Config whose fields prefer ``config`` —
+        # a caller that sets its own ``retries`` wins over the default.
+        return _ADAPTIVE_RETRY_CONFIG.merge(config)
+
+    def client(self, *args: Any, config: Any | None = None, **kwargs: Any) -> Any:
+        return self._session.client(*args, config=self._merged_config(config), **kwargs)
+
+    def resource(self, *args: Any, config: Any | None = None, **kwargs: Any) -> Any:
+        return self._session.resource(*args, config=self._merged_config(config), **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._session, name)

--- a/scripts/live_release_validation/runner.py
+++ b/scripts/live_release_validation/runner.py
@@ -10,14 +10,13 @@ import traceback
 from pathlib import Path
 from typing import Any, Literal
 
-import boto3
-
 from cli.aws_client import GCOAWSClient
 from cli.config import GCOConfig
 from cli.jobs import JobManager
 from cli.stacks import StackManager
 
 from .actions import action_final_inventory, destroy_deployment
+from .aws_session import ThrottleResilientSession
 from .models import (
     ActionResult,
     RunCheckpoint,
@@ -71,7 +70,11 @@ class LiveValidationRunner:
                 action_results=list(self.checkpoint.action_results.values()),
                 baseline=self.checkpoint.baseline,
             )
-            self.session = boto3.Session()
+            # Adaptive throttle retries for every harness client: the
+            # inventory scanners issue one metadata read per resource across
+            # every enabled Region, and a Regional TPS squeeze must surface
+            # as a bounded wait, not a failed action. See aws_session.py.
+            self.session = ThrottleResilientSession()
             self.aws_client = GCOAWSClient(self.config)
             self.aws_client._session = self.session
             self.job_manager = JobManager(self.config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,6 +116,9 @@ _DESTROY_CLEANUP_OWNERS = {
     "TestEksSecurityGroupCleanup",
     "TestCleanupEksSecurityGroups",
     "TestEksSgWatchdog",
+    "TestImplicitLogGroupCleanup",
+    "TestBastionIamCleanup",
+    "TestDestroyOrchestratedImplicitCleanupWiring",
 }
 
 
@@ -130,6 +133,20 @@ def _no_real_destroy_cleanup_aws_calls(request):
         patch.object(_stacks.StackManager, "_cleanup_backup_vault", return_value=None),
         patch.object(_stacks.StackManager, "_cleanup_eks_security_groups", return_value=None),
         patch.object(_stacks.StackManager, "_start_eks_sg_watchdog", return_value=MagicMock()),
+        # The implicit log-group + bastion IAM sweep added for non-strict
+        # teardowns is boto3/AWS-CLI-backed as well; orchestration tests
+        # that don't own these helpers must never fire them for real.
+        patch.object(_stacks.StackManager, "_collect_implicit_log_groups", return_value={}),
+        patch.object(
+            _stacks.StackManager,
+            "_cleanup_implicit_log_groups",
+            return_value={"deleted": [], "missing": [], "errors": []},
+        ),
+        patch.object(
+            _stacks.StackManager,
+            "_cleanup_bastion_iam",
+            return_value={"completed_steps": 0, "absent_steps": 0, "errors": []},
+        ),
     ):
         yield
 

--- a/tests/test_live_release_validation.py
+++ b/tests/test_live_release_validation.py
@@ -3629,7 +3629,7 @@ class TestLocalOnlyRuntime:
         monkeypatch.setenv("GITHUB_ACTIONS", "TRUE")
 
         with (
-            patch.object(runner.boto3, "Session") as session,
+            patch.object(runner, "ThrottleResilientSession") as session,
             pytest.raises(RuntimeError, match="must not run in GitHub Actions"),
         ):
             runner.LiveValidationRunner(settings)
@@ -3908,3 +3908,92 @@ class TestManifestPathResolution:
         assert referenced, "no _load_manifest call sites found; update the scanner regex"
         for filename in sorted(referenced):
             assert (package / "manifests" / filename).is_file(), filename
+
+
+class TestThrottleResilientSession:
+    """Every harness client gets adaptive throttle retries by default.
+
+    A real ``final-inventory`` failed with ``ThrottlingException … reached
+    max retries: 4`` on CloudWatch Logs ``ListTagsForResource`` while
+    scanning 17 Regions. The facade must pace and retry that class of
+    error without changing any other session behavior.
+    """
+
+    def _facade(self):
+        from unittest.mock import MagicMock
+
+        from scripts.live_release_validation.aws_session import ThrottleResilientSession
+
+        inner = MagicMock()
+        return ThrottleResilientSession(inner), inner
+
+    def test_client_injects_adaptive_retry_config(self) -> None:
+        facade, inner = self._facade()
+
+        facade.client("logs", region_name="eu-west-1")
+
+        inner.client.assert_called_once()
+        args, kwargs = inner.client.call_args
+        assert args == ("logs",)
+        assert kwargs["region_name"] == "eu-west-1"
+        retries = kwargs["config"].retries
+        assert retries["mode"] == "adaptive"
+        assert retries["max_attempts"] >= 10
+
+    def test_resource_injects_the_same_retry_config(self) -> None:
+        facade, inner = self._facade()
+
+        facade.resource("s3")
+
+        retries = inner.resource.call_args.kwargs["config"].retries
+        assert retries["mode"] == "adaptive"
+
+    def test_caller_config_fields_survive_the_merge(self) -> None:
+        from botocore.config import Config
+
+        facade, inner = self._facade()
+
+        facade.client("logs", config=Config(read_timeout=7))
+
+        merged = inner.client.call_args.kwargs["config"]
+        assert merged.read_timeout == 7
+        assert merged.retries["mode"] == "adaptive"
+
+    def test_caller_retry_settings_win_over_the_default(self) -> None:
+        from botocore.config import Config
+
+        facade, inner = self._facade()
+
+        facade.client("logs", config=Config(retries={"mode": "standard", "max_attempts": 2}))
+
+        merged = inner.client.call_args.kwargs["config"]
+        assert merged.retries == {"mode": "standard", "max_attempts": 2}
+
+    def test_other_session_attributes_delegate_unchanged(self) -> None:
+        facade, inner = self._facade()
+        inner.get_available_regions.return_value = ["us-east-1"]
+        inner.region_name = "us-east-2"
+
+        assert facade.get_available_regions("logs") == ["us-east-1"]
+        assert facade.region_name == "us-east-2"
+
+    def test_default_construction_wraps_a_real_boto3_session(self) -> None:
+        from unittest.mock import patch
+
+        from scripts.live_release_validation import aws_session
+
+        with patch.object(aws_session.boto3, "Session") as session_cls:
+            facade = aws_session.ThrottleResilientSession()
+
+        session_cls.assert_called_once_with()
+        assert facade._session is session_cls.return_value
+
+    def test_runner_builds_its_session_through_the_facade(self) -> None:
+        """The runner must not hand raw boto3 sessions to the scanners."""
+        import inspect
+
+        from scripts.live_release_validation import runner
+
+        source = inspect.getsource(runner.LiveValidationRunner.__init__)
+        assert "ThrottleResilientSession()" in source
+        assert "boto3.Session()" not in source

--- a/tests/test_stacks_destroy_hardening.py
+++ b/tests/test_stacks_destroy_hardening.py
@@ -670,3 +670,377 @@ class TestWaitForBastionNetworkInterfaces:
 
         assert remaining == {"eni-1"}
         ec2.delete_network_interface.assert_not_called()
+
+
+class TestImplicitLogGroupCleanup:
+    """Non-strict teardown sweeps the log groups CloudFormation never modeled.
+
+    Lambda default groups and the EKS control-plane/Container Insights
+    groups are created out-of-band by the services, so ``destroy-all``
+    used to report success while orphaning them (22 survived a real
+    teardown and failed the live-validation clean-account gate). The
+    sweep may only ever delete exact names derived from the project's
+    own stack resources, and only for stacks whose deletion succeeded.
+    """
+
+    def _manager(self):
+        from cli.stacks import StackManager
+
+        config = MagicMock()
+        config.project_name = "gco"
+        return StackManager(config)
+
+    # -- name derivation ----------------------------------------------
+
+    def test_lambda_function_derives_its_default_group(self):
+        from cli.stacks import StackManager
+
+        names = StackManager._implicit_log_group_names(
+            "AWS::Lambda::Function", "gco-us-east-1-GaRegistration-UJUi"
+        )
+        assert names == ("/aws/lambda/gco-us-east-1-GaRegistration-UJUi",)
+
+    def test_eks_cluster_derives_control_plane_and_container_insights(self):
+        from cli.stacks import StackManager
+
+        names = StackManager._implicit_log_group_names("AWS::EKS::Cluster", "gco-us-east-1")
+        assert names == (
+            "/aws/eks/gco-us-east-1/cluster",
+            "/aws/containerinsights/gco-us-east-1/application",
+            "/aws/containerinsights/gco-us-east-1/dataplane",
+            "/aws/containerinsights/gco-us-east-1/host",
+            "/aws/containerinsights/gco-us-east-1/performance",
+        )
+
+    def test_explicit_log_group_resources_are_cloudformation_owned(self):
+        """CFN deletes modeled AWS::Logs::LogGroup resources itself."""
+        from cli.stacks import StackManager
+
+        assert StackManager._implicit_log_group_names("AWS::Logs::LogGroup", "/gco/api") == ()
+        assert StackManager._implicit_log_group_names("AWS::SQS::Queue", "gco-jobs") == ()
+
+    # -- collection ----------------------------------------------------
+
+    def _stack_target(self, resources):
+        cfn = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{"StackResourceSummaries": resources}]
+        cfn.get_paginator.return_value = paginator
+        stack = {"StackId": "arn:aws:cloudformation:us-east-1:111111111111:stack/gco-us-east-1/x"}
+        return ("us-east-1", cfn, stack)
+
+    def test_collects_exact_names_from_live_stack_resources(self):
+        manager = self._manager()
+        target = self._stack_target(
+            [
+                {
+                    "ResourceType": "AWS::Lambda::Function",
+                    "PhysicalResourceId": "gco-helm-us-east-1",
+                },
+                {"ResourceType": "AWS::EKS::Cluster", "PhysicalResourceId": "gco-us-east-1"},
+                {"ResourceType": "AWS::Logs::LogGroup", "PhysicalResourceId": "/gco/explicit"},
+                {"ResourceType": "AWS::Lambda::Function", "PhysicalResourceId": ""},
+            ]
+        )
+        with patch.object(manager, "_describe_stack_target", return_value=target):
+            collected = manager._collect_implicit_log_groups(["gco-us-east-1"])
+
+        assert collected == {
+            "gco-us-east-1": {
+                "region": "us-east-1",
+                "log_groups": [
+                    "/aws/containerinsights/gco-us-east-1/application",
+                    "/aws/containerinsights/gco-us-east-1/dataplane",
+                    "/aws/containerinsights/gco-us-east-1/host",
+                    "/aws/containerinsights/gco-us-east-1/performance",
+                    "/aws/eks/gco-us-east-1/cluster",
+                    "/aws/lambda/gco-helm-us-east-1",
+                ],
+            }
+        }
+
+    def test_absent_stack_collects_nothing(self):
+        manager = self._manager()
+        with patch.object(manager, "_describe_stack_target", return_value=None):
+            assert manager._collect_implicit_log_groups(["gco-us-east-1"]) == {}
+
+    def test_collection_is_best_effort_per_stack(self):
+        """One stack's describe failure must not block the others."""
+        manager = self._manager()
+        good = self._stack_target(
+            [{"ResourceType": "AWS::Lambda::Function", "PhysicalResourceId": "gco-fn"}]
+        )
+
+        def describe(stack_name):
+            if stack_name == "gco-broken":
+                raise RuntimeError("CloudFormation unavailable")
+            return good
+
+        with patch.object(manager, "_describe_stack_target", side_effect=describe):
+            collected = manager._collect_implicit_log_groups(["gco-broken", "gco-us-east-1"])
+
+        assert list(collected) == ["gco-us-east-1"]
+
+    # -- deletion ------------------------------------------------------
+
+    def _collected(self):
+        return {
+            "gco-us-east-1": {
+                "region": "us-east-1",
+                "log_groups": ["/aws/eks/gco-us-east-1/cluster", "/aws/lambda/gco-fn"],
+            },
+            "gco-global": {
+                "region": "us-east-2",
+                "log_groups": ["/aws/lambda/gco-global-Poller"],
+            },
+        }
+
+    def test_deletes_only_groups_of_successfully_destroyed_stacks(self):
+        manager = self._manager()
+        logs = MagicMock()
+        with patch("boto3.client", return_value=logs) as client_factory:
+            outcome = manager._cleanup_implicit_log_groups(self._collected(), ["gco-us-east-1"])
+
+        client_factory.assert_called_once_with("logs", region_name="us-east-1")
+        deleted = {call.kwargs["logGroupName"] for call in logs.delete_log_group.call_args_list}
+        assert deleted == {"/aws/eks/gco-us-east-1/cluster", "/aws/lambda/gco-fn"}
+        assert outcome["deleted"] == [
+            "us-east-1:/aws/eks/gco-us-east-1/cluster",
+            "us-east-1:/aws/lambda/gco-fn",
+        ]
+        assert outcome["errors"] == []
+
+    def test_missing_group_is_recorded_not_retried(self):
+        """A Lambda that never logged has no default group — that's normal."""
+        manager = self._manager()
+        logs = MagicMock()
+        logs.delete_log_group.side_effect = ClientError(
+            {"Error": {"Code": "ResourceNotFoundException"}}, "DeleteLogGroup"
+        )
+        with patch("boto3.client", return_value=logs):
+            outcome = manager._cleanup_implicit_log_groups(
+                self._collected(), ["gco-us-east-1", "gco-global"]
+            )
+
+        assert outcome["deleted"] == []
+        assert len(outcome["missing"]) == 3
+        assert outcome["errors"] == []
+
+    def test_delete_errors_are_recorded_and_swallowed(self):
+        """Cleanup must never convert a successful destroy into a failure."""
+        manager = self._manager()
+        logs = MagicMock()
+        logs.delete_log_group.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException"}}, "DeleteLogGroup"
+        )
+        with patch("boto3.client", return_value=logs):
+            outcome = manager._cleanup_implicit_log_groups(self._collected(), ["gco-global"])
+
+        assert outcome["errors"] == [
+            "us-east-2:/aws/lambda/gco-global-Poller: AccessDeniedException"
+        ]
+
+
+class TestBastionIamCleanup:
+    """destroy-all retires the ephemeral-bastion IAM role + profile.
+
+    ``destroy_ephemeral_bastion`` already does this on a clean tunnel
+    close, but a killed process orphans the pair; both survived a real
+    teardown and tripped the live-validation clean-account gate.
+    """
+
+    def _manager(self, project_name="gco"):
+        from cli.stacks import StackManager
+
+        config = MagicMock()
+        config.project_name = project_name
+        config.global_region = "us-east-2"
+        return StackManager(config)
+
+    def test_runs_the_exact_teardown_commands_in_order(self):
+        manager = self._manager()
+        with patch("cli.ephemeral_bastion._run_aws", return_value="") as run_aws:
+            outcome = manager._cleanup_bastion_iam()
+
+        operations = [call.args[0][2] for call in run_aws.call_args_list]
+        assert operations == [
+            "remove-role-from-instance-profile",
+            "delete-instance-profile",
+            "detach-role-policy",
+            "delete-role",
+        ]
+        for call in run_aws.call_args_list:
+            argv = call.args[0]
+            assert argv[:2] == ["aws", "iam"]
+            assert "gco-ephemeral-bastion" in " ".join(argv)
+        assert outcome["completed_steps"] == 4
+        assert outcome["errors"] == []
+
+    def test_absent_role_and_profile_read_as_clean(self):
+        """NoSuchEntity everywhere simply means nothing was orphaned."""
+        manager = self._manager()
+        with patch(
+            "cli.ephemeral_bastion._run_aws",
+            side_effect=RuntimeError("An error occurred (NoSuchEntity) ..."),
+        ):
+            outcome = manager._cleanup_bastion_iam()
+
+        assert outcome["completed_steps"] == 0
+        assert outcome["absent_steps"] == 4
+        assert outcome["errors"] == []
+
+    def test_step_failures_are_recorded_and_do_not_raise(self):
+        manager = self._manager()
+        with patch(
+            "cli.ephemeral_bastion._run_aws",
+            side_effect=RuntimeError("AccessDenied"),
+        ):
+            outcome = manager._cleanup_bastion_iam()
+
+        assert outcome["completed_steps"] == 0
+        assert len(outcome["errors"]) == 4
+
+    def test_invalid_project_name_is_best_effort_not_fatal(self):
+        manager = self._manager(project_name=MagicMock())
+        with patch("cli.ephemeral_bastion._run_aws") as run_aws:
+            outcome = manager._cleanup_bastion_iam()
+
+        run_aws.assert_not_called()
+        assert outcome["errors"]
+
+
+class TestDestroyOrchestratedImplicitCleanupWiring:
+    """The sweep runs on every non-strict exit path and never in strict mode."""
+
+    def _run(self, *, destroy_results, strict=False, collected=None):
+        from cli.stacks import StackManager
+
+        config = MagicMock()
+        config.project_name = "gco"
+        config.global_region = "us-east-2"
+        stacks = ["gco-global", "gco-us-east-1"]
+        cleanups: list[tuple[str, dict]] = []
+
+        base_patches = [
+            patch.object(StackManager, "list_stacks", return_value=stacks),
+            patch.object(StackManager, "_image_registry_destroy_preflight", return_value=True),
+            patch.object(StackManager, "cleanup_orphaned_bastions", return_value=0),
+            patch.object(
+                StackManager,
+                "_cleanup_backup_vault",
+                return_value={"errors": []},
+            ),
+            patch.object(StackManager, "_start_eks_sg_watchdog", return_value=MagicMock()),
+            patch.object(
+                StackManager,
+                "_cleanup_eks_security_groups",
+                return_value={"errors": [], "blocked_by_enis": []},
+            ),
+            patch.object(StackManager, "_destroy_phase_remaining_stacks", return_value=[]),
+            patch.object(StackManager, "destroy", side_effect=destroy_results),
+        ]
+        if strict:
+            base_patches.append(
+                patch.object(StackManager, "_resolve_strict_teardown_resources", return_value={})
+            )
+
+        kwargs = {}
+        if strict:
+            kwargs = {
+                "expected_stack_ids": {
+                    "gco-global": "arn:aws:cloudformation:us-east-2:1:stack/gco-global/x",
+                    "gco-us-east-1": "arn:aws:cloudformation:us-east-1:1:stack/gco-us-east-1/y",
+                },
+                "authorize_stack": lambda *_args: None,
+            }
+
+        from contextlib import ExitStack
+
+        with ExitStack() as stack:
+            for item in base_patches:
+                stack.enter_context(item)
+            collect = stack.enter_context(
+                patch.object(
+                    StackManager,
+                    "_collect_implicit_log_groups",
+                    return_value=collected if collected is not None else {},
+                )
+            )
+            cleanup = stack.enter_context(
+                patch.object(
+                    StackManager,
+                    "_cleanup_implicit_log_groups",
+                    return_value={"deleted": [], "missing": [], "errors": []},
+                )
+            )
+            bastion_iam = stack.enter_context(
+                patch.object(
+                    StackManager,
+                    "_cleanup_bastion_iam",
+                    return_value={"completed_steps": 0, "absent_steps": 4, "errors": []},
+                )
+            )
+            manager = StackManager(config)
+            result = manager.destroy_orchestrated(
+                force=True,
+                on_cleanup_complete=lambda name, details: cleanups.append((name, details)),
+                **kwargs,
+            )
+        return result, collect, cleanup, bastion_iam, cleanups
+
+    def test_full_success_sweeps_collected_groups(self):
+        collected = {"gco-us-east-1": {"region": "us-east-1", "log_groups": ["/aws/lambda/x"]}}
+        (ok, successful, failed), collect, cleanup, bastion_iam, cleanups = self._run(
+            destroy_results=[True, True],
+            collected=collected,
+        )
+
+        assert ok is True and failed == []
+        collect.assert_called_once()
+        cleanup.assert_called_once()
+        assert cleanup.call_args.args[0] == collected
+        assert sorted(cleanup.call_args.args[1]) == ["gco-global", "gco-us-east-1"]
+        bastion_iam.assert_called_once()
+        assert {name for name, _ in cleanups} >= {"bastions", "bastion-iam", "implicit-log-groups"}
+
+    def test_partial_failure_still_sweeps_the_destroyed_stacks(self):
+        """gco-us-east-1 deletes, gco-global fails: its groups still go."""
+        collected = {
+            "gco-us-east-1": {"region": "us-east-1", "log_groups": ["/aws/lambda/x"]},
+            "gco-global": {"region": "us-east-2", "log_groups": ["/aws/lambda/y"]},
+        }
+        (ok, successful, failed), _collect, cleanup, _bastion, _cleanups = self._run(
+            destroy_results=[True, False],
+            collected=collected,
+        )
+
+        assert ok is False
+        assert successful == ["gco-us-east-1"]
+        assert failed == ["gco-global"]
+        cleanup.assert_called_once()
+        assert cleanup.call_args.args[1] == ["gco-us-east-1"]
+
+    def test_nothing_collected_records_no_sweep(self):
+        (ok, _successful, _failed), collect, cleanup, bastion_iam, cleanups = self._run(
+            destroy_results=[True, True],
+            collected={},
+        )
+
+        assert ok is True
+        collect.assert_called_once()
+        cleanup.assert_not_called()
+        bastion_iam.assert_called_once()
+        assert "implicit-log-groups" not in {name for name, _ in cleanups}
+
+    def test_strict_teardown_runs_neither_sweep(self):
+        """The live-validation harness owns fenced log-group deletion and
+        audits IAM itself — strict mode must stay byte-identical."""
+        (ok, _successful, failed), collect, cleanup, bastion_iam, _cleanups = self._run(
+            destroy_results=[True, True],
+            strict=True,
+        )
+
+        assert ok is True and failed == []
+        collect.assert_not_called()
+        cleanup.assert_not_called()
+        bastion_iam.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes the two teardown gaps surfaced by the last live release validation cycle:

### 1. `destroy-all` leaves implicit log groups + bastion IAM behind

A real teardown reported "All stacks destroyed successfully" while orphaning 22 CloudWatch log groups and the ephemeral bastion's IAM role + instance profile — which then failed the next validation run's clean-account `baseline` gate. CloudFormation only deletes the log groups it modeled; Lambda default groups (`/aws/lambda/<fn>`), the EKS control-plane group (`/aws/eks/<cluster>/cluster`), and the Container Insights groups are created out-of-band by the services.

Non-strict destroys now:
- capture the exact implicit log-group names derived from each stack's **own resources** (`list_stack_resources`) while the stacks still exist,
- delete those exact names only after their source stack's deletion succeeded (every exit path funnels through the sweep, so a partially failed teardown still cleans up the stacks that did delete),
- retire the bastion IAM role/profile via the existing validated teardown builders (`NoSuchEntity` reads as "nothing to clean").

Safety posture: deletion is by exact derived name only — never by prefix; explicit `AWS::Logs::LogGroup` resources stay CloudFormation-owned; both sweeps are best-effort and can never fail the destroy. **Strict (live-validation) teardowns skip both sweeps entirely** — the harness checkpoints, tags, and fences its own log-group generations and remains the single owner of that deletion authority (asserted by a dedicated test).

### 2. Harness inventory dies on transient throttling

`final-inventory` failed once with `ThrottlingException … reached max retries: 4` from CloudWatch Logs `ListTagsForResource` — the inventory issues one metadata read per resource across all 17 enabled Regions. The harness session is now a small facade (`scripts/live_release_validation/aws_session.py`) that gives every client botocore's `adaptive` retry mode: client-side rate limiting plus a deeper, still-bounded retry budget (12 attempts). Caller-supplied `Config`s keep every field they set; once the budget is exhausted the original `ClientError` still propagates, so all fail-closed paths behave exactly as before.

## Testing

- 19 new tests in `tests/test_stacks_destroy_hardening.py`: exact name derivation (Lambda/EKS/Container Insights; explicit log groups excluded), best-effort collection, deletion scoped to successfully destroyed stacks, missing-group tolerance, error swallowing, bastion IAM order/absence/failure handling, and `destroy_orchestrated` wiring — including the partial-failure sweep and the strict-mode "runs neither sweep" guarantee.
- 7 new tests in `tests/test_live_release_validation.py` for the session facade (adaptive config injection, merge semantics, delegation, runner wiring).
- `tests/conftest.py` extends the autouse no-op guard so orchestration tests can never fire the new AWS-backed helpers for real.
- Local runs, all green: `test_stacks_destroy_hardening.py` (54), `test_live_release_validation.py` (109), `test_stacks.py` (173), `test_stacks_extended.py` (116), `test_stacks_extended_coverage.py` (109), `test_cli_coverage.py` + `test_cli_command_gap_coverage.py` (57), `test_docs_coverage.py` + `test_doc_hygiene.py` (9).
- ruff format/check clean; mypy clean on the changed runtime files; markdownlint clean (110 files).
- Live E2E (full `scripts.live_release_validation` run) will be executed against this branch once CI is green; results will be posted before review.

## Docs

- `docs/CLI.md`: documents the new `destroy-all` sweep behavior.

Do not merge — for manual review per repo owner. The E2E result comment will follow.
