### PR TITLE
docs: fix stale pin locations and lockfile procedure

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -176,16 +176,16 @@ The scan runs as an Advanced Setup workflow rather than Default Setup so the fil
 
 ## README badges
 
-The README's badge row has four parts:
+The README's badge row has three parts, in order — five dynamic health
+signals, then a navigation link:
 
 1. **Four workflow-status badges** (`Unit Tests`, `Integration Tests`, `Security`, `Linting`) from GitHub's native `badge.svg` endpoint.
-2. **A wiki badge** — a static shields.io badge linking to the Pages site root, where `pages.yml` serves the MkDocs wiki.
-3. **A coverage badge** rendered by shields.io from the endpoint JSON that `pages.yml` publishes at the Pages site root (`/coverage-badge.json`), generated from the same run whose HTML report is served at `/coverage/` — the badge links there. Badge, report, and the 90% gate all describe one run.
-4. **Eight stack/tech badges** (Python, CDK, EKS Auto Mode, Kubernetes, CDK-Nag, etc.) rendered by shields.io from hardcoded values, each linking to the authoritative source (pyproject.toml, cdk.json, upstream docs, etc.).
+2. **A coverage badge** rendered by shields.io from the endpoint JSON that `pages.yml` publishes at the Pages site root (`/coverage-badge.json`), generated from the same run whose HTML report is served at `/coverage/` — the badge links there. Badge, report, and the 90% gate all describe one run.
+3. **A wiki badge** — a static shields.io badge linking to the Pages site root, where `pages.yml` serves the MkDocs wiki. It sits last so the dynamic quality signals stay grouped.
 
 ### "repo or workflow not found" on fresh or private repositories
 
-The four workflow-status badges at the top of the README come from GitHub's native `badge.svg` endpoint and render a placeholder image when the repo is unreachable. All other shields.io URLs (`img.shields.io/badge/...`) are static and always render.
+The four workflow-status badges at the top of the README come from GitHub's native `badge.svg` endpoint and render a placeholder image when the repo is unreachable. The wiki badge (`img.shields.io/badge/...`) is static and always renders; the coverage badge (`img.shields.io/endpoint`) renders whatever `/coverage-badge.json` the Pages site last published, so it needs one successful `pages.yml` deploy before it shows a number.
 
 If a stale run ever shows a `img.shields.io/github/actions/workflow/status/...` URL rendering as **"repo or workflow not found"**, the usual cause is the repo being private (shields.io hits the public GitHub REST API and gets a 404). Making the repo public resolves it; there's no code change needed.
 

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -176,11 +176,12 @@ The scan runs as an Advanced Setup workflow rather than Default Setup so the fil
 
 ## README badges
 
-The README's badge row has three parts:
+The README's badge row has four parts:
 
 1. **Four workflow-status badges** (`Unit Tests`, `Integration Tests`, `Security`, `Linting`) from GitHub's native `badge.svg` endpoint.
-2. **A coverage badge** rendered by shields.io from the endpoint JSON that `pages.yml` publishes at the Pages site root (`/coverage-badge.json`), generated from the same run whose HTML report is served at `/coverage/` — the badge links there. Badge, report, and the 90% gate all describe one run.
-3. **Eight stack/tech badges** (Python, CDK, EKS Auto Mode, Kubernetes, CDK-Nag, etc.) rendered by shields.io from hardcoded values, each linking to the authoritative source (pyproject.toml, cdk.json, upstream docs, etc.).
+2. **A wiki badge** — a static shields.io badge linking to the Pages site root, where `pages.yml` serves the MkDocs wiki.
+3. **A coverage badge** rendered by shields.io from the endpoint JSON that `pages.yml` publishes at the Pages site root (`/coverage-badge.json`), generated from the same run whose HTML report is served at `/coverage/` — the badge links there. Badge, report, and the 90% gate all describe one run.
+4. **Eight stack/tech badges** (Python, CDK, EKS Auto Mode, Kubernetes, CDK-Nag, etc.) rendered by shields.io from hardcoded values, each linking to the authoritative source (pyproject.toml, cdk.json, upstream docs, etc.).
 
 ### "repo or workflow not found" on fresh or private repositories
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,11 +208,19 @@ docker build -f Dockerfile.dev -t gco-dev .
 
 # Regenerate the lockfile and strip the project self-reference
 docker run --rm -v "$(pwd):/workspace" -w /workspace gco-dev bash -c '
+  pip install --quiet "pip==25.0.1" &&
   pip-compile --no-emit-index-url --strip-extras --all-extras \
     -o requirements-lock.txt pyproject.toml &&
   sed -i "/^gco-cli @ file:/,+1d" requirements-lock.txt
 '
 ```
+
+The `pip install "pip==25.0.1"` step works around `pip-tools==7.6.0` importing
+pip internals (`pip._internal.utils.compat.stdlib_pkgs`) that newer pip — as
+shipped in the current `python:3.14-slim` base image — has removed. The
+downgrade lives only inside the throwaway container; upgrading `pip-tools`
+past 7.6 would remove the need for it, but that is a dependency change made on
+its own PR, not silently alongside a lockfile regeneration.
 
 The `sed` step removes the `gco-cli @ file:///workspace` self-reference that
 `pip-compile` always emits (two lines — the `file://` URI and its `# via`

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
   <a href="https://github.com/awslabs/global-capacity-orchestrator-on-aws/actions/workflows/integration-tests.yml"><img src="https://github.com/awslabs/global-capacity-orchestrator-on-aws/actions/workflows/integration-tests.yml/badge.svg?branch=main" alt="Integration Tests"></a>
   <a href="https://github.com/awslabs/global-capacity-orchestrator-on-aws/actions/workflows/security.yml"><img src="https://github.com/awslabs/global-capacity-orchestrator-on-aws/actions/workflows/security.yml/badge.svg?branch=main" alt="Security"></a>
   <a href="https://github.com/awslabs/global-capacity-orchestrator-on-aws/actions/workflows/lint.yml"><img src="https://github.com/awslabs/global-capacity-orchestrator-on-aws/actions/workflows/lint.yml/badge.svg?branch=main" alt="Linting"></a>
-  <a href="https://awslabs.github.io/global-capacity-orchestrator-on-aws/"><img src="https://img.shields.io/badge/docs-wiki-blue" alt="Wiki"></a>
   <a href="https://awslabs.github.io/global-capacity-orchestrator-on-aws/coverage/"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fawslabs.github.io%2Fglobal-capacity-orchestrator-on-aws%2Fcoverage-badge.json" alt="Coverage"></a>
+  <a href="https://awslabs.github.io/global-capacity-orchestrator-on-aws/"><img src="https://img.shields.io/badge/docs-wiki-blue" alt="Wiki"></a>
 </p>
 <!-- END BADGE TABLE -->
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   <a href="https://github.com/awslabs/global-capacity-orchestrator-on-aws/actions/workflows/integration-tests.yml"><img src="https://github.com/awslabs/global-capacity-orchestrator-on-aws/actions/workflows/integration-tests.yml/badge.svg?branch=main" alt="Integration Tests"></a>
   <a href="https://github.com/awslabs/global-capacity-orchestrator-on-aws/actions/workflows/security.yml"><img src="https://github.com/awslabs/global-capacity-orchestrator-on-aws/actions/workflows/security.yml/badge.svg?branch=main" alt="Security"></a>
   <a href="https://github.com/awslabs/global-capacity-orchestrator-on-aws/actions/workflows/lint.yml"><img src="https://github.com/awslabs/global-capacity-orchestrator-on-aws/actions/workflows/lint.yml/badge.svg?branch=main" alt="Linting"></a>
+  <a href="https://awslabs.github.io/global-capacity-orchestrator-on-aws/"><img src="https://img.shields.io/badge/docs-wiki-blue" alt="Wiki"></a>
   <a href="https://awslabs.github.io/global-capacity-orchestrator-on-aws/coverage/"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fawslabs.github.io%2Fglobal-capacity-orchestrator-on-aws%2Fcoverage-badge.json" alt="Coverage"></a>
 </p>
 <!-- END BADGE TABLE -->

--- a/README.md
+++ b/README.md
@@ -577,10 +577,13 @@ This is host-socket pass-through, not true Docker-in-Docker. Anyone with access 
 ├── app.py                               # CDK app entry point
 ├── TENETS.md                            # Prioritized project principles and north-star guidance
 ├── cdk.json                             # CDK configuration (regions, features, thresholds)
+├── mkdocs.yml                           # MkDocs configuration for the GitHub Pages wiki (sources in wiki/)
 ├── pyproject.toml                       # Project metadata, dependencies, and CLI installation
 │
 ├── cli/                                 # GCO CLI (jobs, stacks, capacity, inference, costs, DAGs)
+├── demo/                                # Recorded CLI demos (GIFs + asciinema sources) with walkthroughs and re-record scripts
 ├── diagrams/                            # Auto-generated architecture diagrams (infra_diagrams/) and code flowcharts (code_diagrams/)
+├── dockerfiles/                         # Distroless container images for the in-cluster GCO services
 ├── docs/                                # Documentation (architecture, CLI, API, inference, customization, analytics)
 ├── examples/                            # Example manifests (jobs, inference, Ray, Volcano, Kueue, Slurm, YuniKorn)
 ├── gco/
@@ -608,8 +611,10 @@ This is host-socket pass-through, not true Docker-in-Docker. Anyone with access 
 │   └── secret-rotation/                 # Daily secret rotation
 │
 ├── gco_mcp/                             # MCP server for LLM interaction (135 tools default, up to 183 with feature flags)
+├── images/                              # Screenshots and visual assets for docs and the wiki
 ├── scripts/                             # Utility scripts (version bump, cluster access setup)
-└── tests/                               # PyTest + BATS test suites (counts tracked via badges)
+├── tests/                               # PyTest + BATS test suites (counts tracked via badges)
+└── wiki/                                # GitHub Pages wiki sources (published at awslabs.github.io/global-capacity-orchestrator-on-aws)
 ```
 
 ## Contributing

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -192,31 +192,38 @@ shipping a skew.
 1. `cdk.json` — set `context.kubernetes_version` to the new minor.
 2. `pyproject.toml` — bump `kubernetes==<minor>.x` so the Python client's major
    equals the cluster minor (for example `kubernetes==37.*` for EKS `1.37`),
-   then regenerate the lock:
-
-   ```bash
-   pip-compile --all-extras --strip-extras -o requirements-lock.txt pyproject.toml
-   ```
-
+   then regenerate the lock through the container exactly as described in
+   [Updating a dependency](#updating-a-dependency) step 3 — don't run
+   `pip-compile` against your host Python; the flags and platform differ from
+   what CI's staleness check expects.
 3. `gco/stacks/constants.py` — update the five `EKS_ADDON_*` constants to builds
    published for the new minor (see [validating add-ons](#validating-add-on-versions)).
 4. Confirm the pinned `aws-cdk-lib` exposes `eks.KubernetesVersion.V1_<minor>`.
    If it does not, bump `aws-cdk-lib` in `pyproject.toml` and re-lock; otherwise
    the stack silently uses the `.of()` fallback.
-5. kubectl pins — bump to a patch of the new minor in all three spots, staying
-   within one minor of the cluster:
+5. kubectl pins — bump to a patch of the new minor in the two committed spots,
+   staying within one minor of the cluster:
+   - `lambda/helm-installer/Dockerfile` — the `dl.k8s.io/release/...` URL and
+     the `sha256sum -c` line under it (the checksum for each release binary is
+     published alongside it as `<url>.sha256`)
    - `Dockerfile.dev` (`ARG KUBECTL_VERSION`)
-   - `lambda/helm-installer/Dockerfile` (the `dl.k8s.io/release/...` URL)
-   - `.github/workflows/deps-scan.yml` (`KUBECTL_VERSION` env)
-6. Helm pins — if a new Helm is needed for the minor, bump the `HELM_VERSION`
-   env in both `.github/workflows/deps-scan.yml` and
-   `.github/workflows/integration-tests.yml` (the `integration:helm:charts-valid`
-   job) and the `get.helm.sh` URL in `lambda/helm-installer/Dockerfile`. The
-   `deps-scan` **Version Consistency** check flags the two workflow env pins if
-   they drift apart; the Dockerfile copy is a hardcoded `RUN` line it can't see,
-   so keep that one in lockstep by hand.
-7. `.github/workflows/integration-tests.yml` — bump the kind `node_image`
-   (`kindest/node:v<minor>.<patch>`) so CI exercises the new control plane.
+
+   No workflow edits are needed: every workflow that installs kubectl derives
+   the version and checksum from the installer Dockerfile at runtime
+   (`extract_helm_installer_pins` into `GITHUB_ENV`), and
+   `test_helm_and_kubectl_pins_live_only_in_the_installer_dockerfile`
+   (`tests/test_supply_chain_integrity.py`) fails if a literal workflow pin is
+   reintroduced. The `deps-scan` **Version Consistency** check cross-checks the
+   `Dockerfile.dev` ARG against the installer pin, so a half-done bump is
+   reported rather than shipped.
+6. Helm pin — if a new Helm is needed for the minor, bump the `get.helm.sh`
+   URL and its `sha256sum -c` line in `lambda/helm-installer/Dockerfile` (the
+   checksum is published alongside the tarball as `<url>.sha256sum`). That
+   `RUN` line is the single source: workflows derive `HELM_VERSION` /
+   `HELM_SHA256` from it exactly as with kubectl, guarded by the same test.
+7. `.github/workflows/integration-tests.yml` — bump the workflow-level
+   `KIND_NODE_IMAGE` env (`kindest/node:v<minor>.<patch>`) so CI exercises the
+   new control plane; both kind-based jobs read it from there.
 8. `.github/config/.trivyignore` — revisit any suppressions tied to the old
    kubectl/helm binaries; several entries clear once the pins move.
 9. `tests/test_config_loader.py` and `tests/test_config_loader_validation.py` —
@@ -534,11 +541,16 @@ resolve, the environment is dirty — fix the environment, don't loosen the pin.
    ```bash
    docker build -f Dockerfile.dev -t gco-dev .
    docker run --rm -v "$(pwd):/workspace" -w /workspace gco-dev bash -c '
+     pip install --quiet "pip==25.0.1" &&
      pip-compile --no-emit-index-url --strip-extras --all-extras \
        -o requirements-lock.txt pyproject.toml &&
      sed -i "/^gco-cli @ file:/,+1d" requirements-lock.txt
    '
    ```
+
+   The `pip==25.0.1` downgrade is required first: `pip-tools==7.6.0` imports
+   pip internals that newer pip (as shipped in the current `python:3.14-slim`
+   base) has removed, and it only affects the throwaway container.
 
 4. Run the affected checks, then open a PR. CI rejects stale Python or npm
    lockfiles, unmanaged npm graphs, and inconsistent Node/npm/CDK pins.
@@ -624,10 +636,12 @@ There is no auto-retry wrapper — a flake is treated as a bug, not hidden.
   `hashFiles('pyproject.toml', 'requirements-lock.txt')`. Both invalidate
   automatically when dependencies change — don't hand-clear them.
 - **Runners and tools:** jobs run on `ubuntu-latest` with actions pinned by
-  major version (bumped by Dependabot). Hand-installed CI tools
-  (`TRIVY_VERSION`, `HELM_VERSION`, `KUBECTL_VERSION`, the kind node image) are
-  tracked by the scan's **CI tooling** and **Version consistency** rows, so a
-  pin that must move in lockstep across files is caught there.
+  major version (bumped by Dependabot). Hand-installed CI tools — Trivy (the
+  `install-trivy` action's `version` default), Helm and kubectl (derived at
+  runtime from the `lambda/helm-installer/Dockerfile` pins), and the kind node
+  image (`KIND_NODE_IMAGE` in `integration-tests.yml`) — are tracked by the
+  scan's **CI tooling** and **Version consistency** rows, so a pin that must
+  move in lockstep across files is caught there.
 - On an EKS bump the kind `node_image` moves too — see
   [Upgrading the EKS Kubernetes version](#upgrading-the-eks-kubernetes-version).
 


### PR DESCRIPTION
## Summary

Docs-only follow-up to #262 (CI pin single-sourcing) and #263 (wiki), plus README front-matter improvements.

- **EKS upgrade steps 5–7** (`docs/MAINTENANCE.md`) — kubectl/Helm bumps no longer touch workflow env blocks (those pins were removed in #262). The steps now point at the real locations: the `lambda/helm-installer/Dockerfile` RUN-line pins (version + sha256) that every workflow derives at runtime via `extract_helm_installer_pins`, the `Dockerfile.dev` kubectl ARG cross-checked by deps-scan, and the workflow-level `KIND_NODE_IMAGE` env. Also names the guard test (`test_helm_and_kubectl_pins_live_only_in_the_installer_dockerfile`) that fails CI if a literal workflow pin is reintroduced.
- **EKS upgrade step 2** — replaced the inline `pip-compile` variant (which differed in flags and skipped the container) with a pointer to the canonical container procedure, removing a second divergent copy of the command.
- **CI pipeline maintenance bullet** — 'Runners and tools' listed `TRIVY_VERSION`/`HELM_VERSION`/`KUBECTL_VERSION` as workflow env pins; rewritten to the post-#262 locations.
- **Lockfile procedure (MAINTENANCE.md + CONTRIBUTING.md)** — added the required `pip install "pip==25.0.1"` step inside the container: `pip-tools==7.6.0` imports `pip._internal.utils.compat.stdlib_pkgs`, which the pip shipped in the current `python:3.14-slim` base has removed, so the documented command fails without the downgrade. (Discovered while regenerating the lock for #263.) Bumping pip-tools past 7.6 would remove the workaround but is a dependency change for its own PR — noted as such in CONTRIBUTING.md.
- **README wiki badge** — static shields.io badge (`docs | wiki`) linking to the Pages site root, placed last in the badge row so the five dynamic health signals (four workflow badges + coverage) stay grouped and the navigation link sits at the edge.
- **`.github/CI.md` badge section** — inventory updated for the new badge and corrected: the 'eight stack/tech badges' bullet described badges that have never existed in the README; the fresh-repo rendering note now describes the two real shields.io URLs (static wiki badge vs. the coverage `endpoint` badge that needs one successful Pages deploy).
- **README Project Structure tree** — brought the curated listing up to date: added `wiki/` and `mkdocs.yml` (new with the Pages wiki) plus `demo/`, `dockerfiles/`, and `images/`, which existed but were never listed despite being reader-facing content the README links into.

## Testing

- `npm run lint:markdown` — 0 issues in 124 files (re-run after every commit)
- `pytest tests/test_docs_coverage.py tests/test_doc_hygiene.py tests/test_migrate_fork.py tests/test_wiki.py` — 44 passed (fork-migration guard confirms the badge's Pages URL and the tree's Pages mention are classified by existing rewrite rules)
- Verified each pin-location claim against the v6.1.0 tree: `deps-scan.yml` / `integration-tests.yml` derive steps, `KIND_NODE_IMAGE` workflow-level env, installer Dockerfile RUN lines, `Dockerfile.dev` ARG, guard test location
- `img.shields.io/badge/docs-wiki-blue` renders (200); wiki root verified live as part of the post-merge deploy verification

No code changes.