### PR TITLE
Stop reporting transport failures as not-found in gco jobs get

### DIFF
--- a/cli/jobs.py
+++ b/cli/jobs.py
@@ -600,13 +600,23 @@ class JobManager:
         ``gco jobs get`` / ``gco jobs submit --wait`` work unchanged for
         TrainJobs.
 
+        ``None`` means the API confirmed the job does not exist (HTTP 404 on
+        both lookups). Any other failure — an unreachable regional API bridge,
+        an auth error, a 5xx — propagates to the caller so it is never
+        misreported as "not found" (see issue #258).
+
         Args:
             job_name: Name of the job
             namespace: Namespace of the job
             region: Region where the job is running
 
         Returns:
-            JobInfo or None if not found
+            JobInfo, or None if the API confirmed the job does not exist
+
+        Raises:
+            RuntimeError: If the regional API bridge is unreachable or the
+                request fails for reasons other than the job being absent
+            requests.exceptions.HTTPError: For non-404 HTTP responses
         """
         target_region = region or self.config.default_region
         try:
@@ -616,14 +626,17 @@ class JobManager:
             return self._parse_job_info(response, target_region)
         except requests.exceptions.HTTPError as e:
             if e.response is not None and e.response.status_code == 404:
+                # The batch Job endpoint confirmed the name is unknown; the
+                # job may still exist as a Kubeflow TrainJob.
                 trainjob = self._get_trainjob_info(job_name, namespace, target_region)
                 if trainjob is not None:
                     return trainjob
-            logger.debug("Failed to get job details for %s: %s", job_name, e)
-            return None
-        except Exception as e:
-            logger.debug("Failed to get job details for %s: %s", job_name, e)
-            return None
+                logger.debug("Job %s not found in %s/%s", job_name, target_region, namespace)
+                return None
+            # Non-404 responses (401/403/5xx) do not mean the job is absent.
+            # Surface the real failure instead of collapsing it into None,
+            # which the CLI would render as "not found".
+            raise
 
     def _get_trainjob_info(self, job_name: str, namespace: str, region: str) -> JobInfo | None:
         """Fetch a TrainJob through the generic manifests endpoint, or None."""

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -136,6 +136,26 @@ class TestJobsCommands:
         result = runner.invoke(cli, ["jobs", "get", "nonexistent-job", "--region", "us-east-1"])
         assert result.exit_code == 1
 
+    def test_jobs_get_missing_regional_bridge_is_not_reported_as_not_found(self):
+        """Issue #258: an unreachable regional API bridge must surface as such.
+
+        Runs the real command handler, JobManager, and AWS client request
+        path; only regional endpoint discovery is stubbed to "stack not
+        deployed" (None), exactly what happens after deploying the regional
+        stack without gco-regional-api-<region>.
+        """
+        from cli.aws_client import GCOAWSClient
+        from cli.main import cli
+
+        with patch.object(GCOAWSClient, "get_regional_api_endpoint", return_value=None):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["jobs", "get", "gpu-test-job", "--region", "us-east-1"])
+
+        assert result.exit_code == 1
+        assert "Regional API endpoint is not deployed in us-east-1" in result.output
+        # The old behavior collapsed this failure into "Job ... not found".
+        assert "not found" not in result.output.lower()
+
     @patch("cli.commands.jobs_cmd.get_job_manager")
     @patch("cli.commands.jobs_cmd.get_output_formatter")
     def test_jobs_logs(self, mock_formatter, mock_manager):

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -365,20 +365,51 @@ class TestJobManagerOperations:
                 assert job.name == "test-job"
 
     def test_get_job_not_found(self):
-        """Test getting a job that doesn't exist."""
+        """Test getting a job the API confirms does not exist (HTTP 404)."""
+        import requests
+
         from cli.jobs import JobManager
 
         with patch("cli.jobs.get_config") as mock_config:
             mock_config.return_value = MagicMock(default_region="us-east-1")
             with patch("cli.jobs.get_aws_client") as mock_aws:
                 mock_aws_client = MagicMock()
-                mock_aws_client.get_job_details.side_effect = Exception("Not found")
+                mock_aws_client.get_job_details.side_effect = requests.exceptions.HTTPError(
+                    response=MagicMock(status_code=404)
+                )
+                mock_aws_client.call_api.side_effect = RuntimeError("API request failed: not found")
                 mock_aws.return_value = mock_aws_client
 
                 manager = JobManager()
                 job = manager.get_job("nonexistent-job", "gco-jobs")
 
                 assert job is None
+
+    def test_get_job_transport_failure_propagates(self):
+        """A failure to reach the API must not be reported as "not found".
+
+        Regression test for issue #258: with the regional API bridge not
+        deployed, get_job_details raises RuntimeError; get_job used to
+        swallow it and return None, which the CLI rendered as
+        "Job <name> not found" even though the job was running.
+        """
+        from cli.jobs import JobManager
+
+        with patch("cli.jobs.get_config") as mock_config:
+            mock_config.return_value = MagicMock(default_region="us-east-1")
+            with patch("cli.jobs.get_aws_client") as mock_aws:
+                mock_aws_client = MagicMock()
+                mock_aws_client.get_job_details.side_effect = RuntimeError(
+                    "Regional API endpoint is not deployed in us-east-1; "
+                    "exact region routing requires the regional API bridge"
+                )
+                mock_aws.return_value = mock_aws_client
+
+                manager = JobManager()
+                with pytest.raises(RuntimeError, match="Regional API endpoint is not deployed"):
+                    manager.get_job("gpu-test-job", "gco-jobs")
+                # The TrainJob fallback must not run for transport failures.
+                mock_aws_client.call_api.assert_not_called()
 
     def test_get_job_logs(self):
         """Test getting job logs."""
@@ -590,14 +621,19 @@ class TestJobManagerGetJob:
         assert result.namespace == "default"
 
     def test_get_job_not_found(self):
-        """Test get_job when job is not found."""
+        """Test get_job when the API confirms the job does not exist."""
         from unittest.mock import MagicMock
+
+        import requests
 
         from cli.jobs import JobManager
 
         manager = JobManager()
         manager._aws_client = MagicMock()
-        manager._aws_client.get_job_details.side_effect = Exception("Not found")
+        manager._aws_client.get_job_details.side_effect = requests.exceptions.HTTPError(
+            response=MagicMock(status_code=404)
+        )
+        manager._aws_client.call_api.side_effect = RuntimeError("API request failed: not found")
 
         result = manager.get_job("nonexistent", "default", "us-east-1")
         assert result is None
@@ -1550,18 +1586,40 @@ class TestJobManagerWaitExtended:
     """Extended tests for job wait functionality."""
 
     def test_wait_for_job_not_found(self):
-        """Test wait_for_job raises error when job not found."""
+        """Test wait_for_job raises error when the job is confirmed absent."""
+        import requests
+
         from cli.jobs import JobManager
 
         with patch("cli.jobs.get_aws_client") as mock_get_client:
             mock_client = MagicMock()
             mock_get_client.return_value = mock_client
-            mock_client.get_job_details.side_effect = Exception("Not found")
+            mock_client.get_job_details.side_effect = requests.exceptions.HTTPError(
+                response=MagicMock(status_code=404)
+            )
+            mock_client.call_api.side_effect = RuntimeError("API request failed: not found")
 
             manager = JobManager()
 
             with pytest.raises(ValueError, match="not found"):
                 manager.wait_for_job("nonexistent-job", "default", timeout_seconds=1)
+
+    def test_wait_for_job_transport_failure_is_not_reported_as_not_found(self):
+        """Issue #258: an unreachable bridge aborts the wait with the real reason."""
+        from cli.jobs import JobManager
+
+        with patch("cli.jobs.get_aws_client") as mock_get_client:
+            mock_client = MagicMock()
+            mock_get_client.return_value = mock_client
+            mock_client.get_job_details.side_effect = RuntimeError(
+                "Regional API endpoint is not deployed in us-east-1; "
+                "exact region routing requires the regional API bridge"
+            )
+
+            manager = JobManager()
+
+            with pytest.raises(RuntimeError, match="Regional API endpoint is not deployed"):
+                manager.wait_for_job("gpu-test-job", "default", timeout_seconds=1)
 
 
 class TestJobManagerLogsExtended:
@@ -2093,7 +2151,10 @@ class TestTrainJobLifecycleFallbacks:
             response=MagicMock(status_code=503)
         )
 
-        assert manager.get_job("train-demo", "gco-jobs", "us-east-1") is None
+        # A 503 is not "absent": it propagates (issue #258) and must not
+        # trigger the TrainJob fallback.
+        with pytest.raises(requests.exceptions.HTTPError):
+            manager.get_job("train-demo", "gco-jobs", "us-east-1")
         manager._aws_client.call_api.assert_not_called()
 
     def test_trainjob_terminal_conditions_map_to_job_states(self):


### PR DESCRIPTION
## Summary

Fixes #258.

`JobManager.get_job` collapsed every exception into `None`, which `gco jobs get` renders as `✗ Job <name> not found` (exit 1). With the regional API bridge not deployed (the shipped default: `api_gateway.regional_api_enabled: false`, no `gco-regional-api-<region>` stack), the actionable `RuntimeError` from endpoint discovery — *"Regional API endpoint is not deployed in <region>; exact region routing requires the regional API bridge"* — was logged at `debug` and swallowed. A running job was therefore reported as nonexistent, and automated callers treated the wrong-but-plausible answer as terminal.

## Changes

- `cli/jobs.py::JobManager.get_job`: `None` now strictly means the API confirmed the job does not exist (HTTP 404 on the batch Job endpoint, with the existing TrainJob fallback also missing). Any other failure — unreachable bridge, auth error, 5xx — propagates. The `jobs get` handler already prints `Failed to get job: <reason>` and exits 1 for raised exceptions, so the command now reports the same diagnosis `jobs list` gives for the identical failure.
- The TrainJob fallback still runs only after a confirmed 404, and `wait_for_job` now aborts with the real reason instead of a spurious "not found" `ValueError`.

Before / after, with the regional stack up but the bridge not deployed:

```
# before
$ gco jobs get gpu-test-job -r us-east-1 -n gco-jobs
✗ Job gpu-test-job not found

# after
$ gco jobs get gpu-test-job -r us-east-1 -n gco-jobs
✗ Failed to get job: Regional API endpoint is not deployed in us-east-1; exact region routing requires the regional API bridge
```

## Testing

- Updated `tests/test_jobs.py` cases that pinned the old collapse-everything behavior: "not found" now requires a real 404 `HTTPError`; non-404 responses assert propagation.
- New regression tests: `get_job` and `wait_for_job` propagate the bridge-missing `RuntimeError` without probing the TrainJob fallback.
- New CLI-level test in `tests/test_cli_commands.py` reproducing the issue's exact scenario through the real command handler, `JobManager`, and `make_authenticated_request`, with only regional endpoint discovery stubbed to "stack not deployed": asserts exit 1, the bridge message, and that the output does not claim "not found".
- `tests/test_jobs.py` + `tests/test_cli_commands.py` (141 tests) and the adjacent suites (`test_dag`, `test_jobs_dag_extended`, `test_cli_main`, `test_capacity_reservations`, `test_cli_coverage`, `test_aws_client`, `test_mcp_server`; 606 tests) pass locally; `ruff check` and `ruff format --check` clean. Full suite left to CI.

## Not in scope

Suggested fixes 2 and 3 from the issue (a bridge-free read path via Kubernetes API/CloudWatch, and documenting the bridge coupling in CLI/tool descriptions) are follow-up candidates; this PR only fixes the misreporting defect.