### PR TITLE
Adopt official guidance title in README and stack description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <div align="center">
 
-<h1>Automated Deployment of EKS AutoMode Clusters with Global Capacity Orchestrator (GCO) on AWS</h1>
+<h1>Guidance for EKS AutoMode Clusters with<br><em>Global Capacity Orchestrator</em> on AWS</h1>
 
 <p><b><i>One API. Every Accelerator. Any Region.</i></b></p>
 
-<p>Multi-region accelerated-compute orchestration for AWS — NVIDIA GPUs, AWS Trainium, AWS Inferentia, and CPU (amd64 + arm64 / Graviton) — with capacity-aware placement workflows, spot fallback, and autoscaling inference endpoints. Commercial <code>aws</code> deployments add automatic failover and latency-aware routing through one workload API; other partitions use IAM-authenticated regional workload APIs, all through the same CLI.</p>
+<p><b>Global Capacity Orchestrator (GCO)</b>: multi-region accelerated-compute orchestration for AWS — NVIDIA GPUs, AWS Trainium, AWS Inferentia, and CPU (amd64 + arm64 / Graviton) — with capacity-aware placement workflows, spot fallback, and autoscaling inference endpoints. Commercial <code>aws</code> deployments add automatic failover and latency-aware routing through one workload API; other partitions use IAM-authenticated regional workload APIs, all through the same CLI.</p>
 
 <!-- BEGIN BADGE TABLE -->
 <p>

--- a/app.py
+++ b/app.py
@@ -52,8 +52,7 @@ from gco.stacks.regional_stack import GCORegionalStack
 # published guidance (SO9707) through one stack.
 SOLUTION_ID = "SO9707"
 SOLUTION_DESCRIPTION_PREFIX = (
-    f"({SOLUTION_ID}) - Guidance for Automated Deployment of EKS AutoMode Clusters "
-    "with Global Capacity Orchestrator on AWS"
+    f"({SOLUTION_ID}) - Guidance for EKS AutoMode Clusters with Global Capacity Orchestrator on AWS"
 )
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1168,13 +1168,18 @@ class TestDocumentation:
             content = f.read()
 
         assert len(content) > 1000, "README.md should have substantial content"
-        # The H1 wording carries a marketing prefix/suffix on some branches
-        # (e.g. "Automated Deployment of EKS AutoMode Clusters with Global
-        # Capacity Orchestrator (GCO) on AWS"), so assert the project name
-        # appears inside the top-level heading rather than matching an exact
-        # string.
-        assert re.search(r"<h1>[^<]*Global Capacity Orchestrator \(GCO\)[^<]*</h1>", content), (
-            "README.md should have a project-title H1 naming Global Capacity Orchestrator (GCO)"
+        # The H1 carries the official guidance name ("Guidance for EKS
+        # AutoMode Clusters with Global Capacity Orchestrator on AWS") and may
+        # accentuate the project name with inline markup (<br>, <em>), so
+        # assert the project name appears inside the top-level heading rather
+        # than matching an exact string.
+        assert re.search(r"<h1>.*Global Capacity Orchestrator.*</h1>", content), (
+            "README.md should have a project-title H1 naming Global Capacity Orchestrator"
+        )
+        # The short project name is introduced in the intro copy instead of
+        # the official title.
+        assert "Global Capacity Orchestrator (GCO)" in content, (
+            "README.md should introduce the GCO acronym"
         )
 
     def test_architecture_doc_exists(self):


### PR DESCRIPTION
## Summary

- Retitles the README to the official guidance name: **Guidance for EKS AutoMode Clusters with Global Capacity Orchestrator on AWS**. The project name gets its own line in italics inside the `<h1>` — bold renders invisibly inside headings on GitHub, so a `<br>` + `<em>` is what actually accentuates it. The intro paragraph now leads with **Global Capacity Orchestrator (GCO)** so the short name stays above the fold.
- Updates `app.py`'s `SOLUTION_DESCRIPTION_PREFIX` (SO9707 global stack description) to the same official name, dropping the old 'Automated Deployment of' wording.
- Updates `test_readme_has_content` to assert the project name inside the H1 (tolerating inline markup) plus the GCO acronym in the body.

## Testing
- `ruff check`/`format` clean; `markdownlint-cli2` clean (0 issues across 110 files); `pytest tests/test_integration.py -k readme_has_content` passes locally. Full suite left to CI.