### PR TITLE
ci: path-filter heavy jobs, retry scanner pulls, sync stale docs

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -48,7 +48,7 @@ For contributor-facing docs (how to run tests locally, release process, dependen
 │   ├── integration-tests.yml         # Integration Tests workflow
 │   ├── security.yml                  # Security workflow
 │   ├── lint.yml                      # Linting workflow
-│   ├── mooncake-image.yml            # Mooncake vLLM image contract test (push/PR)
+│   ├── mooncake-image.yml            # Mooncake vLLM image contract test (path-filtered push/PR + weekly)
 │   ├── release.yml                   # Manual workflow_dispatch release
 │   ├── deps-scan.yml                 # Monthly dependency scan
 │   ├── cve-scan.yml                  # Weekly CVE scan
@@ -76,7 +76,7 @@ Each file maps to one row in the README badge table.
 
 ### Satellites
 
-Workflows outside the four badged gates. Most are schedule- or dispatch-driven; `mooncake-image.yml` also runs on push and PR but is a narrow, feature-specific contract test rather than a headline gate.
+Workflows outside the four badged gates. Most are schedule- or dispatch-driven; `mooncake-image.yml` also runs on push and PR (path-filtered) but is a narrow, feature-specific contract test rather than a headline gate.
 
 | File | Trigger | Purpose |
 |------|---------|---------|
@@ -84,7 +84,7 @@ Workflows outside the four badged gates. Most are schedule- or dispatch-driven; 
 | `workflows/deps-scan.yml` | `cron: 0 9 1 * *` (monthly, UTC) + manual | Check pinned dependency versions, deterministic accelerator/NodePool/watch-list policy, and live EC2 accelerator-catalog drift; update one rolling issue when drift is found |
 | `workflows/cve-scan.yml` | `cron: 0 9 * * 1` (Mondays, UTC) + manual | Re-run trivy against current CVE databases |
 | `workflows/pages.yml` | `workflow_run` after **Unit Tests** completes on `main` | Download the `pytest-coverage` artifact from the triggering run, regenerate the shields.io coverage badge, and deploy `htmlcov/` to GitHub Pages via `actions/deploy-pages`. Split out of `unit-tests.yml` so a GitHub Pages backend stall surfaces here instead of failing the test gate |
-| `workflows/mooncake-image.yml` | `push`: `main`, PR, manual | Pull the upstream Mooncake vLLM image pinned in `cli/images.py` (`_DISAGGREGATED_DEFAULT_IMAGE`) and run `tests/test_mooncake_image_contract.py`: prefill-decode proxy health under the image's `python3`, `MooncakeStoreConfig` acceptance of the rendered store config, and KV-connector name registration. Deliberately not Trivy/CVE-scanned — the image is upstream and unpatchable; version drift is surfaced by `deps-scan` |
+| `workflows/mooncake-image.yml` | `push`: `main` + PR, both path-filtered to the contract's inputs (`cli/images.py`, `gco/services/mooncake_pd_proxy.py`, `gco/services/inference_monitor.py`, the test module, the workflow file); `cron: 0 9 * * 1` (Mondays, UTC); manual | Pull the upstream Mooncake vLLM image pinned in `cli/images.py` (`_DISAGGREGATED_DEFAULT_IMAGE`) and run `tests/test_mooncake_image_contract.py`: prefill-decode proxy health under the image's `python3`, `MooncakeStoreConfig` acceptance of the rendered store config, and KV-connector name registration. Path-filtered because every run pulls the ~9GB image; the weekly run catches upstream re-pushes of the pinned tag. Deliberately not Trivy/CVE-scanned — the image is upstream and unpatchable; version drift is surfaced by `deps-scan` |
 
 ### Naming conventions
 
@@ -162,13 +162,13 @@ The scan runs as an Advanced Setup workflow rather than Default Setup so the fil
 The README's badge row has two parts:
 
 1. **Four workflow-status badges** (`Unit Tests`, `Integration Tests`, `Security`, `Linting`) from GitHub's native `badge.svg` endpoint.
-2. **Eight stack/tech badges** (Python, CDK, EKS Auto Mode, Kubernetes, CDK-Nag, etc.) rendered by shields.io from hardcoded values, each linking to the authoritative source (pyproject.toml, cdk.json, upstream docs, etc.).
+2. **One coverage badge** rendered by shields.io from the `coverage-badge.json` endpoint that `pages.yml` publishes to GitHub Pages after each green `push: main` Unit Tests run.
 
-There are no auto-generated test-count or coverage badges — those were removed before the first release because they depended on an orphan `badges` branch and a shields.io endpoint that didn't resolve reliably against a private repo. Room to add them back once the repo goes public; for now the workflow status itself carries the signal.
+The old orphan-`badges`-branch test-count badges were removed before the first release; the Pages-hosted coverage endpoint above replaced that mechanism.
 
 ### "repo or workflow not found" on fresh or private repositories
 
-The four workflow-status badges at the top of the README come from GitHub's native `badge.svg` endpoint and render a placeholder image when the repo is unreachable. All other shields.io URLs (`img.shields.io/badge/...`) are static and always render.
+The four workflow-status badges at the top of the README come from GitHub's native `badge.svg` endpoint and render a placeholder image when the repo is unreachable. The coverage badge (`img.shields.io/endpoint?url=...`) resolves against the GitHub Pages site, so it renders once Pages has deployed at least one coverage report.
 
 If a stale run ever shows a `img.shields.io/github/actions/workflow/status/...` URL rendering as **"repo or workflow not found"**, the usual cause is the repo being private (shields.io hits the public GitHub REST API and gets a 404). Making the repo public resolves it; there's no code change needed.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -23,7 +23,7 @@ Run on every push to `main` and every pull request.
 
 ## Satellite Workflows
 
-Workflows outside the four badged gates above. Most are schedule- or dispatch-driven; `mooncake-image.yml` also runs on push and PR but is a narrow, feature-specific contract test rather than a headline gate.
+Workflows outside the four badged gates above. Most are schedule- or dispatch-driven; `mooncake-image.yml` also runs on push and PR (path-filtered) but is a narrow, feature-specific contract test rather than a headline gate.
 
 | File | Trigger | Description |
 |------|---------|-------------|
@@ -31,7 +31,7 @@ Workflows outside the four badged gates above. Most are schedule- or dispatch-dr
 | `deps-scan.yml` | Monthly cron + manual | Check pinned dependencies, offline accelerator/NodePool policy, and online [EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html) accelerator-catalog drift; update one rolling issue when findings exist |
 | `cve-scan.yml` | Weekly cron + manual | Re-run trivy against current CVE databases |
 | `pages.yml` | `workflow_run` after Unit Tests on `main` | Publish the HTML coverage report + shields.io badge JSON to GitHub Pages. Split out of Unit Tests so a Pages outage can't fail the test gate |
-| `mooncake-image.yml` | `push`: `main`, PR, manual | Contract-test the real upstream Mooncake vLLM image GCO defaults to — proxy `/healthz`, store-config loader, KV-connector names. Not CVE-scanned (upstream image); version drift is caught by `deps-scan` |
+| `mooncake-image.yml` | `push`: `main` + PR (path-filtered to the contract's inputs), weekly cron, manual | Contract-test the real upstream Mooncake vLLM image GCO defaults to — proxy `/healthz`, store-config loader, KV-connector names. Path-filtered because every run pulls the ~9GB image; the weekly run catches upstream tag re-pushes. Not CVE-scanned (upstream image); version drift is caught by `deps-scan` |
 
 The accelerator check deliberately has two tiers: `unit-tests.yml` runs only the
 checked-in deterministic validator, while `deps-scan.yml` adds sequential,

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,6 +7,7 @@
 # Triggers: push: main, pull_request, workflow_dispatch.
 #
 # Jobs (alphabetical by display name):
+#   - changes                                — PR-only path filter for the dev-tooling jobs below
 #   - integration:dev-alias:docker           — install latest Docker, build gco-dev, prove the generated `gco` alias runs
 #   - integration:dev-alias:finch            — install latest Finch (rootful), build gco-dev, prove the generated `gco` alias runs
 #   - integration:dev-alias:none             — prove setup-dev-alias.sh refuses cleanly when no runtime is installed
@@ -24,6 +25,16 @@
 #   - integration:lambda:imports             — import each Lambda handler
 #   - integration:mcp:server                 — pytest tests/test_mcp_integration.py
 #   - integration:pytest:cross-module        — pytest tests/test_integration.py
+#
+# Dev-tooling jobs (the four integration:dev-alias:* jobs and the two
+# integration:docker:dev-container matrix cells) are gated on the `changes`
+# path filter for pull requests: they install container runtimes from
+# external package repos and build Dockerfile.dev from scratch, yet only
+# validate the dev-onboarding surface. On PRs they run only when that
+# surface (Dockerfile.dev, the alias scripts, the Python dependency pins,
+# .nvmrc, or this workflow) changes; on push to main and workflow_dispatch
+# they always run, so every merge still gets full coverage. Same pattern as
+# the `changes` gate in unit-tests.yml.
 #
 # =============================================================================
 
@@ -43,6 +54,52 @@ permissions:
   contents: read
 
 jobs:
+  # --------------------------------------------------------------------------
+  # Path filter for the dev-tooling jobs (integration:dev-alias:* and
+  # integration:docker:dev-container). Mirrors the `changes` job in
+  # unit-tests.yml: PR-only, diffing the checked-out head against the event's
+  # immutable base SHA rather than GitHub's paginated PR-files API.
+  #
+  # On push to main and workflow_dispatch the filter is skipped and the
+  # dependent jobs always run — every merge gets at least one full run.
+  # --------------------------------------------------------------------------
+  changes:
+    name: "changes"
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    if: github.event_name == 'pull_request'
+    outputs:
+      dev_tooling: ${{ steps.filter.outputs.dev_tooling }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+      - name: Fetch pull request base
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: git fetch --no-tags --depth=1 origin "$BASE_SHA"
+      - name: Detect dev-tooling changes
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
+            Dockerfile.dev \
+            scripts/setup-dev-alias.sh \
+            .github/scripts/dev_alias_live.sh \
+            .github/scripts/podman_ci_config.sh \
+            pyproject.toml \
+            requirements-lock.txt \
+            .nvmrc \
+            .github/workflows/integration-tests.yml; then
+            echo "dev_tooling=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "dev_tooling=true" >> "$GITHUB_OUTPUT"
+          fi
+
   integration-helm-charts-valid:
     name: "integration:helm:charts-valid"
     # Proves every (chart, version) pinned in lambda/helm-installer/charts.yaml
@@ -510,6 +567,17 @@ jobs:
     # GitHub provides ubuntu-24.04-arm as a standard public runner, so
     # both paths run on native kernels instead of translating every RUN
     # step through binfmt.
+    #
+    # Gated on the dev-tooling path filter for PRs (see `changes` above):
+    # this job validates Dockerfile.dev's toolchain pins and install path,
+    # all covered by the filtered files. CLI behavior itself is covered on
+    # every PR by unit:cli:smoke. Always runs on push/dispatch.
+    needs: changes
+    if: |
+      always() && (
+        github.event_name != 'pull_request' ||
+        needs.changes.outputs.dev_tooling == 'true'
+      )
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 25
     strategy:
@@ -1104,10 +1172,21 @@ jobs:
   # actually launches the runtime and runs the real CLI — closing the gap left
   # by the mocked tests/BATS/test_setup_dev_alias.bats suite. Logic lives in
   # .github/scripts/dev_alias_live.sh so it can be run locally too.
+  #
+  # All four jobs are gated on the dev-tooling path filter for PRs (see
+  # `changes` at the top of this file): they exercise only the dev-onboarding
+  # surface, and installing runtimes from external package repos on every PR
+  # is the workflow's biggest flake source. Always run on push/dispatch.
   # --------------------------------------------------------------------------
 
   integration-dev-alias-docker:
     name: "integration:dev-alias:docker"
+    needs: changes
+    if: |
+      always() && (
+        github.event_name != 'pull_request' ||
+        needs.changes.outputs.dev_tooling == 'true'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1124,6 +1203,12 @@ jobs:
 
   integration-dev-alias-podman:
     name: "integration:dev-alias:podman"
+    needs: changes
+    if: |
+      always() && (
+        github.event_name != 'pull_request' ||
+        needs.changes.outputs.dev_tooling == 'true'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1189,6 +1274,12 @@ jobs:
 
   integration-dev-alias-finch:
     name: "integration:dev-alias:finch"
+    needs: changes
+    if: |
+      always() && (
+        github.event_name != 'pull_request' ||
+        needs.changes.outputs.dev_tooling == 'true'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1242,6 +1333,12 @@ jobs:
 
   integration-dev-alias-none:
     name: "integration:dev-alias:none"
+    needs: changes
+    if: |
+      always() && (
+        github.event_name != 'pull_request' ||
+        needs.changes.outputs.dev_tooling == 'true'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -84,10 +84,11 @@ jobs:
       - name: ruff format --check
         # astral-sh/ruff-action ships a prebuilt ruff binary, so this job
         # skips the ~30-40s setup-python + pip-install-e-[lint] overhead
-        # the other lint jobs pay. The version is pinned to match the
-        # ruff==0.15.21 entry in pyproject.toml's [project.optional-dependencies]
-        # lint group so the pre-commit hook, developer installs, and CI
-        # stay in lockstep. Bump both together.
+        # the other lint jobs pay. The version is pinned to match the ruff
+        # entry in pyproject.toml's [project.optional-dependencies] lint
+        # group so the pre-commit hook, developer installs, and CI stay in
+        # lockstep (the deps-scan version-consistency check compares the
+        # copies). Bump both together.
         uses: astral-sh/ruff-action@v4.1.0
         with:
           version: "0.16.0"

--- a/.github/workflows/mooncake-image.yml
+++ b/.github/workflows/mooncake-image.yml
@@ -21,7 +21,15 @@
 # vulnerability findings aren't actionable here. Version drift (a newer tag is
 # available) is surfaced by the monthly deps-scan workflow instead.
 #
-# Triggers: push:main, pull_request, workflow_dispatch.
+# Triggers: push:main + pull_request, both filtered to the files this contract
+# actually validates (the image pin, the PD proxy script, the config renderers,
+# the test module, and this workflow); weekly schedule; workflow_dispatch.
+#
+# The path filter exists because every run pulls the ~9GB upstream image. The
+# contract can only change when one of the listed files changes, so unrelated
+# pushes and PRs skip the pull entirely. The weekly schedule still catches the
+# two drift modes no repo change would surface: the upstream tag being
+# re-pushed with different content, and runner/toolchain drift.
 #
 # =============================================================================
 
@@ -30,7 +38,23 @@ name: Mooncake Image Contract
 on:
   push:
     branches: [main]
+    paths:
+      - "cli/images.py"
+      - "gco/services/mooncake_pd_proxy.py"
+      - "gco/services/inference_monitor.py"
+      - "tests/test_mooncake_image_contract.py"
+      - ".github/workflows/mooncake-image.yml"
   pull_request:
+    paths:
+      - "cli/images.py"
+      - "gco/services/mooncake_pd_proxy.py"
+      - "gco/services/inference_monitor.py"
+      - "tests/test_mooncake_image_contract.py"
+      - ".github/workflows/mooncake-image.yml"
+  schedule:
+    # 09:00 UTC every Monday — same cadence as cve-scan. Catches upstream
+    # re-pushes of the pinned tag between repo changes.
+    - cron: "0 9 * * 1"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -332,6 +332,11 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
+      - name: Pre-pull trufflehog image
+        # Same registry-flake shield the lint.yml docker-run jobs use.
+        uses: ./.github/actions/docker-pull-with-retry
+        with:
+          images: trufflesecurity/trufflehog:3.95.2
       - name: Run TruffleHog
         run: |
           docker run --rm -v "$PWD":/repo \
@@ -351,6 +356,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
+      - name: Pre-pull gitleaks image
+        uses: ./.github/actions/docker-pull-with-retry
+        with:
+          images: zricethezav/gitleaks:v8.30.1
       - name: Run gitleaks
         run: |
           docker run --rm -v "$PWD":/repo -w /repo \
@@ -394,6 +403,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
+      - name: Pre-pull checkov image
+        uses: ./.github/actions/docker-pull-with-retry
+        with:
+          images: bridgecrew/checkov:3.2.524
       - name: Run checkov
         run: |
           docker run --rm -v "$PWD":/repo -w /repo \
@@ -432,6 +445,10 @@ jobs:
       - uses: ./.github/actions/build-lambda-package
       - name: cdk synth
         run: npm exec -- cdk synth --quiet
+      - name: Pre-pull KICS image
+        uses: ./.github/actions/docker-pull-with-retry
+        with:
+          images: checkmarx/kics:v2.1.20
       - name: Run KICS
         run: |
           docker run --rm -v "$PWD":/repo -w /repo \

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -48,16 +48,18 @@ permissions:
 
 jobs:
   # --------------------------------------------------------------------------
-  # Path filter used by the lockfile / fresh-install jobs below. Both of those
-  # only exercise pyproject.toml + requirements-lock.txt (plus the workflow
-  # file itself), so running them on every docs- or code-only PR is waste —
-  # especially unit:fresh-install, which intentionally disables the pip cache.
+  # Path filters used by the lockfile / fresh-install / recorder jobs below.
+  # The lockfile and fresh-install jobs only exercise pyproject.toml +
+  # requirements-lock.txt (plus the workflow file itself), and the macOS
+  # recorder job only exercises demo/, so running them on every docs- or
+  # code-only PR is waste — especially unit:fresh-install, which
+  # intentionally disables the pip cache.
   #
   # On push to main and workflow_dispatch the filter is skipped and the
   # dependent jobs always run: we want at least one guaranteed green run per
   # merge. On PRs, compare the checked-out head directly with the event's
   # immutable base SHA. This avoids GitHub's paginated PR-files API, which can
-  # fail on large PRs, while retaining the same three-path gate.
+  # fail on large PRs, while retaining the same path gates.
   # --------------------------------------------------------------------------
   changes:
     name: "changes"
@@ -66,6 +68,7 @@ jobs:
     if: github.event_name == 'pull_request'
     outputs:
       deps: ${{ steps.filter.outputs.deps }}
+      demo: ${{ steps.demo_filter.outputs.demo }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -89,6 +92,20 @@ jobs:
             echo "deps=false" >> "$GITHUB_OUTPUT"
           else
             echo "deps=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Detect demo recorder changes
+        id: demo_filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
+            demo/ \
+            .github/workflows/unit-tests.yml; then
+            echo "demo=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "demo=true" >> "$GITHUB_OUTPUT"
           fi
 
   # --------------------------------------------------------------------------
@@ -297,6 +314,17 @@ jobs:
 
   unit-recorder-macos-bash32:
     name: "unit:recorder:macos-bash32"
+    # Verifies the demo recorder scripts stay compatible with the macOS
+    # system Bash 3.2. Only demo/ changes can break it, so it is gated on
+    # the demo path filter for PRs (see `changes` above); the ubuntu BATS
+    # job still exercises the recorder logic itself on every PR. Always
+    # runs on push to main / workflow_dispatch.
+    needs: changes
+    if: |
+      always() && (
+        github.event_name != 'pull_request' ||
+        needs.changes.outputs.demo == 'true'
+      )
     runs-on: macos-15
     timeout-minutes: 5
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -459,7 +459,7 @@ When required, obtain explicit account and KMS-deletion authorization, run `pyth
 
 ### CI/CD Pipeline
 
-The project uses GitHub Actions for automated testing. Every push and pull request runs six primary workflows in parallel, plus three satellites on schedule or manual trigger.
+The project uses GitHub Actions for automated testing. Every push and pull request runs five primary workflows in parallel, plus satellites on path-filter, schedule, or manual trigger.
 
 #### Primary workflows (run on every push + PR)
 
@@ -470,7 +470,6 @@ The project uses GitHub Actions for automated testing. Every push and pull reque
 | `.github/workflows/security.yml` | Security | bandit, pip-audit, npm audit for every owned graph, trivy (filesystem + per-image), trufflehog, gitleaks, semgrep, checkov, KICS, and CodeQL for Python + JavaScript |
 | `.github/workflows/inference-streaming-proxy.yml` | — (no badge) | Native Node.js 24 tests for the streaming Lambda with 93% line/function/branch gates |
 | `.github/workflows/lint.yml` | Linting | actionlint, hadolint, markdownlint, mypy (strict/stacks/lambda), ruff (format + check, imports included), shellcheck, yamllint |
-| `.github/workflows/mooncake-image.yml` | — (no badge) | Mooncake vLLM image contract: runs the real upstream image GCO defaults to (`cli/images.py::_DISAGGREGATED_DEFAULT_IMAGE`) and asserts the PD proxy starts under `python3` + serves `/healthz`, the rendered store config is accepted by the image's loader, and the connector names GCO emits are registered — so an image-version bump is validated by CI |
 
 Each workflow file has a comment header documenting triggers and per-job purpose — that is the single source of truth. Every job uses `category:tool:test_name` display names (e.g., `unit:pytest:core`, `security:trivy:container-scan`) and `category-tool-test_name` job IDs.
 
@@ -481,16 +480,11 @@ Each workflow file has a comment header documenting triggers and per-job purpose
 | `.github/workflows/release.yml` | Manual (`workflow_dispatch`) | Bump version, tag, and create a GitHub Release with auto-generated notes |
 | `.github/workflows/deps-scan.yml` | `cron: 0 9 1 * *` (monthly) | Check pinned versions plus deterministic NodePool/watch-list policy and live EC2 accelerator-catalog drift; update one rolling issue when drift is detected |
 | `.github/workflows/cve-scan.yml` | `cron: 0 9 * * 1` (weekly) | Re-run Trivy against current CVE databases |
+| `.github/workflows/mooncake-image.yml` | Push/PR path-filtered to the contract's inputs, `cron: 0 9 * * 1` (weekly), manual | Mooncake vLLM image contract: runs the real upstream image GCO defaults to (`cli/images.py::_DISAGGREGATED_DEFAULT_IMAGE`) and asserts the PD proxy starts under `python3` + serves `/healthz`, the rendered store config is accepted by the image's loader, and the connector names GCO emits are registered — so an image-version bump is validated by CI. Path-filtered because every run pulls the ~9GB image |
 
-#### Auto-generated badges
+#### Coverage badge
 
-Three README badges update automatically from `push: main` runs:
-
-- `unit:pytest:core` test count
-- `unit:bats:count`
-- `unit:coverage` percentage
-
-Values are published to the orphan `badges` branch as shields.io endpoint JSON and consumed via `img.shields.io/endpoint?url=…`. Fork PRs cannot write to this branch — the publish step is gated on `push: main`.
+The README coverage badge updates automatically after each green `push: main` Unit Tests run: `pages.yml` regenerates the shields.io endpoint JSON from the run's coverage artifact and publishes it (with the HTML report) to GitHub Pages. Fork PRs cannot affect it — the deploy only triggers from Unit Tests runs on `main`.
 
 #### Running the pipeline locally
 


### PR DESCRIPTION
## Summary

Solo-maintainer CI cost/flake reduction plus stale-doc fixes. Five small commits, no change to what CI covers on `push: main` — every gated job still runs on every merge and on `workflow_dispatch`; PRs skip only jobs whose inputs they don't touch.

1. **`mooncake-image.yml`** — path-filter push/PR to the contract's actual inputs (`cli/images.py`, `gco/services/mooncake_pd_proxy.py`, `gco/services/inference_monitor.py`, the test module, the workflow), and add a weekly schedule so upstream re-pushes of the pinned tag are still caught. Stops pulling the ~9GB vLLM image on every unrelated push/PR.
2. **`integration-tests.yml`** — new `changes` path-filter job (same head-vs-base diff pattern `unit-tests.yml` already uses) gating the four `integration:dev-alias:*` jobs and the two `integration:docker:dev-container` matrix cells. These install container runtimes from external package repos on every PR and were the workflow's largest flake source while validating only the dev-onboarding surface.
3. **`unit-tests.yml`** — gate `unit:recorder:macos-bash32` (macOS runner) on `demo/` changes via a second output on the existing `changes` job. The ubuntu BATS job still covers recorder logic on every PR.
4. **`security.yml`** — pre-pull the trufflehog/gitleaks/checkov/KICS images through the existing `docker-pull-with-retry` composite action (same shield `lint.yml` already uses), so a Docker Hub blip no longer fails a scan job.
5. **Docs** — sync the mooncake trigger tables (`CI.md`, `workflows/README.md`, `CONTRIBUTING.md`); fix CONTRIBUTING's badge section (described orphan-`badges`-branch publishing that no longer exists) and CI.md's badge section (denied the Pages-hosted coverage badge the README actually renders; claimed eight stack badges that aren't in the badge table); drop a stale `ruff==0.15.21` version literal from a `lint.yml` comment.

## Type of change

- [x] `ci:` CI / tooling change
- [x] `docs:` Documentation only (doc-sync portions)

## Testing

- [x] `actionlint` clean on all workflows
- [x] `yamllint --strict` (repo config) clean on `.github/workflows/`
- [x] `npm run lint:markdown` clean (112 files, 0 issues)
- [x] `pytest tests/test_split_tests.py` — 18 passed (shard-contract guards over `unit-tests.yml`)
- [x] `pytest tests/test_live_release_validation.py -k "workflow or guard or contract"` — 2 passed (workflow-scan guards)
- [x] `bats tests/BATS/test_dependency_scan.bats` — 179 ok (env-pin/kind-pin extractors over the real workflows)
- [x] This PR itself exercises the new gating live: it touches `unit-tests.yml` + `integration-tests.yml` (so the dev-tooling, recorder, lockfile, and fresh-install jobs should all RUN via their filters) and does not touch mooncake inputs (so Mooncake Image Contract should be SKIPPED).

## Live release validation

- [x] Not required (explain the applicability decision below)

**Applicability rationale:** CI/workflow and documentation changes only. No deployed CDK/CloudFormation lifecycle, IAM/networking, Kubernetes wiring, or service/Lambda behavior is affected.

## Checklist

- [x] Documentation updated (README, `docs/`, inline docstrings) as needed
- [x] No secrets, credentials, or customer data committed
- [x] `requirements-lock.txt` regenerated if `pyproject.toml` changed (not changed)
- [x] Changes align with the architecture described in `docs/ARCHITECTURE.md`
