### PR TITLE
chore: refresh dependencies from issue #214

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.0
+    rev: v0.16.1
     hooks:
       # Formatter. Run before ``ruff`` so the check sees formatter output.
       - id: ruff-format

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -177,7 +177,7 @@ RUN curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARC
 # preserved across rebuilds. Bump when a new feature or bugfix is needed
 # (see https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst).
 # AWS CLI v2 uses GNU arch tags (x86_64 / aarch64) in the install URL.
-ARG AWSCLI_VERSION=2.36.11
+ARG AWSCLI_VERSION=2.36.14
 RUN GNU_ARCH=$(cat /tmp/gnu_arch) \
     && curl "https://awscli.amazonaws.com/awscli-exe-linux-${GNU_ARCH}-${AWSCLI_VERSION}.zip" -o "awscliv2.zip" \
     && unzip awscliv2.zip \
@@ -196,7 +196,7 @@ RUN GNU_ARCH=$(cat /tmp/gnu_arch) \
 # Latest stable at pin time:
 #   https://download.docker.com/linux/static/stable/x86_64/
 #   https://download.docker.com/linux/static/stable/aarch64/
-ARG DOCKER_VERSION=29.6.2
+ARG DOCKER_VERSION=29.7.1
 RUN GNU_ARCH=$(cat /tmp/gnu_arch) \
     && curl -fsSL "https://download.docker.com/linux/static/stable/${GNU_ARCH}/docker-${DOCKER_VERSION}.tgz" \
       -o /tmp/docker.tgz \

--- a/gco/stacks/constants.py
+++ b/gco/stacks/constants.py
@@ -277,7 +277,7 @@ def backend_tls_certificate_arn_parameter_name(project_name: str, region: str) -
 EKS_ADDON_POD_IDENTITY_AGENT = "v1.3.10-eksbuild.3"
 """EKS Pod Identity Agent — enables IRSA and Pod Identity for service accounts."""
 
-EKS_ADDON_METRICS_SERVER = "v0.9.0-eksbuild.4"
+EKS_ADDON_METRICS_SERVER = "v0.9.0-eksbuild.5"
 """Kubernetes Metrics Server — provides CPU/memory metrics for HPA and ``kubectl top``."""
 
 EKS_ADDON_EFS_CSI_DRIVER = "v3.4.1-eksbuild.1"
@@ -322,10 +322,10 @@ restriction. Keep in sync with the AWS EKS networking requirements doc.
 # ``aws rds describe-db-engine-versions`` monthly for newer releases
 # within the same major line.
 
-AURORA_POSTGRES_VERSION = "VER_17_9"
-"""CDK enum name for the Aurora PostgreSQL engine version (e.g. ``rds.AuroraPostgresEngineVersion.VER_17_9``)."""
+AURORA_POSTGRES_VERSION = "VER_17_10"
+"""CDK enum name for the Aurora PostgreSQL engine version (e.g. ``rds.AuroraPostgresEngineVersion.VER_17_10``)."""
 
-AURORA_POSTGRES_VERSION_DISPLAY = "17.9"
+AURORA_POSTGRES_VERSION_DISPLAY = "17.10"
 """Human-readable version string for documentation and logging."""
 # ---------------------------------------------------------------------------
 # Analytics Environment Constants

--- a/lambda/helm-installer/charts.yaml
+++ b/lambda/helm-installer/charts.yaml
@@ -77,7 +77,7 @@ charts:
     repo_name: kedacore
     repo_url: https://kedacore.github.io/charts
     chart: keda
-    version: "2.20.1"
+    version: "2.20.2"
     namespace: keda
     create_namespace: true
     values:
@@ -338,7 +338,7 @@ charts:
     repo_name: slinky-oci
     repo_url: oci://ghcr.io/slinkyproject/charts
     chart: slurm-operator
-    version: "1.2.0"
+    version: "1.2.1"
     namespace: slurm-operator
     create_namespace: true
     use_oci: true
@@ -352,7 +352,7 @@ charts:
         replicas: 1
         image:
           repository: ghcr.io/slinkyproject/slurm-operator
-          tag: "1.2.0"
+          tag: "1.2.1"
         resources:
           requests:
             cpu: 100m
@@ -369,7 +369,7 @@ charts:
         enabled: true
         image:
           repository: ghcr.io/slinkyproject/slurm-operator-webhook
-          tag: "1.2.0"
+          tag: "1.2.1"
         resources:
           requests:
             cpu: 50m
@@ -390,7 +390,7 @@ charts:
     repo_name: slinky-oci
     repo_url: oci://ghcr.io/slinkyproject/charts
     chart: slurm
-    version: "1.2.0"
+    version: "1.2.1"
     namespace: gco-jobs
     create_namespace: false
     use_oci: true
@@ -541,7 +541,7 @@ charts:
     repo_name: prometheus-community
     repo_url: https://prometheus-community.github.io/helm-charts
     chart: kube-prometheus-stack
-    version: "87.21.0"
+    version: "88.0.1"
     namespace: monitoring
     create_namespace: true
     wait: false

--- a/lambda/inference-streaming-proxy/package-lock.json
+++ b/lambda/inference-streaming-proxy/package-lock.json
@@ -8,22 +8,22 @@
       "name": "gco-inference-streaming-proxy",
       "version": "0.0.0",
       "dependencies": {
-        "@aws-sdk/client-elastic-load-balancing-v2": "3.1098.0",
-        "@aws-sdk/client-secrets-manager": "3.1098.0",
-        "@aws-sdk/client-ssm": "3.1098.0"
+        "@aws-sdk/client-elastic-load-balancing-v2": "3.1101.0",
+        "@aws-sdk/client-secrets-manager": "3.1101.0",
+        "@aws-sdk/client-ssm": "3.1101.0"
       },
       "engines": {
         "node": "24.x"
       }
     },
     "node_modules/@aws-sdk/client-elastic-load-balancing-v2": {
-      "version": "3.1098.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-elastic-load-balancing-v2/-/client-elastic-load-balancing-v2-3.1098.0.tgz",
-      "integrity": "sha512-Wh3ULwDxyh5NcEaFeARUSAan4sBy2Obv+TmBCrdBpNV6WRXDM0D0xw5gI3/ql7HkEp10PmW6Tai8R8IvyUp8cg==",
+      "version": "3.1101.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-elastic-load-balancing-v2/-/client-elastic-load-balancing-v2-3.1101.0.tgz",
+      "integrity": "sha512-SHAEfZX2EZbtf0pEFcgicY/ngfbBWhyoDJvmet1ex9Www8tAAiV0N1HETCd2sngSVnyE5anZ15rM0xR8W6Ny0A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
-        "@aws-sdk/credential-provider-node": "^3.972.75",
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/credential-provider-node": "^3.972.76",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
@@ -36,13 +36,13 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1098.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1098.0.tgz",
-      "integrity": "sha512-XdFhAffKIWY+dAsiWXnIwH57iFAdtiUFdsBACLmWOoSg54KsANtZuk5pTxsSyU7c+DQdUJTg/eknKNNk2lvLfg==",
+      "version": "3.1101.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1101.0.tgz",
+      "integrity": "sha512-+FZgLzBuzbGOJN3Hoo0QadoFs8U9MK7PwqHscRCNdMaU33yqqBTjCtHsiZCXyCJeuW7gar8+fojLGQQEmEiOAA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
-        "@aws-sdk/credential-provider-node": "^3.972.75",
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/credential-provider-node": "^3.972.76",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
@@ -55,13 +55,13 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm": {
-      "version": "3.1098.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1098.0.tgz",
-      "integrity": "sha512-PS1R2Py6gn6vQFcDKxzRMDrExL4V8mfxPBQpsUgZRfC1WTveR5pnm+UEWWCMqus9RQpO7lHD+HMm6YTtOb20bQ==",
+      "version": "3.1101.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1101.0.tgz",
+      "integrity": "sha512-8R5aywNT7ccoTFsbqKB+XIh5LA+XgqlB0PnICFplZUM8NfJIENip9LTXv6weFIuruqiAe2gMS0K2pjO2gP+gUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
-        "@aws-sdk/credential-provider-node": "^3.972.75",
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/credential-provider-node": "^3.972.76",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.3.tgz",
-      "integrity": "sha512-6YZTpF5Zzl0KdSrztM0l6ErKdnXrnnodIDYfayHE9SFfZU8Ubxls7H2XnfWT121jgwiG+WP1z5kyfVDsH5V4qA==",
+      "version": "3.977.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.4.tgz",
+      "integrity": "sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
@@ -93,12 +93,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.64",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.64.tgz",
-      "integrity": "sha512-14kkR5aj1c7D+cYCrEcG2W3xw87wMYAEUeB/tMiQ2j0RVKzzdewd4mJw1+Q0JVLr4IFU1JHGDCyj0WqLrtIixg==",
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.65.tgz",
+      "integrity": "sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/core": "^3.977.4",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -109,12 +109,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.66",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.66.tgz",
-      "integrity": "sha512-BrZxoXScBZ+nTOYy388zHkz1n5cS8C+uGFMozD4w9OKEWMq39Cu/9l/k385Hb54dtv0VIeh12f8h67o3xDNH9g==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.67.tgz",
+      "integrity": "sha512-N7fw/15hSwI/CPxe5ohOyb7O4ge9f5me1gVIn8OIkBRB0squ8OJqQyDyH/HoL+Sb1W5xdC88jVC+bHkw73iu+Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/core": "^3.977.4",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
@@ -127,19 +127,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.9.tgz",
-      "integrity": "sha512-d/mMvS+sQjSWNA6+JCldK1YB/jQmtoWM8Izj10mrOZdRCeWNVb8IYQuuyHHKKKXcpGo5Pd0LIK6onHbLvlhuVQ==",
+      "version": "3.973.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.10.tgz",
+      "integrity": "sha512-Zh9XRaPnDN9buO7GfWBubS22R6Nq5D6hbyYEMN05LiOnXugm/8WDjUx6y756bSPbdn3aJB2qG4zFW3bN82QhoQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
-        "@aws-sdk/credential-provider-env": "^3.972.64",
-        "@aws-sdk/credential-provider-http": "^3.972.66",
-        "@aws-sdk/credential-provider-login": "^3.972.71",
-        "@aws-sdk/credential-provider-process": "^3.972.64",
-        "@aws-sdk/credential-provider-sso": "^3.973.8",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.70",
-        "@aws-sdk/nested-clients": "^3.997.38",
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/credential-provider-env": "^3.972.65",
+        "@aws-sdk/credential-provider-http": "^3.972.67",
+        "@aws-sdk/credential-provider-login": "^3.972.72",
+        "@aws-sdk/credential-provider-process": "^3.972.65",
+        "@aws-sdk/credential-provider-sso": "^3.973.9",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.71",
+        "@aws-sdk/nested-clients": "^3.997.39",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
@@ -151,13 +151,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.71",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.71.tgz",
-      "integrity": "sha512-l93922lXnTs5RjM3QrMCXSmXiEgLFLaQ0Lco9F3tJ08o0mzGdAj6m2nAXDuTMHoUuL0u7RKmrhm+Z8/7GCilyg==",
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.72.tgz",
+      "integrity": "sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
-        "@aws-sdk/nested-clients": "^3.997.38",
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/nested-clients": "^3.997.39",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -168,17 +168,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.75",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.75.tgz",
-      "integrity": "sha512-sdFhR4E3HWZefGL6OsBhxqXdqtFvxGOh8VLfiu9yttPgVNcpEozEDPmrTYmXA3CIf6npUETVLveQPGQ7GBzVhg==",
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.76.tgz",
+      "integrity": "sha512-1yzLmRiYSgGC25v7ZZEwJn/auhHHTIHgFOmzL2f36hf1+7jSLcX+1QrAz4760WEzPiiQl8xmlpFhHfl2OoyVzA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.64",
-        "@aws-sdk/credential-provider-http": "^3.972.66",
-        "@aws-sdk/credential-provider-ini": "^3.973.9",
-        "@aws-sdk/credential-provider-process": "^3.972.64",
-        "@aws-sdk/credential-provider-sso": "^3.973.8",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.70",
+        "@aws-sdk/credential-provider-env": "^3.972.65",
+        "@aws-sdk/credential-provider-http": "^3.972.67",
+        "@aws-sdk/credential-provider-ini": "^3.973.10",
+        "@aws-sdk/credential-provider-process": "^3.972.65",
+        "@aws-sdk/credential-provider-sso": "^3.973.9",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.71",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
@@ -190,12 +190,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.64",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.64.tgz",
-      "integrity": "sha512-Q5noG5vfFo++bUaLGcjj8OHX5tmwa1O/5nDVMeaSSZgjzgvWbW6tgu/gSa+aENwcJXjoXDQh+8TRZR2zHds/aw==",
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.65.tgz",
+      "integrity": "sha512-e5DbbNteOSalN58U83G6kFa4ECLEuGbGqNBHIXE7zYXA/m4GHblIGjFbSH7wYv6gBV8iNSDcRZBKfQZF5vF9nw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/core": "^3.977.4",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -206,14 +206,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.8.tgz",
-      "integrity": "sha512-37okeZyRdVkGrU6nyKBPGqQvyl/7CEiMpUVOb0+BCNCIR0VAuBxNgjMb0mnsR1EXm8dqQFfQZOJ5YW/0sBfa1w==",
+      "version": "3.973.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.9.tgz",
+      "integrity": "sha512-0V0u4t+KBku9fbh5CPCaC5hUWwSzDafp8nCuDy817zWbp2gz80jO44rMQkiwnZ+k54B+tjAtzRy00DJRGTKGBg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
-        "@aws-sdk/nested-clients": "^3.997.38",
-        "@aws-sdk/token-providers": "3.1098.0",
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/token-providers": "3.1100.0",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -224,13 +224,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.70",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.70.tgz",
-      "integrity": "sha512-Ps/f9USafScb6CSQTRPNMzdKL5x5XRwDIRgFvnuFWfClGZe7/fI7iCFqXdxKjc9LBxP28E7iUgNloGgfgw406w==",
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.71.tgz",
+      "integrity": "sha512-e4dwiRltGAaQ+2yxw57Hj0l/BF3BHiG14+QpYE7bGYBlpAq/fkIri2BDhjWon8c0mhhtd2txQBAkQb9BcTStFg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
-        "@aws-sdk/nested-clients": "^3.997.38",
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/nested-clients": "^3.997.39",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
@@ -241,12 +241,12 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.38.tgz",
-      "integrity": "sha512-jQDs+nxnmgo4+WPOmY373HIC8jx4KyYYMYDI74FWrzX3Ba9fYsV0dSA+7PNYNkhRbbRCRLre83tQ31F1ACCHkA==",
+      "version": "3.997.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.39.tgz",
+      "integrity": "sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
+        "@aws-sdk/core": "^3.977.4",
         "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
@@ -275,13 +275,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1098.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1098.0.tgz",
-      "integrity": "sha512-6cFAviffeqYGjrXn4FqGbWcTxB3nbpBpQXUm6MvnrWZThJaVBTHHnespHgSUh4yVLfzhipSh9H/XjzkHQd9P4g==",
+      "version": "3.1100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1100.0.tgz",
+      "integrity": "sha512-THf3MkgY3fNJZ3zdgSenLqR7gSE68KccCj1RCKretlG73Ppszvues02VpCUO9NlB/tZDC483FvGCld+AiPCkvg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.3",
-        "@aws-sdk/nested-clients": "^3.997.38",
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/nested-clients": "^3.997.39",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",

--- a/lambda/inference-streaming-proxy/package.json
+++ b/lambda/inference-streaming-proxy/package.json
@@ -11,8 +11,8 @@
     "test": "node --test --experimental-test-coverage --test-coverage-lines=93 --test-coverage-functions=93 --test-coverage-branches=93 ../../tests/inference-streaming-proxy/*.test.mjs"
   },
   "dependencies": {
-    "@aws-sdk/client-elastic-load-balancing-v2": "3.1098.0",
-    "@aws-sdk/client-secrets-manager": "3.1098.0",
-    "@aws-sdk/client-ssm": "3.1098.0"
+    "@aws-sdk/client-elastic-load-balancing-v2": "3.1101.0",
+    "@aws-sdk/client-secrets-manager": "3.1101.0",
+    "@aws-sdk/client-ssm": "3.1101.0"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "boto3==1.43.59",
+    "boto3==1.43.62",
     "click==8.4.2",
     "requests==2.34.2",
     "pyyaml==6.0.3",
@@ -71,7 +71,7 @@ dependencies = [
 
 [project.optional-dependencies]
 cdk = [
-    "aws-cdk-lib==2.262.2",
+    "aws-cdk-lib==2.263.0",
     "cdk-nag==3.0.1",
     "constructs==10.8.0",
 ]
@@ -89,15 +89,15 @@ diagrams = [
     # ``lint`` extra to avoid version-drift between the generator and
     # the CI lint gate).
     "pyflowchart==0.6.0",
-    "playwright==1.61.0",
-    "ruff==0.16.0",
+    "playwright==1.62.0",
+    "ruff==0.16.1",
 ]
 # Direct runtime roots for the six production service images. Their Dockerfiles
 # read exactly one group with Python 3.14's tomllib and use requirements-lock.txt
 # only as the shared transitive constraint; they never install the project extra.
 image-health-monitor = [
-    "boto3==1.43.59",
-    "botocore==1.43.59",
+    "boto3==1.43.62",
+    "botocore==1.43.62",
     "fastapi==0.141.1",
     "httpx==0.28.1",
     "kubernetes==36.0.3",
@@ -106,8 +106,8 @@ image-health-monitor = [
     "uvicorn==0.52.0",
 ]
 image-manifest-processor = [
-    "boto3==1.43.59",
-    "botocore==1.43.59",
+    "boto3==1.43.62",
+    "botocore==1.43.62",
     "fastapi==0.141.1",
     "httpx==0.28.1",
     "kubernetes==36.0.3",
@@ -119,8 +119,8 @@ image-manifest-processor = [
     "uvicorn==0.52.0",
 ]
 image-inference-proxy = [
-    "boto3==1.43.59",
-    "botocore==1.43.59",
+    "boto3==1.43.62",
+    "botocore==1.43.62",
     "fastapi==0.141.1",
     "httpx==0.28.1",
     "prometheus-client==0.26.0",
@@ -128,20 +128,20 @@ image-inference-proxy = [
     "uvicorn==0.52.0",
 ]
 image-inference-monitor = [
-    "boto3==1.43.59",
-    "botocore==1.43.59",
+    "boto3==1.43.62",
+    "botocore==1.43.62",
     "kubernetes==36.0.3",
     "prometheus-client==0.26.0",
     "pyyaml==6.0.3",
 ]
 image-queue-processor = [
-    "boto3==1.43.59",
+    "boto3==1.43.62",
     "kubernetes==36.0.3",
     "pyyaml==6.0.3",
 ]
 image-cost-monitor = [
-    "boto3==1.43.59",
-    "botocore==1.43.59",
+    "boto3==1.43.62",
+    "botocore==1.43.62",
     "fastapi==0.141.1",
     "httpx==0.28.1",
     "prometheus-client==0.26.0",
@@ -179,7 +179,7 @@ mcp = [
     "fastmcp[tasks,code-mode]==3.4.5",
 ]
 lint = [
-    "ruff==0.16.0",
+    "ruff==0.16.1",
     "yamllint==1.38.0",
 ]
 typecheck = [

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -47,7 +47,7 @@ aws-cdk-asset-node-proxy-agent-v6==2.1.2
     # via aws-cdk-lib
 aws-cdk-cloud-assembly-schema==54.15.0
     # via aws-cdk-lib
-aws-cdk-lib==2.262.2
+aws-cdk-lib==2.263.0
     # via
     #   cdk-nag
     #   gco-cli
@@ -58,12 +58,12 @@ bandit==1.9.4
     #   gco-cli (pyproject.toml)
 beartype==0.22.9
     # via py-key-value-aio
-boto3==1.43.59
+boto3==1.43.62
     # via
     #   gco-cli
     #   gco-cli (pyproject.toml)
     #   moto
-botocore==1.43.59
+botocore==1.43.62
     # via
     #   boto3
     #   gco-cli (pyproject.toml)
@@ -328,7 +328,7 @@ platformdirs==4.9.6
     #   fastmcp-slim
     #   python-discovery
     #   virtualenv
-playwright==1.61.0
+playwright==1.62.0
     # via
     #   gco-cli
     #   gco-cli (pyproject.toml)
@@ -506,7 +506,7 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.16.0
+ruff==0.16.1
     # via
     #   gco-cli
     #   gco-cli (pyproject.toml)


### PR DESCRIPTION
## Summary
- refresh the Python, npm, Dockerfile.dev, pre-commit, EKS add-on, Aurora, Helm chart, and Slinky image pins reported in #214
- regenerate the Python and inference-streaming-proxy lockfiles with the repository-pinned toolchains
- keep Slinky chart and image tags in lockstep

## Local validation
- rebuilt `Dockerfile.dev` successfully with the updated toolchain pins
- lockfile freshness check
- Ruff format and lint
- strict non-stack mypy
- accelerator catalog validation and focused tests
- inference-streaming-proxy: 71 tests passing with coverage gates
- all 13 Helm charts resolved and rendered online at their pinned versions
- `git diff --check`

The full suite is delegated to GitHub Actions. After all PR CI is green, the E2E workflow will be dispatched and monitored separately.

Closes #214