### PR TITLE
docs: fold the autopilot README hero into the recording dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,8 @@
 
 </details>
 
-**🤖 One command to a working agent — the easiest way to start:**
-
-```bash
-gco autopilot
-```
-
 <details>
-<summary>🤖 Autopilot recording — a real agent session, one command</summary>
+<summary>🤖 Autopilot recording — one command to a working agent, the easiest way to start</summary>
 
 ![GCO Autopilot — one command to a fully configured Claude Code session on Amazon Bedrock, grounded by the GCO MCP server](demo/autopilot.gif)
 


### PR DESCRIPTION
Removes the standalone autopilot hook (bold line + `gco autopilot` code fence) from the README hero so the top of the page is the four uniform collapsible recordings. The autopilot dropdown's summary now carries the message instead: *one command to a working agent, the easiest way to start*. The full getting-started block lower in the README is unchanged. README-only change.