### PR TITLE
Never cap Bedrock output tokens by default; isolate capacity lookups

### DIFF
--- a/cli/capacity/advisor.py
+++ b/cli/capacity/advisor.py
@@ -15,6 +15,7 @@ from botocore.exceptions import ClientError
 from cli.config import GCOConfig, get_config
 from gco.bedrock import (
     BEDROCK_READ_TIMEOUT_SECONDS,
+    BedrockResponseTruncatedError,
     build_bedrock_converse_options,
     extract_bedrock_converse_text,
     get_default_bedrock_model_id,
@@ -25,6 +26,12 @@ from .checker import CapacityChecker
 from .multi_region import MultiRegionCapacityChecker, compute_price_trend
 
 logger = logging.getLogger(__name__)
+
+
+def _snippet(text: str, limit: int = 200) -> str:
+    """Compact, single-line prefix of ``text`` for parse-failure messages."""
+    collapsed = " ".join(text.split())
+    return collapsed[:limit] + ("..." if len(collapsed) > limit else "")
 
 
 @dataclass
@@ -103,7 +110,8 @@ class BedrockCapacityAdvisor:
         Gather comprehensive capacity data for AI analysis.
 
         Args:
-            instance_types: List of instance types to analyze (defaults to common GPU types)
+            instance_types: List of instance types to analyze (defaults to one
+                representative per current GPU generation, T4 through Blackwell)
             regions: List of regions to check (defaults to deployed GCO regions)
 
         Returns:
@@ -111,17 +119,25 @@ class BedrockCapacityAdvisor:
         """
         from cli.aws_client import get_aws_client
 
-        # Default to common GPU instance types if not specified
+        # Default to one representative per current GPU generation, spanning
+        # budget inference through frontier training, so workload questions
+        # about any generation get real telemetry. Sibling sizes of the same
+        # GPU (e.g. g5.2xlarge/g5.4xlarge) are deliberately omitted — each
+        # type costs a full set of AWS API calls per region. GB200/GB300
+        # NVL72 are UltraServer families, not standalone EC2 instance types
+        # (see cli/capacity/blocks.py NON_STANDALONE_INSTANCE_NOTES), so the
+        # standalone Blackwell types represent that generation here.
         if not instance_types:
             instance_types = [
-                "g4dn.xlarge",
-                "g4dn.2xlarge",
-                "g4dn.4xlarge",
-                "g5.xlarge",
-                "g5.2xlarge",
-                "g5.4xlarge",
-                "p3.2xlarge",
-                "p4d.24xlarge",
+                "g4dn.xlarge",  # T4 — budget inference
+                "g6.xlarge",  # L4 — current-gen budget inference
+                "g5.xlarge",  # A10G — mainstream single-GPU
+                "g6e.xlarge",  # L40S — current-gen mainstream single-GPU
+                "p4d.24xlarge",  # 8x A100 — distributed training
+                "p5.48xlarge",  # 8x H100 — large-scale training
+                "p5en.48xlarge",  # 8x H200 — large-scale training
+                "p6-b200.48xlarge",  # 8x B200 (Blackwell) — frontier training
+                "p6-b300.48xlarge",  # 8x B300 (Blackwell Ultra) — frontier training
             ]
 
         # Get deployed regions if not specified
@@ -158,73 +174,107 @@ class BedrockCapacityAdvisor:
                 )
             except Exception as e:
                 logger.debug("Failed to get cluster metrics for %s: %s", region, e)
+
+        # Failed lookups are recorded here and rendered into the prompt so the
+        # model reasons about *missing* data instead of inventing a story for
+        # why a row is absent (e.g. GetSpotPlacementScores' 24-hour
+        # new-configuration limit must not read as "this type has no spot").
+        data["data_gaps"] = []
+
+        def record_gap(instance_type: str, region: str, source: str, error: Exception) -> None:
+            code = (
+                error.response.get("Error", {}).get("Code", "")
+                if isinstance(error, ClientError)
+                else ""
+            ) or type(error).__name__
+            data["data_gaps"].append(
+                {
+                    "instance_type": instance_type,
+                    "region": region,
+                    "source": source,
+                    "error": code,
+                }
+            )
+            logger.debug(
+                "Capacity lookup %r failed for %s in %s: %s", source, instance_type, region, error
+            )
+
         for instance_type in instance_types:
             data["spot_data"][instance_type] = {}
             data["on_demand_data"][instance_type] = {}
 
             for region in regions:
+                # Each lookup is isolated so one failing or throttled API
+                # cannot discard the other signals for this (type, region)
+                # pair, which previously erased real on-demand pricing and
+                # spot history whenever the placement-score call failed.
+                spot_entry: dict[str, Any] = {"placement_scores": {}, "prices": []}
                 try:
-                    # Get spot placement scores and prices
-                    spot_scores = self._capacity_checker.get_spot_placement_score(
-                        instance_type, region
+                    spot_entry["placement_scores"] = (
+                        self._capacity_checker.get_spot_placement_score(instance_type, region)
                     )
+                except Exception as e:
+                    record_gap(instance_type, region, "spot placement score", e)
+                try:
                     spot_prices = self._capacity_checker.get_spot_price_history(
                         instance_type, region, days=7
                     )
-                    on_demand_price = self._capacity_checker.get_on_demand_price(
-                        instance_type, region
-                    )
-
-                    data["spot_data"][instance_type][region] = {
-                        "placement_scores": spot_scores,
-                        "prices": [
-                            {
-                                "az": p.availability_zone,
-                                "current": p.current_price,
-                                "avg_7d": p.avg_price_7d,
-                                "stability": p.price_stability,
-                            }
-                            for p in spot_prices
-                        ],
-                    }
-
-                    # Spot price trend analysis per AZ (for AI interpretation)
-                    try:
-                        ec2 = self._session.client("ec2", region_name=region)
-                        raw_resp = ec2.describe_spot_price_history(
-                            InstanceTypes=[instance_type],
-                            ProductDescriptions=["Linux/UNIX"],
-                            StartTime=datetime.now(UTC) - timedelta(days=7),
-                            EndTime=datetime.now(UTC),
-                        )
-                        az_raw: dict[str, list[float]] = {}
-                        for item in raw_resp.get("SpotPriceHistory", []):
-                            az = item["AvailabilityZone"]
-                            if az not in az_raw:
-                                az_raw[az] = []
-                            az_raw[az].append(float(item["SpotPrice"]))
-                        az_trends = {
-                            az: compute_price_trend(prices)
-                            for az, prices in az_raw.items()
-                            if len(prices) >= 2
+                    spot_entry["prices"] = [
+                        {
+                            "az": p.availability_zone,
+                            "current": p.current_price,
+                            "avg_7d": p.avg_price_7d,
+                            "stability": p.price_stability,
                         }
-                        if az_trends:
-                            data["spot_data"][instance_type][region]["price_trends"] = az_trends
-                    except Exception as e:
-                        logger.debug(
-                            "Failed to get price trends for %s in %s: %s", instance_type, region, e
-                        )
+                        for p in spot_prices
+                    ]
+                except Exception as e:
+                    record_gap(instance_type, region, "spot price history", e)
+                data["spot_data"][instance_type][region] = spot_entry
 
-                    data["on_demand_data"][instance_type][region] = {
-                        "price_per_hour": on_demand_price,
-                        "available": self._capacity_checker.check_instance_available_in_region(
-                            instance_type, region
-                        ),
+                # Spot price trend analysis per AZ (for AI interpretation)
+                try:
+                    ec2 = self._session.client("ec2", region_name=region)
+                    raw_resp = ec2.describe_spot_price_history(
+                        InstanceTypes=[instance_type],
+                        ProductDescriptions=["Linux/UNIX"],
+                        StartTime=datetime.now(UTC) - timedelta(days=7),
+                        EndTime=datetime.now(UTC),
+                    )
+                    az_raw: dict[str, list[float]] = {}
+                    for item in raw_resp.get("SpotPriceHistory", []):
+                        az = item["AvailabilityZone"]
+                        if az not in az_raw:
+                            az_raw[az] = []
+                        az_raw[az].append(float(item["SpotPrice"]))
+                    az_trends = {
+                        az: compute_price_trend(prices)
+                        for az, prices in az_raw.items()
+                        if len(prices) >= 2
                     }
+                    if az_trends:
+                        data["spot_data"][instance_type][region]["price_trends"] = az_trends
                 except Exception as e:
                     logger.debug(
-                        "Failed to gather capacity data for %s in %s: %s", instance_type, region, e
+                        "Failed to get price trends for %s in %s: %s", instance_type, region, e
                     )
+
+                od_entry: dict[str, Any] = {"price_per_hour": None, "available": None}
+                try:
+                    od_entry["price_per_hour"] = self._capacity_checker.get_on_demand_price(
+                        instance_type, region
+                    )
+                except Exception as e:
+                    record_gap(instance_type, region, "on-demand price", e)
+                try:
+                    od_entry["available"] = (
+                        self._capacity_checker.check_instance_available_in_region(
+                            instance_type, region
+                        )
+                    )
+                except Exception as e:
+                    record_gap(instance_type, region, "region availability", e)
+                data["on_demand_data"][instance_type][region] = od_entry
 
         # Gather capacity reservation and block data
         data["reservations"] = {}
@@ -305,6 +355,7 @@ class BedrockCapacityAdvisor:
             data["weighted_recommendation"] = {
                 "top_region": weighted_results.get("region"),
                 "scoring_method": weighted_results.get("scoring_method", "simple"),
+                "instance_type": weighted_results.get("instance_type"),
                 "all_regions": weighted_results.get("all_regions", []),
             }
         except Exception as e:
@@ -426,6 +477,15 @@ IMPORTANT DISCLAIMERS:
                 avg_price = sum(p["current"] for p in prices) / len(prices) if prices else "N/A"
                 prompt += f"    {region}: Score={regional_score}/10, "
                 prompt += f"Avg Price=${avg_price if isinstance(avg_price, str) else f'{avg_price:.4f}'}/hr\n"
+                trends = spot_info.get("price_trends", {})
+                if trends:
+                    rendered = ", ".join(
+                        f"{az} {t['direction']} "
+                        f"(normalized slope {t['normalized_slope']:+.2f}, "
+                        f"{t['price_changes']} price changes)"
+                        for az, t in sorted(trends.items())
+                    )
+                    prompt += f"      7-day spot price trend by AZ: {rendered}\n"
         prompt += "\n"
 
         # On-demand data summary
@@ -434,9 +494,12 @@ IMPORTANT DISCLAIMERS:
             prompt += f"  {instance_type}:\n"
             for region, od_info in regions_data.items():
                 price = od_info.get("price_per_hour")
-                available = od_info.get("available", False)
+                available = od_info.get("available")
+                # None means the offerings lookup failed — say "unknown" so the
+                # model cannot mistake a failed check for "not offered".
+                availability = "unknown (lookup failed)" if available is None else available
                 prompt += f"    {region}: ${price:.4f}/hr" if price else f"    {region}: N/A"
-                prompt += f" (Available: {available})\n"
+                prompt += f" (Available: {availability})\n"
         prompt += "\n"
 
         # Capacity reservations (ODCRs)
@@ -467,6 +530,69 @@ IMPORTANT DISCLAIMERS:
                             f"{b['duration_hours']}h starting {b['start_date']}, "
                             f"${b['upfront_fee']}\n"
                         )
+            prompt += "\n"
+
+        # Capacity block availability trends (26-week offering-density regression)
+        block_trends = capacity_data.get("capacity_block_trends", {})
+        has_block_trends = any(bool(regions_data) for regions_data in block_trends.values())
+        if has_block_trends:
+            prompt += "CAPACITY BLOCK AVAILABILITY TRENDS (26-week, near-term vs far-term):\n"
+            for instance_type, regions_data in block_trends.items():
+                for region, trend in regions_data.items():
+                    prompt += (
+                        f"  {instance_type} in {region}: "
+                        f"{trend['trend_score']:+.2f} ({trend['interpretation']})\n"
+                    )
+            prompt += "\n"
+
+        # Algorithmic multi-signal ranking (context for the model, not binding)
+        weighted = capacity_data.get("weighted_recommendation")
+        if weighted and weighted.get("all_regions"):
+            scoring_method = weighted.get("scoring_method", "simple")
+            scored_for = (
+                f" for {weighted['instance_type']}" if weighted.get("instance_type") else ""
+            )
+            prompt += (
+                f"ALGORITHMIC REGION RANKING ({scoring_method} scoring{scored_for}; "
+                "lower score = better; advisory pre-computation, weigh it "
+                "against the raw data above):\n"
+            )
+            for entry in weighted["all_regions"]:
+                prompt += f"  {entry['region']}: score={entry['score']:.1f}"
+                details = []
+                if entry.get("spot_placement_score") is not None:
+                    details.append(f"spot availability {entry['spot_placement_score']:.0%}")
+                if entry.get("spot_price_ratio") is not None:
+                    details.append(f"spot/on-demand price ratio {entry['spot_price_ratio']:.2f}")
+                if entry.get("capacity_block_trend"):
+                    details.append(f"block trend {entry['capacity_block_trend']:+.2f}")
+                details.append(f"queue depth {entry.get('queue_depth', 'N/A')}")
+                gpu_util = entry.get("gpu_utilization")
+                if gpu_util is not None:
+                    details.append(f"GPU util {gpu_util:.0f}%")
+                prompt += f" ({', '.join(details)})\n"
+            prompt += "\n"
+
+        # Failed lookups — spelled out so the model reasons about missing
+        # data instead of inventing an explanation for absent rows (e.g. the
+        # placement-score API's 24-hour new-configuration limit must not read
+        # as "this instance type has no spot pools").
+        data_gaps = capacity_data.get("data_gaps") or []
+        if data_gaps:
+            prompt += "DATA GAPS (lookups that FAILED — treat as unknown, not as unavailable):\n"
+            grouped: dict[tuple[str, str, str], list[str]] = {}
+            for gap in data_gaps:
+                key = (gap["source"], gap["error"], gap["region"])
+                grouped.setdefault(key, []).append(gap["instance_type"])
+            for (source, error, region), types in sorted(grouped.items()):
+                prompt += (
+                    f"  {source} in {region} failed with {error} for: {', '.join(sorted(types))}\n"
+                )
+            prompt += (
+                "  Do not draw capacity or availability conclusions from these "
+                "missing values; rely on the signals that are present and "
+                "mention the gap in your warnings.\n"
+            )
             prompt += "\n"
 
         if historical_context:
@@ -553,7 +679,11 @@ Respond ONLY with the JSON object, no additional text."""
                 messages=[{"role": "user", "content": [{"text": prompt}]}],
                 **build_bedrock_converse_options(
                     self.model_id,
-                    inference_config={"maxTokens": 2048, "temperature": 0.1},
+                    # Deliberately no maxTokens: the Converse default is the
+                    # model's own maximum output length, so reasoning plus the
+                    # JSON answer can never hit a GCO-imposed cap. A cap is
+                    # opt-in — pass maxTokens here to restore one.
+                    inference_config={"temperature": 0.1},
                     apply_default_reasoning=self._uses_default_model,
                 ),
             )
@@ -570,7 +700,10 @@ Respond ONLY with the JSON object, no additional text."""
                 json_str = response_text[json_start:json_end]
                 result = json.loads(json_str)
             else:
-                raise ValueError("No valid JSON found in response")
+                raise ValueError(
+                    "No JSON object found in the model response "
+                    f"(response begins: {_snippet(response_text)!r})"
+                )
 
             return BedrockCapacityRecommendation(
                 recommended_region=result.get("recommended_region", "unknown"),
@@ -601,7 +734,16 @@ Respond ONLY with the JSON object, no additional text."""
                 ) from e
             raise RuntimeError(f"Bedrock API error: {e}") from e
         except json.JSONDecodeError as e:
-            raise RuntimeError(f"Failed to parse AI response as JSON: {e}") from e
+            # ``response_text`` is always bound here: the decoder can only
+            # fail after the response text was extracted.
+            raise RuntimeError(
+                f"Failed to parse AI response as JSON: {e} "
+                f"(response begins: {_snippet(response_text)!r})"
+            ) from e
+        except BedrockResponseTruncatedError:
+            # Already carries its own remediation; wrapping it in the generic
+            # "Failed to get AI recommendation" message would only bury it.
+            raise
         except Exception as e:
             raise RuntimeError(f"Failed to get AI recommendation: {e}") from e
 
@@ -672,7 +814,9 @@ Respond ONLY with the JSON object, no additional text."""
         Reads the historical capacity surface, builds a timing-focused prompt,
         and asks Bedrock. Raises ``ValueError`` when there are no samples yet;
         propagates the underlying ``ClientError`` (e.g. ResourceNotFoundException)
-        when the history table does not exist so callers can surface a hint.
+        when the history table does not exist so callers can surface a hint, and
+        ``BedrockResponseTruncatedError`` when the model's answer was cut off by
+        an output-token limit.
         """
         from cli.capacity.history import get_capacity_history_store
 
@@ -692,7 +836,8 @@ Respond ONLY with the JSON object, no additional text."""
             messages=[{"role": "user", "content": [{"text": prompt}]}],
             **build_bedrock_converse_options(
                 self.model_id,
-                inference_config={"maxTokens": 2048, "temperature": 0.2},
+                # No maxTokens by default — see get_recommendation.
+                inference_config={"temperature": 0.2},
                 apply_default_reasoning=self._uses_default_model,
             ),
         )

--- a/cli/capacity/advisor.py
+++ b/cli/capacity/advisor.py
@@ -130,9 +130,11 @@ class BedrockCapacityAdvisor:
         if not instance_types:
             instance_types = [
                 "g4dn.xlarge",  # T4 — budget inference
-                "g6.xlarge",  # L4 — current-gen budget inference
+                "g6.xlarge",  # L4 — budget inference
                 "g5.xlarge",  # A10G — mainstream single-GPU
-                "g6e.xlarge",  # L40S — current-gen mainstream single-GPU
+                "g6e.xlarge",  # L40S — mainstream single-GPU
+                "g7.2xlarge",  # RTX PRO 4500 Blackwell — current-gen budget inference
+                "g7e.2xlarge",  # RTX PRO 6000 Blackwell — current-gen single-GPU inference
                 "p4d.24xlarge",  # 8x A100 — distributed training
                 "p5.48xlarge",  # 8x H100 — large-scale training
                 "p5en.48xlarge",  # 8x H200 — large-scale training

--- a/cli/commands/capacity_cmd.py
+++ b/cli/commands/capacity_cmd.py
@@ -303,10 +303,16 @@ def ai_recommend(
     """Get AI-powered capacity recommendation using Amazon Bedrock.
 
     This command gathers comprehensive capacity data including:
-    - Spot placement scores and pricing across regions
+    - Spot placement scores, pricing, and 7-day per-AZ price trends across regions
     - On-demand availability and pricing
+    - Capacity Reservations (ODCRs), Capacity Block offerings, and 26-week
+      block-availability trends
     - Current cluster utilization (queue depth, GPU/CPU usage)
     - Running and pending job counts
+    - The algorithmic multi-signal region ranking as advisory context
+
+    Without --instance-type, one representative type per current GPU
+    generation is scanned (T4, L4, A10G, L40S, A100, H100, H200, B200, B300).
 
     The data is analyzed by an LLM to provide intelligent recommendations
     for where to place your workload.
@@ -431,7 +437,9 @@ def ai_recommend(
         if is_bedrock_ftu_form_error(e):
             formatter.print_error(BEDROCK_FTU_REMEDIATION)
             sys.exit(1)
-        formatter.print_error(f"Failed to get AI recommendation: {e}")
+        # Advisor errors are already fully worded (and may carry their own
+        # remediation); re-prefixing here used to print the same phrase twice.
+        formatter.print_error(str(e))
         sys.exit(1)
 
 

--- a/cli/commands/capacity_cmd.py
+++ b/cli/commands/capacity_cmd.py
@@ -312,7 +312,8 @@ def ai_recommend(
     - The algorithmic multi-signal region ranking as advisory context
 
     Without --instance-type, one representative type per current GPU
-    generation is scanned (T4, L4, A10G, L40S, A100, H100, H200, B200, B300).
+    generation is scanned (T4, L4, A10G, L40S, RTX PRO 4500/6000 Blackwell,
+    A100, H100, H200, B200, B300).
 
     The data is analyzed by an LLM to provide intelligent recommendations
     for where to place your workload.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1909,7 +1909,8 @@ This command gathers comprehensive capacity data including:
 - The algorithmic multi-signal region ranking as advisory context
 
 Without `--instance-type`, one representative type per current GPU generation
-is scanned (T4, L4, A10G, L40S, A100, H100, H200, B200, B300).
+is scanned (T4, L4, A10G, L40S, RTX PRO 4500/6000 Blackwell, A100, H100, H200,
+B200, B300).
 
 The data is analyzed by the Bedrock model selected by `cdk.json`
 `context.bedrock.default_model_id` (Anthropic Claude Opus 5's global inference

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1900,10 +1900,16 @@ gco capacity ai-recommend [OPTIONS]
 
 This command gathers comprehensive capacity data including:
 
-- Spot placement scores and pricing across regions
+- Spot placement scores, pricing, and 7-day per-AZ price trends across regions
 - On-demand availability and pricing
+- Capacity Reservations (ODCRs), Capacity Block offerings, and 26-week
+  block-availability trends
 - Current cluster utilization (queue depth, GPU/CPU usage)
 - Running and pending job counts
+- The algorithmic multi-signal region ranking as advisory context
+
+Without `--instance-type`, one representative type per current GPU generation
+is scanned (T4, L4, A10G, L40S, A100, H100, H200, B200, B300).
 
 The data is analyzed by the Bedrock model selected by `cdk.json`
 `context.bedrock.default_model_id` (Anthropic Claude Opus 5's global inference

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -1546,7 +1546,13 @@ default because:
 > **Cost and latency:** reasoning tokens are billed as output tokens. High
 > effort can materially increase latency and token usage. Claude removed
 > `temperature`, `top_p`, and `top_k` starting with Opus 4.7, so GCO omits
-> those controls for the canonical default and keeps only `maxTokens`.
+> those controls for the canonical default. GCO also sets no `maxTokens` cap
+> on any of its Bedrock requests: the Converse default — the model's own
+> maximum output length — applies, so reasoning plus the final answer are
+> never cut off by a GCO-imposed limit. A cap is opt-in for code that calls
+> the shared helpers directly, and a response that still hits the model's own
+> ceiling surfaces as an explicit truncation error rather than a confusing
+> JSON-parse failure.
 >
 > These Bedrock features are advisory and degrade gracefully. When no model is reachable (no credentials, model not enabled, or access denied) the Mission engine falls back to its deterministic templates and the capacity advisor surfaces a clear error. Core orchestration never depends on Bedrock. The one exception is the Anthropic FTU form: because it is a permanent account-setup gap rather than a transient fault, it is reported as an error instead of being absorbed by a fallback.
 

--- a/gco/bedrock.py
+++ b/gco/bedrock.py
@@ -50,7 +50,9 @@ _CLAUDE_ADAPTIVE_THINKING_MODELS = frozenset(
 # Claude dropped sampling controls starting with Opus 4.7 ("temperature,
 # top_p, and top_k parameters are no longer supported"); verified live against
 # the Opus 5 global profile, which answers a ValidationException for each.
-# ``maxTokens`` is still required and stays.
+# ``maxTokens`` is accepted and passes through, but only when a caller opts
+# into a cap; GCO's own call sites deliberately set none, so the Converse
+# default — the model's own maximum output length — applies.
 _CLAUDE_UNSUPPORTED_SAMPLING_FIELDS = frozenset({"temperature", "topP", "topK"})
 BEDROCK_READ_TIMEOUT_SECONDS = 3600
 _DISTRIBUTION_NAME = "gco-cli"
@@ -408,8 +410,47 @@ def is_bedrock_ftu_form_error(error: BaseException | None) -> bool:
     return False
 
 
+#: Remediation shown when a Converse response was cut off by an output-token
+#: limit. GCO's own call sites set no ``maxTokens`` (the Converse default is
+#: the model's maximum output length), so this fires only at the model's own
+#: ceiling or under an explicitly configured cap.
+BEDROCK_TRUNCATION_REMEDIATION = (
+    "Bedrock stopped generating before the answer was complete "
+    '(stopReason="max_tokens"). GCO sets no output-token cap by default, so '
+    "the response hit either the model's own maximum output length or an "
+    "explicitly configured maxTokens cap. Try a shorter or narrower request "
+    "(for the capacity advisor: fewer instance types or regions), raise or "
+    "remove any explicit maxTokens cap, or choose a model with a larger "
+    "output window via --model."
+)
+
+
+class BedrockResponseTruncatedError(RuntimeError):
+    """A Converse response was cut off by an output-token limit.
+
+    Raised instead of returning truncated text because every GCO consumer of
+    Bedrock text does worse with a partial answer than with a clear failure:
+    the capacity advisor would surface a confusing JSON-parse error and the
+    Mission engine would record a silently incomplete rationale. Subclasses
+    ``RuntimeError`` so existing callers that catch ``RuntimeError`` around
+    Bedrock calls keep working.
+    """
+
+    def __init__(self, message: str | None = None) -> None:
+        super().__init__(message or BEDROCK_TRUNCATION_REMEDIATION)
+
+
 def extract_bedrock_converse_text(response: Mapping[str, Any]) -> str:
-    """Return the first non-empty text block, skipping reasoning content."""
+    """Return the first non-empty text block, skipping reasoning content.
+
+    Raises :class:`BedrockResponseTruncatedError` when the response was cut
+    off by an output-token limit (``stopReason == "max_tokens"``); the
+    truncation check runs first because a partial text block would otherwise
+    be returned as if it were a complete answer.
+    """
+    if response.get("stopReason") == "max_tokens":
+        raise BedrockResponseTruncatedError()
+
     content = response["output"]["message"]["content"]
     if not isinstance(content, list):
         raise TypeError("Bedrock response content must be a list")
@@ -441,9 +482,11 @@ __all__ = [
     "BEDROCK_FTU_FORM_ERROR_CODE",
     "BEDROCK_FTU_REMEDIATION",
     "BEDROCK_READ_TIMEOUT_SECONDS",
+    "BEDROCK_TRUNCATION_REMEDIATION",
     "BedrockDefaultConfiguration",
     "BedrockFTUFormNotAcceptedError",
     "BedrockModelConfigurationError",
+    "BedrockResponseTruncatedError",
     "build_bedrock_converse_options",
     "extract_bedrock_converse_text",
     "get_default_bedrock_configuration",

--- a/gco_mcp/mission/sampling.py
+++ b/gco_mcp/mission/sampling.py
@@ -48,6 +48,7 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol, cast, runtime_checkabl
 
 from gco.bedrock import (
     BEDROCK_READ_TIMEOUT_SECONDS,
+    BedrockResponseTruncatedError,
     build_bedrock_converse_options,
     extract_bedrock_converse_text,
     get_default_bedrock_model_id,
@@ -78,7 +79,6 @@ if TYPE_CHECKING:  # pragma: no cover - import-time only
     from fastmcp import Context as _FastMCPContext  # noqa: F401
 
 __all__ = [
-    "BEDROCK_MAX_TOKENS",
     "BEDROCK_READ_TIMEOUT_SECONDS",
     "BEDROCK_TEMPERATURE",
     "DEFAULT_BEDROCK_MODEL_ID",
@@ -238,11 +238,6 @@ ENV_BEDROCK_MODEL_ID: str = "GCO_MISSION_BEDROCK_MODEL_ID"
 
 #: Env var that overrides :data:`DEFAULT_BEDROCK_REGION` at runtime.
 ENV_BEDROCK_REGION: str = "GCO_MISSION_BEDROCK_REGION"
-
-#: Maximum response tokens for non-default Bedrock model overrides. The
-#: canonical Nova 2 default uses high reasoning, for which AWS requires
-#: maxTokens to be unset; :func:`build_bedrock_converse_options` removes it.
-BEDROCK_MAX_TOKENS: int = 8192
 
 #: Sampling temperature for non-default Bedrock model overrides. The
 #: canonical Nova 2 default uses high reasoning, for which AWS requires
@@ -819,6 +814,9 @@ class SamplingTransportError(Exception):
     * ``"bedrock_malformed_response"`` — Converse returned a payload
       that did not have the expected ``output.message.content[0].text``
       shape.
+    * ``"bedrock_truncated_response"`` — the answer was cut off by an
+      output-token limit (``stopReason == "max_tokens"``), so its text
+      cannot be trusted to be complete.
     * ``"bedrock_no_credentials"`` — the local ``boto3`` session could
       not resolve credentials.
 
@@ -986,6 +984,10 @@ class BedrockSamplingBackend:
       ``output.message.content`` — including reasoning-only and empty
       ``content`` lists — surfaces as :class:`SamplingTransportError`
       with code ``"bedrock_malformed_response"``.
+    * A response cut off by an output-token limit
+      (``stopReason == "max_tokens"``) surfaces as
+      :class:`SamplingTransportError` with code
+      ``"bedrock_truncated_response"``.
     """
 
     backend_name: Literal["mcp", "bedrock"] = "bedrock"
@@ -1082,6 +1084,9 @@ class BedrockSamplingBackend:
                   code from the envelope.
                 * ``bedrock_malformed_response`` — the response did not
                   contain a non-empty final text content block.
+                * ``bedrock_truncated_response`` — the response was cut
+                  off by an output-token limit and cannot be trusted to
+                  be complete.
             gco.bedrock.BedrockFTUFormNotAcceptedError: The account has
                 not submitted Anthropic's one-time first-time-use case
                 form. Raised instead of a transport error so callers
@@ -1096,10 +1101,11 @@ class BedrockSamplingBackend:
         text = prompt.assemble()
         converse_options = build_bedrock_converse_options(
             self.model_id,
-            inference_config={
-                "maxTokens": BEDROCK_MAX_TOKENS,
-                "temperature": BEDROCK_TEMPERATURE,
-            },
+            # Deliberately no maxTokens: the Converse default is the model's
+            # own maximum output length, so a rationale can never be cut off
+            # by a GCO-imposed cap. A cap is opt-in — pass maxTokens here to
+            # restore one.
+            inference_config={"temperature": BEDROCK_TEMPERATURE},
             apply_default_reasoning=self._uses_default_model,
         )
         try:
@@ -1135,6 +1141,10 @@ class BedrockSamplingBackend:
 
         try:
             return extract_bedrock_converse_text(response)
+        except BedrockResponseTruncatedError as err:
+            # A cut-off rationale is unusable; let the deterministic-fallback
+            # path absorb it like any other transport-shaped fault.
+            raise SamplingTransportError("bedrock_truncated_response") from err
         except (KeyError, IndexError, TypeError) as err:
             raise SamplingTransportError("bedrock_malformed_response") from err
 

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -2329,9 +2329,10 @@ class TestBedrockCapacityAdvisor:
                 assert rec.recommended_capacity_type == "spot"
                 assert rec.confidence == "high"
                 request = mock_bedrock.converse.call_args.kwargs
-                # The canonical Claude default keeps maxTokens (still required)
-                # and drops temperature, which Claude no longer supports.
-                assert request["inferenceConfig"] == {"maxTokens": 2048}
+                # No inferenceConfig at all: GCO sets no maxTokens (the
+                # Converse default is the model's own maximum output length)
+                # and Claude dropped temperature, so nothing remains.
+                assert "inferenceConfig" not in request
                 assert request["additionalModelRequestFields"] == {
                     "thinking": {"type": "adaptive"},
                     "output_config": {"effort": "high"},
@@ -2411,7 +2412,10 @@ class TestBedrockCapacityAdvisor:
                     advisor.get_recommendation()
                     pytest.fail("Should have raised RuntimeError")
                 except RuntimeError as e:
-                    assert "No valid JSON found" in str(e)
+                    # The failure names the problem and quotes the response
+                    # head so the operator can see what the model actually said.
+                    assert "No JSON object found" in str(e)
+                    assert "This is not valid JSON" in str(e)
 
 
 class TestGetBedrockCapacityAdvisor:
@@ -3427,11 +3431,25 @@ class TestAdvisorGatherExceptions:
         assert data["cluster_metrics"] == []
 
     def test_spot_data_exception(self):
+        """A failing placement-score call no longer discards the whole pair.
+
+        The other signals for the (type, region) pair are kept and the failed
+        lookup is recorded as a data gap for the prompt.
+        """
         advisor = _make_advisor_with_mocks()
         _setup_advisor_mocks(advisor)
         advisor._capacity_checker.get_spot_placement_score.side_effect = RuntimeError("boom")
         data = advisor.gather_capacity_data(instance_types=["g4dn.xlarge"], regions=["us-east-1"])
-        assert data["spot_data"]["g4dn.xlarge"] == {}
+        entry = data["spot_data"]["g4dn.xlarge"]["us-east-1"]
+        assert entry["placement_scores"] == {}
+        assert {
+            "instance_type": "g4dn.xlarge",
+            "region": "us-east-1",
+            "source": "spot placement score",
+            "error": "RuntimeError",
+        } in data["data_gaps"]
+        # The independent lookups for the same pair still landed.
+        assert data["on_demand_data"]["g4dn.xlarge"]["us-east-1"]["available"] is not None
 
     def test_reservation_exception(self):
         advisor = _make_advisor_with_mocks()

--- a/tests/test_capacity_advisor_historical.py
+++ b/tests/test_capacity_advisor_historical.py
@@ -152,9 +152,10 @@ class TestPredictCapacityWindow:
         assert result.avoid_windows[0]["day"] == "Friday"
         assert "Mondays" in result.reasoning
         request = client.converse.call_args.kwargs
-        # The canonical Claude default keeps maxTokens (still required) and
-        # drops temperature, which Claude no longer supports.
-        assert request["inferenceConfig"] == {"maxTokens": 2048}
+        # No inferenceConfig at all: GCO sets no maxTokens (the Converse
+        # default is the model's own maximum output length) and Claude
+        # dropped temperature, so nothing remains.
+        assert "inferenceConfig" not in request
         assert request["additionalModelRequestFields"] == {
             "thinking": {"type": "adaptive"},
             "output_config": {"effort": "high"},

--- a/tests/test_default_bedrock_model_consistency.py
+++ b/tests/test_default_bedrock_model_consistency.py
@@ -199,7 +199,8 @@ def test_default_high_thinking_translates_to_native_converse_fields() -> None:
 
     ``temperature``/``topP`` are dropped (Claude removed sampling controls from
     Opus 4.7 onward and answers a ValidationException for them) while
-    ``maxTokens`` — which the model still requires — survives.
+    ``maxTokens`` — an opt-in cap that GCO's own call sites no longer set —
+    still passes through for callers that supply one.
     """
     options = build_bedrock_converse_options(
         _EXPECTED_DEFAULT_MODEL_ID,

--- a/tests/test_mission_sampling.py
+++ b/tests/test_mission_sampling.py
@@ -691,7 +691,6 @@ def test_mcp_backend_satisfies_protocol() -> None:
 import unittest.mock as mock  # noqa: E402
 
 from mission.sampling import (  # noqa: E402
-    BEDROCK_MAX_TOKENS,
     BEDROCK_READ_TIMEOUT_SECONDS,
     BEDROCK_TEMPERATURE,
     DEFAULT_BEDROCK_MODEL_ID,
@@ -955,12 +954,11 @@ def test_bedrock_backend_passes_correct_inference_config() -> None:
     kwargs = fake_client.converse_calls[0]
     assert kwargs["modelId"] == "explicit-model"
     assert kwargs["messages"] == [{"role": "user", "content": [{"text": prompt.assemble()}]}]
-    # Pinned to the named constants so a tunable bump in one place
-    # carries through here without producing a test-only regression.
-    assert kwargs["inferenceConfig"] == {
-        "maxTokens": BEDROCK_MAX_TOKENS,
-        "temperature": BEDROCK_TEMPERATURE,
-    }
+    # Pinned to the named constant so a tunable bump in one place carries
+    # through here without producing a test-only regression. No maxTokens:
+    # GCO sets no output-token cap, so the Converse default (the model's own
+    # maximum output length) applies.
+    assert kwargs["inferenceConfig"] == {"temperature": BEDROCK_TEMPERATURE}
     assert "additionalModelRequestFields" not in kwargs
 
 
@@ -968,8 +966,9 @@ def test_bedrock_backend_applies_default_high_reasoning_without_sampling_control
     """The canonical Claude default receives adaptive thinking at the set effort.
 
     ``temperature`` is dropped because Claude removed sampling controls from
-    Opus 4.7 onward, while ``maxTokens`` — still required by the model —
-    survives.
+    Opus 4.7 onward, and GCO sets no ``maxTokens``, so no inference controls
+    remain at all — the response is bounded only by the model's own maximum
+    output length.
     """
     fake_client = _FakeBedrockClient(response=_well_shaped_response("ok"))
     with _patch_boto3_session(fake_client):
@@ -977,8 +976,7 @@ def test_bedrock_backend_applies_default_high_reasoning_without_sampling_control
         _run(backend.sample(_make_prompt()))
 
     kwargs = fake_client.converse_calls[0]
-    assert kwargs["inferenceConfig"] == {"maxTokens": BEDROCK_MAX_TOKENS}
-    assert "temperature" not in kwargs["inferenceConfig"]
+    assert "inferenceConfig" not in kwargs
     assert kwargs["additionalModelRequestFields"] == {
         "thinking": {"type": "adaptive"},
         "output_config": {"effort": "high"},


### PR DESCRIPTION
## Summary

Fixes two field failures in `gco capacity ai-recommend`:

1. **Truncation surfaced as "No valid JSON found in response".** The advisor and mission sampling sent `maxTokens` caps (2048/8192) while the default Opus 5 profile runs adaptive thinking, whose reasoning tokens count against the same budget — so large capacity prompts got cut off mid-JSON. GCO now sets **no output-token cap anywhere**: the Converse default (the model's own maximum output length) applies, and a cap remains opt-in via `inference_config`. Responses that still hit a limit (`stopReason=max_tokens`) now raise `BedrockResponseTruncatedError` with remediation from `extract_bedrock_converse_text`; mission sampling converts it to `SamplingTransportError("bedrock_truncated_response")` so the deterministic fallback absorbs it.

2. **One failing lookup silently erased a whole instance type.** `gather_capacity_data` wrapped all lookups per (type, region) in one try/except, so a single `GetSpotPlacementScores` failure (reproduced live: `MaxConfigLimitExceeded`, the API's 24h new-configuration limit) discarded the spot history and on-demand pricing that had succeeded — and the model then confabulated explanations for the missing rows (e.g. "expected signature of capacity-block-only instances"). Lookups are now isolated, failures are recorded as `data_gaps` and rendered in the prompt as *unknown, not unavailable*, and a failed offerings check renders as `Available: unknown (lookup failed)` instead of `False`.

Also: parse failures now include a snippet of the model text, and the CLI no longer double-prefixes "Failed to get AI recommendation".

## Testing
- Live repro of both failures against us-east-1 (per-call diagnostic confirmed `MaxConfigLimitExceeded` on placement scores while spot history and pricing succeeded for p4d/p5/p5en/p6-b200/p6-b300).
- `ruff check` and `ruff format --check` clean on all changed files; imports verified.
- Full test suite deliberately left to CI (updated the four test files that pinned the old capped inference configs).