### PR TITLE
fix: honor structured capacity output

### DIFF
--- a/cli/commands/capacity_cmd.py
+++ b/cli/commands/capacity_cmd.py
@@ -190,6 +190,8 @@ def capacity_status(config: Any, region: Any, all_regions: Any) -> None:
 
             if not capacities:
                 formatter.print_warning("No GCO stacks found")
+                if config.output_format != "table":
+                    formatter.print(capacities)
                 return
 
             if config.output_format == "table":

--- a/cli/commands/capacity_cmd.py
+++ b/cli/commands/capacity_cmd.py
@@ -90,8 +90,16 @@ def recommend_capacity(config: Any, instance_type: Any, region: Any, fault_toler
             instance_type, region, fault_tolerance
         )
 
-        formatter.print_info(f"Recommended: {capacity_type.upper()}")
-        formatter.print_info(f"Reason: {explanation}")
+        if config.output_format == "table":
+            formatter.print_info(f"Recommended: {capacity_type.upper()}")
+            formatter.print_info(f"Reason: {explanation}")
+        else:
+            formatter.print(
+                {
+                    "capacity_type": capacity_type,
+                    "explanation": explanation,
+                }
+            )
 
     except Exception as e:
         formatter.print_error(f"Failed to get recommendation: {e}")
@@ -184,19 +192,21 @@ def capacity_status(config: Any, region: Any, all_regions: Any) -> None:
                 formatter.print_warning("No GCO stacks found")
                 return
 
-            # Format as table
-            print("\n  REGION          QUEUE  RUNNING  GPU%   CPU%   SCORE")
-            print("  " + "-" * 55)
-            for c in sorted(capacities, key=lambda x: x.recommendation_score):
-                print(
-                    f"  {c.region:<15} {c.queue_depth:>5}  {c.running_jobs:>7}  "
-                    f"{c.gpu_utilization:>4.0f}%  {c.cpu_utilization:>4.0f}%  {c.recommendation_score:>5.0f}"
-                )
+            if config.output_format == "table":
+                print("\n  REGION          QUEUE  RUNNING  GPU%   CPU%   SCORE")
+                print("  " + "-" * 55)
+                for c in sorted(capacities, key=lambda x: x.recommendation_score):
+                    print(
+                        f"  {c.region:<15} {c.queue_depth:>5}  {c.running_jobs:>7}  "
+                        f"{c.gpu_utilization:>4.0f}%  {c.cpu_utilization:>4.0f}%  "
+                        f"{c.recommendation_score:>5.0f}"
+                    )
 
-            # Show recommendation
-            print()
-            best = min(capacities, key=lambda x: x.recommendation_score)
-            formatter.print_info(f"Recommended region: {best.region} (lowest score = best)")
+                print()
+                best = min(capacities, key=lambda x: x.recommendation_score)
+                formatter.print_info(f"Recommended region: {best.region} (lowest score = best)")
+            else:
+                formatter.print(capacities)
 
     except Exception as e:
         formatter.print_error(f"Failed to get capacity status: {e}")
@@ -243,16 +253,19 @@ def recommend_region(
             gpu_count=gpu_count,
         )
 
-        formatter.print_success(f"Recommended region: {recommendation['region']}")
-        formatter.print_info(f"Reason: {recommendation['reason']}")
+        if config.output_format == "table":
+            formatter.print_success(f"Recommended region: {recommendation['region']}")
+            formatter.print_info(f"Reason: {recommendation['reason']}")
 
-        if config.verbose:
-            print("\nAll regions ranked:")
-            for r in recommendation.get("all_regions", []):
-                print(
-                    f"  {r['region']}: score={r['score']:.4f}, "
-                    f"queue={r['queue_depth']}, gpu={r['gpu_utilization']:.0f}%"
-                )
+            if config.verbose:
+                print("\nAll regions ranked:")
+                for r in recommendation.get("all_regions", []):
+                    print(
+                        f"  {r['region']}: score={r['score']:.4f}, "
+                        f"queue={r['queue_depth']}, gpu={r['gpu_utilization']:.0f}%"
+                    )
+        else:
+            formatter.print(recommendation)
 
     except Exception as e:
         formatter.print_error(f"Failed to get recommendation: {e}")

--- a/tests/test_cli_command_gap_coverage.py
+++ b/tests/test_cli_command_gap_coverage.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 from click.testing import CliRunner
 
+from cli.capacity.multi_region import RegionCapacity
 from cli.commands.capacity_cmd import capacity
 from cli.commands.config_cmd import config_cmd
 from cli.commands.costs_cmd import costs
@@ -1026,6 +1027,122 @@ def test_capacity_status_sorts_regions_and_recommends_lowest_score(
     assert result.exit_code == 0, result.output
     assert result.output.index("us-east-1") < result.output.index("us-west-2")
     assert "Recommended region: us-east-1" in result.output
+
+
+def test_capacity_status_json_emits_empty_array_when_no_stacks(runner: CliRunner) -> None:
+    checker = MagicMock()
+    checker.get_all_regions_capacity.return_value = []
+
+    with patch("cli.capacity.get_multi_region_capacity_checker", return_value=checker):
+        result = _invoke(
+            runner,
+            capacity,
+            ["status"],
+            config=_config(output_format="json"),
+        )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == []
+    assert "No GCO stacks found" in result.stderr
+
+
+def test_capacity_status_json_emits_region_objects(runner: CliRunner) -> None:
+    checker = MagicMock()
+    checker.get_all_regions_capacity.return_value = [
+        RegionCapacity(
+            region="us-east-1",
+            queue_depth=2,
+            running_jobs=1,
+            recommendation_score=12.5,
+        )
+    ]
+
+    with patch("cli.capacity.get_multi_region_capacity_checker", return_value=checker):
+        result = _invoke(
+            runner,
+            capacity,
+            ["status"],
+            config=_config(output_format="json"),
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload[0]["region"] == "us-east-1"
+    assert payload[0]["recommendation_score"] == 12.5
+    assert "REGION" not in result.stdout
+    assert "ℹ" not in result.stdout
+
+
+def test_capacity_recommend_json_emits_structured_result(runner: CliRunner) -> None:
+    checker = MagicMock()
+    checker.recommend_capacity_type.return_value = (
+        "on-demand",
+        "stable capacity for this workload",
+    )
+
+    with patch("cli.commands.capacity_cmd.get_capacity_checker", return_value=checker):
+        result = _invoke(
+            runner,
+            capacity,
+            ["recommend", "-i", "g5.2xlarge", "-r", "us-east-1"],
+            config=_config(output_format="json"),
+        )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {
+        "capacity_type": "on-demand",
+        "explanation": "stable capacity for this workload",
+    }
+    assert "ℹ" not in result.stdout
+
+
+def test_capacity_recommend_table_preserves_human_output(runner: CliRunner) -> None:
+    checker = MagicMock()
+    checker.recommend_capacity_type.return_value = ("spot", "lowest cost")
+
+    with patch("cli.commands.capacity_cmd.get_capacity_checker", return_value=checker):
+        result = _invoke(
+            runner,
+            capacity,
+            ["recommend", "-i", "g5.2xlarge", "-r", "us-east-1"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Recommended: SPOT" in result.output
+    assert "Reason: lowest cost" in result.output
+
+
+def test_capacity_recommend_region_json_ignores_verbose_human_output(
+    runner: CliRunner,
+) -> None:
+    checker = MagicMock()
+    recommendation = {
+        "region": "eu-west-1",
+        "reason": "lowest weighted score",
+        "all_regions": [
+            {
+                "region": "eu-west-1",
+                "score": 0.125,
+                "queue_depth": 1,
+                "gpu_utilization": 25.0,
+            }
+        ],
+    }
+    checker.recommend_region_for_job.return_value = recommendation
+
+    with patch("cli.capacity.get_multi_region_capacity_checker", return_value=checker):
+        result = _invoke(
+            runner,
+            capacity,
+            ["recommend-region", "--gpu", "-i", "p5.48xlarge"],
+            config=_config(output_format="json", verbose=True),
+        )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == recommendation
+    assert "All regions ranked" not in result.stdout
+    assert "✓" not in result.stdout
+    assert "ℹ" not in result.stdout
 
 
 def test_capacity_recommend_region_verbose_prints_ranked_signals(


### PR DESCRIPTION
## Summary

- route all-region capacity status through the configured formatter for JSON and YAML output
- return structured capacity recommendations instead of success/info text outside table mode
- emit an empty structured result when no GCO stacks are deployed while retaining the warning on stderr
- keep existing human-readable table output, including verbose region rankings
- add regression coverage for all affected JSON paths and table compatibility

## Type of change

- [ ] `feat:` New feature (non-breaking)
- [x] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [ ] `test:` Test-only change
- [ ] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [x] New tests added for new behavior
- [x] Ran the change against a real AWS account (describe below)

Validation completed:
- `pytest tests/test_capacity.py tests/test_capacity_cmd_coverage.py tests/test_cli_command_gap_coverage.py -q` (217 passed)
- `ruff format --check cli/commands/capacity_cmd.py tests/test_cli_command_gap_coverage.py`
- `ruff check cli/commands/capacity_cmd.py tests/test_cli_command_gap_coverage.py`
- actual workspace-backed `gco` 5.3.3 commands were piped through `json.load`: `capacity status`, `capacity recommend-region --gpu -i g5.2xlarge`, and `capacity recommend -i g5.2xlarge -r us-east-1` all parsed successfully
- the local account has no deployed GCO stacks, confirming `capacity status` emits `[]` on stdout and keeps its warning on stderr

The documented mypy command is currently blocked by unrelated existing CDK typing errors in `gco/stacks`, `app.py`, and `tests/test_nag_compliance.py`.

## Live release validation

- [x] Not required (explain the applicability decision below)
- [ ] Required and completed locally with `--actions all` for this exact SHA; a sanitized `PASSED` summary comment (run ID, SHA, per-action statuses) was posted on the pull request
- [ ] Required but pending explicit validation-account and KMS-deletion authorization

**Applicability rationale:** This is an isolated CLI rendering fix exercised with mocked tests and read-only local CLI checks. It does not change infrastructure, AWS resource mutation, IAM, networking, or deployed runtime behavior.

**Sanitized validation summary or comment link:** Not applicable.

## Checklist

- [x] Documentation updated (README, `docs/`, inline docstrings) as needed — no documentation changes are needed because this restores the documented output contract
- [x] No secrets, credentials, or customer data committed
- [x] `requirements-lock.txt` regenerated if `pyproject.toml` changed — not applicable
- [x] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

Fixes #212