### PR TITLE
ci: retry every CI image build against transient registry failures

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -5,7 +5,9 @@ Reusable GitHub Actions composite actions shared across multiple CI workflows. I
 ## Table of Contents
 
 - [Actions](#actions)
+  - [`build-image-with-retry`](#build-image-with-retry)
   - [`build-lambda-package`](#build-lambda-package)
+  - [`docker-build-with-retry`](#docker-build-with-retry)
   - [`docker-pull-with-retry`](#docker-pull-with-retry)
   - [`free-disk-space`](#free-disk-space)
   - [`install-trivy`](#install-trivy)
@@ -14,6 +16,40 @@ Reusable GitHub Actions composite actions shared across multiple CI workflows. I
 - [Adding a New Action](#adding-a-new-action)
 
 ## Actions
+
+### `build-image-with-retry`
+
+Wraps `docker/build-push-action@v7.3.0` with retry-on-failure. Every build starts by resolving base-image metadata against Docker Hub, whose registry and token endpoints intermittently time out on GitHub runners (`failed to resolve source metadata for docker.io/library/python:3.14.6-slim ... dial tcp ...:443: i/o timeout`) — a network fault that failed an integration job before a single layer was built. The build-push action has no retry of its own, so one blip fails the job.
+
+Retrying the whole action keeps the GHA layer-cache semantics identical on every attempt, and layers completed by a failed attempt are reused by the next. Genuine build failures are deterministic and still fail on the final attempt with the real error. Behaviour matches `docker/build-push-action@v7.3.0` on every successful path. Three attempts with a 15 s / 45 s backoff, matching [`setup-buildx-with-retry`](#setup-buildx-with-retry) (typically paired immediately before this action).
+
+**Inputs (passed straight through to `build-push-action`):**
+
+| Name | Default | Description |
+|------|---------|-------------|
+| `context` | `.` | Build context |
+| `file` | (required) | Dockerfile path |
+| `tags` | (required) | Image tag(s) |
+| `load` | `true` | Load the result into the local image store |
+| `cache-from` | `""` | Cache sources |
+| `cache-to` | `""` | Cache destinations |
+
+**Used by:** every `integration:docker:*` image job and the kind E2E builds in `integration-tests.yml`, and `security:trivy:container-scan` in `security.yml`. Drop-in replacement for `docker/build-push-action@v7.3.0` for the input surface above.
+
+**Usage:**
+
+```yaml
+- uses: ./.github/actions/setup-buildx-with-retry
+- name: Build image
+  uses: ./.github/actions/build-image-with-retry
+  with:
+    context: .
+    file: dockerfiles/cost-monitor-dockerfile
+    tags: cost-monitor:ci
+    load: true
+    cache-from: type=gha,scope=cost-monitor
+    cache-to: type=gha,mode=max,scope=cost-monitor,ignore-error=true
+```
 
 ### `build-lambda-package`
 
@@ -48,6 +84,32 @@ steps:
   - uses: ./.github/actions/build-lambda-package
 ```
 
+### `docker-build-with-retry`
+
+Runs a plain `docker build` (the daemon's default builder — no Buildx) with a retry loop, for jobs that deliberately want the image built exactly as a contributor's `docker build` would produce it. Same failure class as [`build-image-with-retry`](#build-image-with-retry): Docker Hub registry timeouts while resolving base-image metadata. Layers completed by a failed attempt stay in the daemon cache, so retries resume rather than rebuild. Genuine build failures still fail on the final attempt with the real error.
+
+**Inputs:**
+
+| Name | Default | Description |
+|------|---------|-------------|
+| `dockerfile` | `""` | Dockerfile path passed to `-f` (empty = the context default) |
+| `tag` | (required) | Image tag passed to `-t` |
+| `context` | `.` | Build context directory |
+| `attempts` | `3` | Total attempts. Set to `1` to disable retries. |
+| `delay` | `15` | Seconds between attempts, doubled after each failure |
+
+**Used by:** `integration:docker:dev-container` (`integration-tests.yml`) — the native-arch matrix that intentionally avoids Buildx and the GHA cache.
+
+**Usage:**
+
+```yaml
+- name: Build dev container
+  uses: ./.github/actions/docker-build-with-retry
+  with:
+    dockerfile: Dockerfile.dev
+    tag: gco-dev
+```
+
 ### `docker-pull-with-retry`
 
 Pulls one or more pinned container images with a retry loop, so a following `docker run` finds them in the local cache. Docker Hub's registry and token endpoints intermittently time out on GitHub runners (`auth.docker.io ... Client.Timeout exceeded while awaiting headers`), and because a plain `docker run` pulls implicitly with no retry, a single blip failed a lint job whose checks never ran. Retrying with backoff makes that class self-healing; a genuinely missing or unauthorised image still fails on the final attempt with the real registry error.
@@ -60,7 +122,7 @@ Pulls one or more pinned container images with a retry loop, so a following `doc
 | `attempts` | `3` | Total attempts per image. Set to `1` to disable retries. |
 | `delay` | `15` | Seconds to sleep between attempts. |
 
-**Used by:** `lint.yml` (`lint:hadolint:dockerfile`, `lint:shellcheck:shell`) — the jobs that run a Docker Hub linter image directly.
+**Used by:** `lint.yml` (`lint:hadolint:dockerfile`, `lint:shellcheck:shell`), `security.yml` (`security:trufflehog:secrets`), `integration-tests.yml` (`integration:docker:dev-container` — DinD probe base image), and `mooncake-image.yml` — every job that runs or builds from a Docker Hub image it did not itself build.
 
 **Usage:**
 
@@ -147,8 +209,10 @@ Behaviour matches `docker/setup-buildx-action@v4.2.0` for every successful path;
 
 ```yaml
 - uses: ./.github/actions/setup-buildx-with-retry
-- uses: docker/build-push-action@v7.3.0
+- uses: ./.github/actions/build-image-with-retry
   with:
+    file: dockerfiles/my-image-dockerfile
+    tags: my-image:ci
     cache-from: type=gha,scope=my-image
 ```
 

--- a/.github/actions/build-image-with-retry/action.yml
+++ b/.github/actions/build-image-with-retry/action.yml
@@ -1,0 +1,106 @@
+name: "Build Image (with retry)"
+description: |
+  Wraps `docker/build-push-action@v7.3.0` with retry-on-failure.
+
+  Every build starts by resolving base-image metadata against Docker Hub,
+  whose registry and token endpoints intermittently time out on GitHub
+  runners. Observed in CI:
+
+      ERROR: failed to build: failed to solve: DeadlineExceeded:
+      python:3.14.6-slim: failed to resolve source metadata for
+      docker.io/library/python:3.14.6-slim: failed to do request: Head
+      "https://registry-1.docker.io/v2/library/python/manifests/3.14.6-slim":
+      dial tcp ...:443: i/o timeout
+
+  That is a network fault on a public dependency the build does not control,
+  and it failed an integration job before a single layer was built. The
+  build-push action has no retry of its own, so one blip fails the job.
+
+  Retrying the whole action keeps the GHA layer cache semantics identical on
+  every attempt; layers completed by a failed attempt are reused by the next
+  one. Genuine build failures (bad Dockerfile, failing RUN step) are not
+  masked — they are deterministic, so the final attempt fails with the real
+  error. Behaviour matches `docker/build-push-action@v7.3.0` on every
+  successful path; the only observable difference is on transient failures.
+
+  Three attempts with a 15 s / 45 s backoff, matching
+  `setup-buildx-with-retry` (typically paired immediately before this action).
+
+inputs:
+  context:
+    description: "Build context (passed straight through)."
+    required: false
+    default: "."
+  file:
+    description: "Dockerfile path (passed straight through)."
+    required: true
+  tags:
+    description: "Image tag(s) (passed straight through)."
+    required: true
+  load:
+    description: "Load the result into the local image store (passed straight through)."
+    required: false
+    default: "true"
+  cache-from:
+    description: "Cache sources (passed straight through)."
+    required: false
+    default: ""
+  cache-to:
+    description: "Cache destinations (passed straight through)."
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build image (attempt 1 of 3)
+      id: try1
+      uses: docker/build-push-action@v7.3.0
+      continue-on-error: true
+      with:
+        context: ${{ inputs.context }}
+        file: ${{ inputs.file }}
+        tags: ${{ inputs.tags }}
+        load: ${{ inputs.load }}
+        cache-from: ${{ inputs.cache-from }}
+        cache-to: ${{ inputs.cache-to }}
+
+    - name: Wait before retry 1
+      if: steps.try1.outcome == 'failure'
+      shell: bash
+      run: |
+        echo "::warning::Build of ${{ inputs.tags }} failed (attempt 1/3); retrying in 15s." \
+          "Usually a transient registry/network error."
+        sleep 15
+
+    - name: Build image (attempt 2 of 3)
+      id: try2
+      if: steps.try1.outcome == 'failure'
+      uses: docker/build-push-action@v7.3.0
+      continue-on-error: true
+      with:
+        context: ${{ inputs.context }}
+        file: ${{ inputs.file }}
+        tags: ${{ inputs.tags }}
+        load: ${{ inputs.load }}
+        cache-from: ${{ inputs.cache-from }}
+        cache-to: ${{ inputs.cache-to }}
+
+    - name: Wait before retry 2
+      if: steps.try1.outcome == 'failure' && steps.try2.outcome == 'failure'
+      shell: bash
+      run: |
+        echo "::warning::Build of ${{ inputs.tags }} failed (attempt 2/3); retrying in 45s." \
+          "Usually a transient registry/network error."
+        sleep 45
+
+    - name: Build image (attempt 3 of 3 — final)
+      if: steps.try1.outcome == 'failure' && steps.try2.outcome == 'failure'
+      uses: docker/build-push-action@v7.3.0
+      with:
+        context: ${{ inputs.context }}
+        file: ${{ inputs.file }}
+        tags: ${{ inputs.tags }}
+        load: ${{ inputs.load }}
+        cache-from: ${{ inputs.cache-from }}
+        cache-to: ${{ inputs.cache-to }}

--- a/.github/actions/build-image-with-retry/action.yml
+++ b/.github/actions/build-image-with-retry/action.yml
@@ -68,8 +68,12 @@ runs:
     - name: Wait before retry 1
       if: steps.try1.outcome == 'failure'
       shell: bash
+      env:
+        # Interpolating inputs directly into `run:` is an injection risk
+        # (semgrep run-shell-injection); env indirection keeps the value data.
+        BUILD_TAGS: ${{ inputs.tags }}
       run: |
-        echo "::warning::Build of ${{ inputs.tags }} failed (attempt 1/3); retrying in 15s." \
+        echo "::warning::Build of ${BUILD_TAGS} failed (attempt 1/3); retrying in 15s." \
           "Usually a transient registry/network error."
         sleep 15
 
@@ -89,8 +93,10 @@ runs:
     - name: Wait before retry 2
       if: steps.try1.outcome == 'failure' && steps.try2.outcome == 'failure'
       shell: bash
+      env:
+        BUILD_TAGS: ${{ inputs.tags }}
       run: |
-        echo "::warning::Build of ${{ inputs.tags }} failed (attempt 2/3); retrying in 45s." \
+        echo "::warning::Build of ${BUILD_TAGS} failed (attempt 2/3); retrying in 45s." \
           "Usually a transient registry/network error."
         sleep 45
 

--- a/.github/actions/docker-build-with-retry/action.yml
+++ b/.github/actions/docker-build-with-retry/action.yml
@@ -1,0 +1,85 @@
+name: "Docker Build (with retry)"
+description: |
+  Runs a plain `docker build` with retry-on-failure, for jobs that
+  deliberately use the daemon's default builder instead of Buildx
+  (e.g. the dev-container matrix, which builds natively on each host
+  arch with no GHA layer cache and wants the image in the local store
+  exactly as a contributor's `docker build` would produce it).
+
+  Every build starts by resolving base-image metadata against Docker Hub,
+  whose registry and token endpoints intermittently time out on GitHub
+  runners. Observed in CI:
+
+      ERROR: failed to build: failed to solve: DeadlineExceeded:
+      python:3.14.6-slim: failed to resolve source metadata for
+      docker.io/library/python:3.14.6-slim: failed to do request: Head
+      "https://registry-1.docker.io/v2/library/python/manifests/3.14.6-slim":
+      dial tcp ...:443: i/o timeout
+
+  Retrying with backoff makes that class self-healing while a genuine build
+  failure (bad Dockerfile, failing RUN step) is deterministic and still
+  fails on the final attempt with the real error. Layers completed by a
+  failed attempt stay in the daemon's cache, so retries resume rather than
+  rebuild from scratch.
+
+inputs:
+  dockerfile:
+    description: "Dockerfile path, passed to -f (empty = the context default)."
+    required: false
+    default: ""
+  tag:
+    description: "Image tag, passed to -t (e.g. `gco-dev`)."
+    required: true
+  context:
+    description: "Build context directory."
+    required: false
+    default: "."
+  attempts:
+    description: "Total attempts (default 3). Set to 1 to disable retries."
+    required: false
+    default: "3"
+  delay:
+    description: "Seconds to sleep between attempts, doubled after each failure (default 15)."
+    required: false
+    default: "15"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build with retry
+      shell: bash
+      env:
+        DOCKERFILE: ${{ inputs.dockerfile }}
+        TAG: ${{ inputs.tag }}
+        CONTEXT: ${{ inputs.context }}
+        ATTEMPTS: ${{ inputs.attempts }}
+        DELAY: ${{ inputs.delay }}
+      run: |
+        set -euo pipefail
+
+        build_args=(build -t "$TAG")
+        if [ -n "$DOCKERFILE" ]; then
+          build_args+=(-f "$DOCKERFILE")
+        fi
+        build_args+=("$CONTEXT")
+
+        attempt=1
+        delay="$DELAY"
+        while true; do
+          echo "::group::docker ${build_args[*]} (attempt ${attempt}/${ATTEMPTS})"
+          if docker "${build_args[@]}"; then
+            echo "::endgroup::"
+            break
+          fi
+          echo "::endgroup::"
+          if [ "$attempt" -ge "$ATTEMPTS" ]; then
+            echo "::error::docker build of ${TAG} failed after ${ATTEMPTS} attempt(s)."
+            exit 1
+          fi
+          echo "::warning::docker build of ${TAG} failed" \
+            "(attempt ${attempt}/${ATTEMPTS}); retrying in ${delay}s." \
+            "Usually a transient registry/network error."
+          sleep "$delay"
+          delay=$((delay * 2))
+          attempt=$((attempt + 1))
+        done

--- a/.github/scripts/dependency-scan.sh
+++ b/.github/scripts/dependency-scan.sh
@@ -359,7 +359,7 @@ if [ -d "$WORKFLOWS_DIR" ]; then
   grep -rhoE "image: [a-zA-Z0-9_./-]+:[a-zA-Z0-9._-]+" "$WORKFLOWS_DIR" 2>/dev/null \
     | sed 's/image: //' >> "$ALL_IMAGES" || true
   grep -rhoE "[a-zA-Z0-9_./-]+:[a-zA-Z0-9._-]+" "$WORKFLOWS_DIR" 2>/dev/null \
-    | grep -E '^(hadolint|koalaman|semgrep|bridgecrew|checkmarx|trufflesecurity|zricethezav|aquasec|bats|python):' \
+    | grep -E '^(alpine|hadolint|koalaman|semgrep|bridgecrew|checkmarx|trufflesecurity|zricethezav|aquasec|bats|python):' \
     | sed 's/[[:space:]]*$//' >> "$ALL_IMAGES" || true
 fi
 

--- a/.github/scripts/dev_alias_live.sh
+++ b/.github/scripts/dev_alias_live.sh
@@ -120,8 +120,28 @@ if [ "$SKIP_BUILD" -eq 1 ]; then
         || die "setup-dev-alias.sh failed to install the gco function for $RUNTIME"
 else
     note "setup GCO: setup-dev-alias.sh builds $IMAGE from Dockerfile.dev with $RUNTIME and installs the function"
-    "$SETUP" --runtime "$RUNTIME" --image "$IMAGE" --rc "$rc" \
-        || die "setup-dev-alias.sh failed to build $IMAGE / install the gco function for $RUNTIME"
+    # The build pulls the base image from Docker Hub, whose registry endpoints
+    # intermittently time out on GitHub runners. Retry the whole setup run
+    # (build + rc write, both idempotent; completed layers stay cached) so a
+    # transient registry blip does not fail the job — or, in the podman job,
+    # masquerade as an OCI-runtime configuration failure and burn one of its
+    # crun/runc attempts.
+    build_ok=0
+    retry_delay=15
+    for attempt in 1 2 3; do
+        if "$SETUP" --runtime "$RUNTIME" --image "$IMAGE" --rc "$rc"; then
+            build_ok=1
+            break
+        fi
+        if [ "$attempt" -lt 3 ]; then
+            printf 'setup-dev-alias.sh failed (attempt %s/3); retrying in %ss (usually a transient registry/network error)\n' \
+                "$attempt" "$retry_delay" >&2
+            sleep "$retry_delay"
+            retry_delay=$((retry_delay * 2))
+        fi
+    done
+    [ "$build_ok" -eq 1 ] \
+        || die "setup-dev-alias.sh failed to build $IMAGE / install the gco function for $RUNTIME (after 3 attempts)"
 fi
 grep -q '>>> gco >>>' "$rc" || die "setup script did not write a gco function block"
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -359,7 +359,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-buildx-with-retry
       - name: Build image
-        uses: docker/build-push-action@v7.3.0
+        uses: ./.github/actions/build-image-with-retry
         with:
           context: .
           file: dockerfiles/cost-monitor-dockerfile
@@ -386,7 +386,7 @@ jobs:
         # reused by this job, integration:kind:cluster-e2e, and
         # security:trivy:container-scan — all three build the same image
         # from the same Dockerfile + context.
-        uses: docker/build-push-action@v7.3.0
+        uses: ./.github/actions/build-image-with-retry
         with:
           context: .
           file: dockerfiles/health-monitor-dockerfile
@@ -411,7 +411,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-buildx-with-retry
       - name: Build image
-        uses: docker/build-push-action@v7.3.0
+        uses: ./.github/actions/build-image-with-retry
         with:
           context: .
           file: dockerfiles/manifest-processor-dockerfile
@@ -436,7 +436,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-buildx-with-retry
       - name: Build image
-        uses: docker/build-push-action@v7.3.0
+        uses: ./.github/actions/build-image-with-retry
         with:
           context: .
           file: dockerfiles/inference-monitor-dockerfile
@@ -462,7 +462,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-buildx-with-retry
       - name: Build image
-        uses: docker/build-push-action@v7.3.0
+        uses: ./.github/actions/build-image-with-retry
         with:
           context: .
           file: dockerfiles/inference-proxy-dockerfile
@@ -485,7 +485,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-buildx-with-retry
       - name: Build image
-        uses: docker/build-push-action@v7.3.0
+        uses: ./.github/actions/build-image-with-retry
         with:
           context: .
           file: dockerfiles/queue-processor-dockerfile
@@ -512,7 +512,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-buildx-with-retry
       - name: Build image
-        uses: docker/build-push-action@v7.3.0
+        uses: ./.github/actions/build-image-with-retry
         with:
           context: lambda/helm-installer
           file: lambda/helm-installer/Dockerfile
@@ -536,7 +536,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-buildx-with-retry
       - name: Build image
-        uses: docker/build-push-action@v7.3.0
+        uses: ./.github/actions/build-image-with-retry
         with:
           context: lambda/tls-certificate-manager
           file: lambda/tls-certificate-manager/Dockerfile
@@ -582,8 +582,14 @@ jobs:
       - name: Build dev container
         # Native build on the matching host arch — no --platform or QEMU.
         # Dockerfile.dev is parameterized on BuildKit's $TARGETARCH, which
-        # resolves to the host's arch by default.
-        run: docker build -f Dockerfile.dev -t gco-dev .
+        # resolves to the host's arch by default. The retry wrapper absorbs
+        # Docker Hub registry timeouts while resolving base-image metadata;
+        # this stays a plain `docker build` (daemon default builder), exactly
+        # what a contributor runs.
+        uses: ./.github/actions/docker-build-with-retry
+        with:
+          dockerfile: Dockerfile.dev
+          tag: gco-dev
       - name: Exercise CLI inside dev container
         run: |
           docker run --rm -v "$PWD":/workspace -w /workspace gco-dev gco --help
@@ -686,6 +692,13 @@ jobs:
                   sys.exit(1)
               print(f"OK: {binary} e_machine=0x{e_machine:X}")
           PY
+      - name: Pre-pull the DinD probe base image (with retry)
+        # The inner build below is FROM alpine:3.21; warming the host
+        # daemon's cache here (the inner build talks to that same daemon
+        # over the socket) keeps a registry blip from failing the probe.
+        uses: ./.github/actions/docker-pull-with-retry
+        with:
+          images: alpine:3.21
       - name: Verify Docker-in-Docker via host socket pass-through
         # `gco stacks deploy-all` drives `cdk deploy`, which shells out to
         # Docker to bundle Lambda assets. The dev container ships only the
@@ -832,7 +845,7 @@ jobs:
         # Shares the same GHA cache scope as integration:docker:health-monitor
         # and security:trivy:container-scan. All three build the same image
         # from the same Dockerfile + context, so layer reuse is automatic.
-        uses: docker/build-push-action@v7.3.0
+        uses: ./.github/actions/build-image-with-retry
         with:
           context: .
           file: dockerfiles/health-monitor-dockerfile
@@ -841,7 +854,7 @@ jobs:
           cache-from: type=gha,scope=health-monitor
           cache-to: type=gha,mode=max,scope=health-monitor,ignore-error=true
       - name: Build cost-monitor image
-        uses: docker/build-push-action@v7.3.0
+        uses: ./.github/actions/build-image-with-retry
         with:
           context: .
           file: dockerfiles/cost-monitor-dockerfile
@@ -850,7 +863,7 @@ jobs:
           cache-from: type=gha,scope=cost-monitor
           cache-to: type=gha,mode=max,scope=cost-monitor,ignore-error=true
       - name: Build manifest-processor image
-        uses: docker/build-push-action@v7.3.0
+        uses: ./.github/actions/build-image-with-retry
         with:
           context: .
           file: dockerfiles/manifest-processor-dockerfile
@@ -859,7 +872,7 @@ jobs:
           cache-from: type=gha,scope=manifest-processor
           cache-to: type=gha,mode=max,scope=manifest-processor,ignore-error=true
       - name: Build inference-monitor image
-        uses: docker/build-push-action@v7.3.0
+        uses: ./.github/actions/build-image-with-retry
         with:
           context: .
           file: dockerfiles/inference-monitor-dockerfile
@@ -868,7 +881,7 @@ jobs:
           cache-from: type=gha,scope=inference-monitor
           cache-to: type=gha,mode=max,scope=inference-monitor,ignore-error=true
       - name: Build inference-proxy image
-        uses: docker/build-push-action@v7.3.0
+        uses: ./.github/actions/build-image-with-retry
         with:
           context: .
           file: dockerfiles/inference-proxy-dockerfile

--- a/.github/workflows/mooncake-image.yml
+++ b/.github/workflows/mooncake-image.yml
@@ -67,14 +67,21 @@ jobs:
         # gco.services.inference_monitor, which imports the kubernetes client
         # (the [image-inference-monitor] group). [test] brings pytest.
         run: pip install -e ".[image-inference-monitor,test]"
-      - name: Resolve + pull the Mooncake image (single source of truth)
+      - name: Resolve the Mooncake image (single source of truth)
         # The version is read from cli.images so this job always validates the
         # exact image GCO defaults to — bump the constant and CI re-validates.
+        id: mooncake-image
         run: |
           set -euo pipefail
           IMAGE="$(python3 -c 'from cli.images import _DISAGGREGATED_DEFAULT_IMAGE; print(_DISAGGREGATED_DEFAULT_IMAGE)')"
           echo "Mooncake default image: $IMAGE"
-          docker pull "$IMAGE"
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+      - name: Pull the Mooncake image (with retry)
+        uses: ./.github/actions/docker-pull-with-retry
+        with:
+          images: ${{ steps.mooncake-image.outputs.image }}
+          # The ~9GB vLLM image is a long pull; give retries breathing room.
+          delay: "30"
       - name: Run image contract tests
         run: |
           pytest tests/test_mooncake_image_contract.py -m mooncake_image -v \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -291,7 +291,7 @@ jobs:
         # is used by the integration:docker:* jobs and the kind E2E build,
         # so each image's layers are built exactly once per commit and
         # reused everywhere.
-        uses: docker/build-push-action@v7.3.0
+        uses: ./.github/actions/build-image-with-retry
         with:
           context: ${{ matrix.context || '.' }}
           file: ${{ matrix.dockerfile }}
@@ -341,6 +341,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
+      - name: Pre-pull TruffleHog image (with retry)
+        # A plain `docker run` pulls implicitly with no retry; pre-pulling
+        # keeps a Docker Hub blip from failing the scan before it starts.
+        # Keep the tag in lockstep with the run step below.
+        uses: ./.github/actions/docker-pull-with-retry
+        with:
+          images: trufflesecurity/trufflehog:3.95.2
       - name: Run TruffleHog
         run: |
           docker run --rm -v "$PWD":/repo \


### PR DESCRIPTION
## Summary

Docker Hub's registry/token endpoints intermittently time out on GitHub runners. The latest instance failed the dev-container build before a single layer was built:

```
ERROR: failed to build: failed to solve: DeadlineExceeded: python:3.14.6-slim:
failed to resolve source metadata for docker.io/library/python:3.14.6-slim:
failed to do request: Head "https://registry-1.docker.io/v2/library/python/manifests/3.14.6-slim":
dial tcp 32.193.199.148:443: i/o timeout
```

None of the CI image builds had retries, so one blip fails a job whose actual checks never ran. This PR gives **every image build in CI** retry protection, plus the handful of unprotected pulls that fail the same way.

## Changes

**New composite action `build-image-with-retry`** — wraps `docker/build-push-action@v7.3.0` with the same 3-attempt 15s/45s ladder as the existing `setup-buildx-with-retry`. Drop-in for the input surface the repo uses (context/file/tags/load/cache-from/cache-to); GHA layer-cache semantics identical on every attempt, and completed layers from a failed attempt are reused. Swapped in at all 14 call sites:

- 8 `integration:docker:*` image jobs
- 5 kind E2E image builds
- `security:trivy:container-scan` (10-image matrix)

**New composite action `docker-build-with-retry`** — plain `docker build` retry loop (mirrors `docker-pull-with-retry`'s bash-loop style) for `integration:docker:dev-container`, which deliberately uses the daemon default builder (native-arch matrix, no Buildx) so the image is built exactly as a contributor's `docker build` would.

**`dev_alias_live.sh`** — the docker/podman/finch dev-alias jobs build gco-dev through `scripts/setup-dev-alias.sh` itself; the build path now retries 3x (15s/30s). In the podman job this also stops a registry blip from masquerading as an OCI-runtime failure and burning one of the crun/runc configuration attempts. Bats suite (hermetic paths) unchanged, 7/7 passing.

**Pull hardening via the existing `docker-pull-with-retry`** (same failure class, adjacent to the builds):

- TruffleHog scan image (`security:trufflehog:secrets`)
- DinD probe's `alpine:3.21` base (dev-container job; warms the host daemon the in-container build talks to)
- the ~9GB Mooncake contract image — the tag resolved from `cli.images` now flows through a step output into the retry action, keeping the single source of truth

**Docs** — both actions documented in `.github/actions/README.md` (ToC, inputs, used-by); refreshed the stale used-by/pairing references.

Genuine build failures are not masked: they are deterministic, so the final attempt fails with the real error.

## Testing

- `yamllint` (repo config) clean on all touched workflows and both new actions
- `actionlint` clean on all three touched workflows
- `shellcheck -x` + `bash -n` clean on `dev_alias_live.sh`; `bats tests/BATS/test_dev_alias_live.bats` 7/7
- `markdownlint-cli2` (repo config) clean on the actions README
- Grep-verified: zero raw `docker/build-push-action` references remain in workflows (the pin lives only inside the composite)
