### PR TITLE
Fix deps-scan false INCOMPLETEs under pipefail; drop withdrawn ray tag

### DIFF
--- a/.github/scripts/dependency-scan.sh
+++ b/.github/scripts/dependency-scan.sh
@@ -416,7 +416,10 @@ check_image() {
   # No newer family member. If the pinned tag itself is no longer listed,
   # the pin points at something the registry stopped advertising (renamed
   # variant scheme, withdrawn tag) — that deserves eyes, not silence.
-  if ! printf '%s\n' "$raw_tags" | grep -qxF -e "$current_tag" -e "v${current_tag#v}" -e "${current_tag#v}"; then
+  # tag_listed reads the list from an argument, not a printf pipe: under
+  # pipefail, grep -q's early exit gave printf SIGPIPE on large tag lists
+  # and inverted "tag present" into a false INCOMPLETE (2026-09 scan).
+  if ! tag_listed "$current_tag" "$raw_tags"; then
     mark_scan_incomplete "Pinned tag ${current_tag} is no longer listed by ${registry}/${repo}."
   fi
 }

--- a/.github/scripts/lib_dependency_scan.sh
+++ b/.github/scripts/lib_dependency_scan.sh
@@ -288,6 +288,24 @@ if best_tag:
 " "$1" 2>/dev/null
 }
 
+# tag_listed <tag> <raw_tags>
+#
+# Whether <raw_tags> (a newline-separated registry tag list passed as one
+# argument, not on stdin) lists <tag> exactly, accepting a leading ``v`` on
+# either side. Exists because the obvious spelling —
+# ``printf '%s\n' "$raw_tags" | grep -qxF …`` — is wrong under ``pipefail``
+# for large repositories: ``grep -q`` exits at the first match and closes
+# the pipe, ``printf`` takes SIGPIPE/EPIPE while still writing tag lists
+# bigger than the pipe buffer (python has ~3900 tags, tritonserver ~2600),
+# and the pipeline reports failure for a tag that is in fact listed. That
+# inverted into false "pinned tag is no longer listed" INCOMPLETE findings
+# in the 2026-09 scan. A herestring keeps grep's stdin writer-free, so
+# early exit has nothing to signal.
+tag_listed() {
+  local tag="$1" raw_tags="$2"
+  grep -qxF -e "$tag" -e "v${tag#v}" -e "${tag#v}" <<< "$raw_tags"
+}
+
 # parse_accelerator_drift_count <json-summary-file>
 #
 # Validates the machine-readable output from

--- a/docs/KUBERAY.md
+++ b/docs/KUBERAY.md
@@ -54,7 +54,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.57.0
+          image: rayproject/ray:2.56.1
           resources:
             requests:
               cpu: "2"
@@ -73,7 +73,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.57.0
+          image: rayproject/ray:2.56.1
           resources:
             requests:
               cpu: "2"
@@ -91,7 +91,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.57.0
+          image: rayproject/ray:2.56.1
           resources:
             requests:
               cpu: "4"
@@ -188,7 +188,7 @@ workerGroupSpecs:
     spec:
       containers:
       - name: ray-worker
-        image: rayproject/ray:2.57.0
+        image: rayproject/ray:2.56.1
         resources:
           requests:
             cpu: "4"

--- a/examples/ray-cluster.yaml
+++ b/examples/ray-cluster.yaml
@@ -42,7 +42,7 @@ spec:
           fsGroup: 1000
         containers:
         - name: ray-head
-          image: rayproject/ray:2.57.0
+          image: rayproject/ray:2.56.1
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false  # Ray needs to write to /tmp
@@ -88,7 +88,7 @@ spec:
           fsGroup: 1000
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.57.0
+          image: rayproject/ray:2.56.1
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false  # Ray needs to write to /tmp

--- a/tests/BATS/test_dependency_scan.bats
+++ b/tests/BATS/test_dependency_scan.bats
@@ -218,6 +218,36 @@ setup() {
     [ "$result" = "20260805" ]
 }
 
+# ── tag_listed ───────────────────────────────────────────────────────────────
+
+@test "tag_listed: finds an early tag in a list larger than the pipe buffer" {
+    # Regression (2026-09 scan): the old printf-into-grep -q pipeline took
+    # SIGPIPE under pipefail whenever the match landed before the end of a
+    # >64KiB tag list (docker.io/library/python, nvcr.io tritonserver, ...),
+    # inverting "tag present" into a false INCOMPLETE. Build a list well past
+    # the pipe buffer with the pinned tag near the top.
+    local big_list
+    big_list="$(printf '3.14.7-slim\n'; seq -f 'tag-%.0f-suffix' 1 30000)"
+    set -o pipefail
+    tag_listed "3.14.7-slim" "$big_list"
+}
+
+@test "tag_listed: accepts a v-prefix mismatch in either direction" {
+    tag_listed "v1.2.3" "$(printf '%s\n' one 1.2.3 two)"
+    tag_listed "1.2.3" "$(printf '%s\n' one v1.2.3 two)"
+}
+
+@test "tag_listed: exact match only, not substrings" {
+    ! tag_listed "1.2.3" "$(printf '%s\n' 1.2.30 11.2.3 1.2.3-slim)"
+}
+
+@test "tag_listed: fails for an absent tag" {
+    # The true-positive path: rayproject/ray:2.57.0 was withdrawn upstream
+    # after being pinned; the INCOMPLETE for it was correct and the check
+    # must keep firing when the tag is genuinely unlisted.
+    ! tag_listed "2.57.0" "$(printf '%s\n' 2.56.0 2.56.1 2.57.0.106e80)"
+}
+
 # ── is_semver_tag ────────────────────────────────────────────────────────────
 
 @test "is_semver_tag: v1.2.3 is semver" {


### PR DESCRIPTION
## Summary

The [2026-09 monthly deps scan](https://github.com/awslabs/global-capacity-orchestrator-on-aws/actions/runs/31349792850/job/93338342329) failed its incomplete-scan gate with five `INCOMPLETE: Pinned tag X is no longer listed by ...` findings. Four were false positives caused by a shell bug; one was a real withdrawn tag. This PR fixes both.

### 1. False INCOMPLETEs: SIGPIPE under `pipefail` (script bug)

The pinned-tag existence check was:

```bash
if ! printf '%s\n' "$raw_tags" | grep -qxF -e "$current_tag" ...; then
  mark_scan_incomplete "Pinned tag ... is no longer listed ..."
```

`grep -q` exits at the first match and closes the pipe. When the tag list is larger than the 64KiB pipe buffer (`library/python` ~3900 tags, `nvcr.io/nvidia/tritonserver` ~2600, `dcgm-exporter`, `nvcr.io/nvidia/pytorch`), `printf` is still writing, takes SIGPIPE/EPIPE (the `printf: write error: Broken pipe` lines in the job log), and under `set -o pipefail` the pipeline reports failure for a tag that was found — inverted by `!` into a false "no longer listed". Verified live: all four tags exist in their registries.

Fix: new `tag_listed()` helper in `lib_dependency_scan.sh` hands the list to grep as a herestring, so early exit has no writer process to signal. BATS regressions: a >64KiB-list/early-match case (fails against the old pattern), v-prefix acceptance both directions, exact-match-not-substring, and absent-tag-still-fails.

### 2. Real INCOMPLETE: `rayproject/ray:2.57.0` withdrawn upstream

Docker Hub 404s the bare `2.57.0` tag (bare release tags now end at `2.56.1`, matching PyPI's latest `ray`); only `2.57.0.<build>` nightlies remain. The tag existed when #237 pinned it and was withdrawn since — exactly the situation this check exists to catch. Pinned `examples/ray-cluster.yaml` + `docs/KUBERAY.md` image tags back to `2.56.1`, which also re-aligns them with the `rayVersion: '2.56.1'` both specs declared all along (the image bump in #237 had missed that field).

Not addressed on purpose: the slurm `25.11 -> 26.05.2` and cuda `12.6.3 -> 13.3.1` lines in the same log are ordinary drift-report rows, not failures (slurm is deliberately held back pending an operator-chart pairing PR).

## Testing

- `bats tests/BATS/test_dependency_scan.bats`: 240 passed, 0 failed (4 new `tag_listed` tests)
- `shellcheck -x` + `bash -n` on both scripts: clean
- Live reproduction through the real `check_image` function with `set -uo pipefail` against the five registries from the failed run: the four false INCOMPLETEs are gone, `ray:2.56.1` passes, and a probe with the withdrawn `ray:2.57.0` still correctly reports INCOMPLETE (the check keeps its teeth)
- `validate_k8s_manifests.py`: 157 manifests schema-valid

## Live release validation

- [x] Not required — no deployed-infrastructure change (CI scan script, BATS tests, example/docs image tag), no runtime dependency change
- [ ] Required and completed ...
- [ ] Required but pending ...

**Applicability rationale:** Not required: touches the monthly dependency-scan tooling and an example manifest pin only; nothing under `gco/`, `lambda/`, or chart/deploy paths changed.
