### PR TITLE
Bump every image's security epoch to pull the libexpat1 fixes

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -88,7 +88,7 @@ RUN case "${TARGETARCH}" in \
 # APT_SECURITY_EPOCH busts the CI layer cache so a freshly-published
 # trixie-security patch isn't masked by a stale cached upgrade layer;
 # bump the date when a new fix needs pulling.
-ARG APT_SECURITY_EPOCH=2026-07-28
+ARG APT_SECURITY_EPOCH=2026-07-30
 RUN echo "apt security epoch ${APT_SECURITY_EPOCH}" \
     && apt-get update \
     && apt-get upgrade -y \

--- a/dockerfiles/cost-monitor-dockerfile
+++ b/dockerfiles/cost-monitor-dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 # APT_SECURITY_EPOCH busts the CI layer cache so a freshly-published
 # trixie-security patch isn't masked by a stale cached upgrade layer;
 # bump the date when a new fix needs pulling.
-ARG APT_SECURITY_EPOCH=2026-07-28
+ARG APT_SECURITY_EPOCH=2026-07-30
 RUN echo "apt security epoch ${APT_SECURITY_EPOCH}" \
     && apt-get update \
     && apt-get upgrade -y \

--- a/dockerfiles/health-monitor-dockerfile
+++ b/dockerfiles/health-monitor-dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 # APT_SECURITY_EPOCH busts the CI layer cache so a freshly-published
 # trixie-security patch isn't masked by a stale cached upgrade layer;
 # bump the date when a new fix needs pulling.
-ARG APT_SECURITY_EPOCH=2026-07-28
+ARG APT_SECURITY_EPOCH=2026-07-30
 RUN echo "apt security epoch ${APT_SECURITY_EPOCH}" \
     && apt-get update \
     && apt-get upgrade -y \

--- a/dockerfiles/inference-monitor-dockerfile
+++ b/dockerfiles/inference-monitor-dockerfile
@@ -6,7 +6,7 @@ FROM python:3.14.6-slim
 # Apply Debian security patches at build time. APT_SECURITY_EPOCH busts
 # the CI layer cache so a freshly-published trixie-security patch isn't
 # masked by a stale cached upgrade layer; bump the date when needed.
-ARG APT_SECURITY_EPOCH=2026-07-28
+ARG APT_SECURITY_EPOCH=2026-07-30
 RUN echo "apt security epoch ${APT_SECURITY_EPOCH}" \
     && apt-get update \
     && apt-get upgrade -y \

--- a/dockerfiles/inference-proxy-dockerfile
+++ b/dockerfiles/inference-proxy-dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 # APT_SECURITY_EPOCH busts the CI layer cache so a freshly-published
 # trixie-security patch isn't masked by a stale cached upgrade layer;
 # bump the date when a new fix needs pulling.
-ARG APT_SECURITY_EPOCH=2026-07-28
+ARG APT_SECURITY_EPOCH=2026-07-30
 RUN echo "apt security epoch ${APT_SECURITY_EPOCH}" \
     && apt-get update \
     && apt-get upgrade -y \

--- a/dockerfiles/manifest-processor-dockerfile
+++ b/dockerfiles/manifest-processor-dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 # APT_SECURITY_EPOCH busts the CI layer cache so a freshly-published
 # trixie-security patch isn't masked by a stale cached upgrade layer;
 # bump the date when a new fix needs pulling.
-ARG APT_SECURITY_EPOCH=2026-07-28
+ARG APT_SECURITY_EPOCH=2026-07-30
 RUN echo "apt security epoch ${APT_SECURITY_EPOCH}" \
     && apt-get update \
     && apt-get upgrade -y \

--- a/dockerfiles/queue-processor-dockerfile
+++ b/dockerfiles/queue-processor-dockerfile
@@ -17,7 +17,7 @@ WORKDIR /app
 # APT_SECURITY_EPOCH busts the CI layer cache so a freshly-published
 # trixie-security patch isn't masked by a stale cached upgrade layer;
 # bump the date when a new fix needs pulling.
-ARG APT_SECURITY_EPOCH=2026-07-28
+ARG APT_SECURITY_EPOCH=2026-07-30
 RUN echo "apt security epoch ${APT_SECURITY_EPOCH}" \
     && apt-get update \
     && apt-get upgrade -y \

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -268,7 +268,7 @@ hand-bumped epoch ARG that busts the CI layer cache. Bump the date to force a
 rebuild that pulls the latest fixes. The dependency scan flags an epoch older
 than 45 days; Trivy's container scan is the backstop.
 
-- `APT_SECURITY_EPOCH` (Debian images): `Dockerfile.dev` and the four
+- `APT_SECURITY_EPOCH` (Debian images): `Dockerfile.dev` and the six
   `dockerfiles/*-dockerfile` service images.
 - `DNF_SECURITY_EPOCH` (Amazon Linux 2023): `lambda/helm-installer/Dockerfile`.
 

--- a/lambda/helm-installer/Dockerfile
+++ b/lambda/helm-installer/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR ${LAMBDA_TASK_ROOT}
 # run. DNF_SECURITY_EPOCH busts the CI layer cache so a freshly-published patch
 # isn't masked by a stale cached upgrade layer; bump the date when a new fix
 # needs pulling.
-ARG DNF_SECURITY_EPOCH=2026-07-28
+ARG DNF_SECURITY_EPOCH=2026-07-30
 # hadolint ignore=DL3041
 RUN echo "dnf security epoch ${DNF_SECURITY_EPOCH}" \
     && dnf upgrade -y --releasever=latest \


### PR DESCRIPTION
## Summary

`dev:scan` on main fails with five HIGH Trivy findings against `libexpat1 2.7.1-2` (CVE-2025-59375, CVE-2026-25210, CVE-2026-45186, CVE-2026-56131, CVE-2026-56408). Debian fixed all five in `2.8.2-1~deb13u1`, published to trixie-security after our current epoch date — so this is a **fix**, not a suppression.

Every image already runs `apt-get upgrade` at build time behind the hand-bumped `APT_SECURITY_EPOCH` / `DNF_SECURITY_EPOCH` cache-bust ARG (the mechanism documented in `docs/MAINTENANCE.md`). The CI layer cache had frozen that upgrade at the 2026-07-28 state, masking the newer patch. Bumping the epoch to 2026-07-30 forces every image to rebuild its upgrade layer against current security feeds.

## Changes

- `APT_SECURITY_EPOCH` 2026-07-28 → 2026-07-30 in `Dockerfile.dev` and all six `dockerfiles/*-dockerfile` service images
- `DNF_SECURITY_EPOCH` 2026-07-28 → 2026-07-30 in `lambda/helm-installer/Dockerfile` (AL2023, bumped in lockstep per the documented procedure)
- `docs/MAINTENANCE.md`: corrected "the four `dockerfiles/*-dockerfile` service images" to six (cost-monitor and inference-monitor joined after that sentence was written)

Bumped across **all** images rather than only the failing dev image: the same stale-cache window applies to every Debian image, and the Trivy matrix scans each one — fixing only dev would leave the service images one publication behind.

## Verification

- All eight epoch ARGs confirmed at `2026-07-30`
- `tests/BATS/test_dependency_scan.bats --filter extract_security_epochs`: 4/4 pass (the scan's epoch parser handles the new dates; no format change)
- The proof that `libexpat1` lands at `2.8.2-1~deb13u1` is the Trivy container-scan matrix in this PR's CI run — the scans rebuild each image with the busted cache and fail on any remaining HIGH/CRITICAL
