### PR TITLE
Split the release workflow to work under full branch protection

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -50,7 +50,8 @@ For contributor-facing docs (how to run tests locally, release process, dependen
 │   ├── security.yml                  # Security workflow
 │   ├── lint.yml                      # Linting workflow
 │   ├── mooncake-image.yml            # Mooncake vLLM image contract test (push/PR)
-│   ├── release.yml                   # Manual workflow_dispatch release
+│   ├── release.yml                   # Release stage 1: open the version-bump PR
+│   ├── release-publish.yml           # Release stage 2: tag + GitHub Release on merge
 │   ├── deps-scan.yml                 # Monthly dependency scan
 │   ├── cve-scan.yml                  # Weekly CVE scan
 │   └── pages.yml                     # Publish coverage report to GitHub Pages (workflow_run)
@@ -82,7 +83,8 @@ Workflows outside the four badged gates. Most are schedule- or dispatch-driven; 
 
 | File | Trigger | Purpose |
 |------|---------|---------|
-| `workflows/release.yml` | `workflow_dispatch` | Bump version, tag, create a GitHub Release with auto-generated notes. Uses the built-in `GITHUB_TOKEN` — no PAT required |
+| `workflows/release.yml` | `workflow_dispatch` | Release stage 1: bump the version files on a `release/vX.Y.Z` branch, open the release PR, and dispatch the PR-gating CI workflows against that branch so its required checks report (pushes/PRs made with `GITHUB_TOKEN` never trigger `push:`/`pull_request:` runs; `workflow_dispatch` is the documented exception). Never writes to `main`, so it works under full branch protection. Uses the built-in `GITHUB_TOKEN` — no PAT required |
+| `workflows/release-publish.yml` | `push`: `main` (paths: `VERSION`) + manual | Release stage 2: after the release PR squash-merges, verify all three version mirrors agree, create the annotated `vX.Y.Z` tag on the merge commit, and create the GitHub Release with auto-generated notes. Idempotent end to end (a partial failure is completed by re-dispatching), refuses to move an existing v-tag, and only auto-publishes push events whose commit subject is `Release vX.Y.Z` — a stray VERSION edit never becomes a release |
 | `workflows/deps-scan.yml` | `cron: 0 9 1 * *` (monthly, UTC) + manual | Check pinned dependency versions, deterministic accelerator/NodePool/watch-list policy, and live EC2 accelerator-catalog drift; open or refresh one rolling issue when drift is found, then comment and close it after a complete clean scan with no skipped checks |
 | `workflows/cve-scan.yml` | `cron: 0 9 * * 1` (Mondays, UTC) + manual | Re-run trivy against current CVE databases |
 | `workflows/pages.yml` | `workflow_run` after **Unit Tests** completes on `main` | Publish the project site to GitHub Pages via `actions/deploy-pages`: build the MkDocs orientation wiki (`wiki/` + `mkdocs.yml`, strict mode) from the triggering run's commit at the site root, download that run's `pytest-coverage` artifact and serve `htmlcov/` at `/coverage/`, and regenerate the shields.io badge JSON at the site root (so the README badge's percent-encoded URL never changes). Split out of `unit-tests.yml` so a GitHub Pages backend stall — or a wiki build failure — surfaces here instead of failing the test gate; the PR-side `lint:mkdocs:strict` job runs the identical build pre-merge |
@@ -98,9 +100,9 @@ Workflows outside the four badged gates. Most are schedule- or dispatch-driven; 
 
 All CI workflows share the same safety defaults:
 
-- `concurrency.group: ${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true` so rapid pushes on the same branch supersede in-flight runs. Explicitly **off** on `release.yml` — a half-run release is worse than a slow one. `pages.yml` is the other exception: it uses a dedicated `concurrency.group: pages` with `cancel-in-progress: false` so a real Pages deployment is never cancelled mid-flight.
+- `concurrency.group: ${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true` so rapid pushes on the same branch supersede in-flight runs. Explicitly **off** for the release pair — `release.yml` and `release-publish.yml` share one repository-wide `group: release` with `cancel-in-progress: false`, so releases serialize across both stages and a half-run release is never cancelled mid-flight. `pages.yml` is the other exception: it uses a dedicated `concurrency.group: pages` with `cancel-in-progress: false` so a real Pages deployment is never cancelled mid-flight.
 - `timeout-minutes` on every job (10 min for lint, 15 for unit, 20–30 for integration).
-- `permissions:` scoped narrowly. All CI workflows run with `contents: read`; `release.yml` upgrades to `contents: write` so the version-bump job can push a tag and create a GitHub Release. `pages.yml`'s deploy job grants `pages: write` + `id-token: write` (to publish to Pages) and `actions: read` (to pull the `pytest-coverage` artifact from the triggering Unit Tests run).
+- `permissions:` scoped narrowly. All CI workflows run with `contents: read`. `release.yml` grants `contents: write` (push the release branch), `pull-requests: write` (open the release PR; also requires the repository Actions setting "Allow GitHub Actions to create and approve pull requests"), and `actions: write` (dispatch the PR-gating workflows). `release-publish.yml` grants `contents: write` for the tag push and Release creation. `pages.yml`'s deploy job grants `pages: write` + `id-token: write` (to publish to Pages) and `actions: read` (to pull the `pytest-coverage` artifact from the triggering Unit Tests run).
 - Caching: `actions/setup-python@v7.0.0` with `cache: pip` and `cache-dependency-path: requirements-lock.txt`. Mypy jobs add an explicit `actions/cache@v6.1.0` on `.mypy_cache/`.
 - AWS-backed dependency discovery uses OIDC via `aws-actions/configure-aws-credentials@v6.2.3` — never long-lived access keys. The monthly scan uses the role for EKS, RDS, EMR, Bedrock, and EC2 accelerator-catalog reads; deterministic accelerator policy validation remains offline.
 

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -20,13 +20,16 @@ Reusable GitHub Actions composite actions shared across multiple CI workflows. I
 
 ### `apt-install-with-retry`
 
-Runs `apt-get update` + `apt-get install` with bounded network timeouts and a retry loop. GitHub-hosted runners resolve `archive.ubuntu.com` through an Azure-internal mirror list, and when `azure.archive.ubuntu.com` is unreachable, stock apt retries every index fetch against it with 120-second default timeouts before falling back — observed in CI as ten minutes of `Ign:` lines on a plain `sudo apt-get update` while the job's actual tests never started. This action caps each connection attempt at seconds (`Acquire::http::Timeout=15`, `Acquire::Retries=3`), and re-runs the update+install pair with backoff so a mid-install mirror blip or stale index is self-healing. `update` and `install` retry as one unit because a failed install often means a stale index. A genuinely missing package or dependency conflict is not masked — it still fails on the final attempt with the real apt error.
+Runs `apt-get update` + `apt-get install` with ordered fallback mirrors, bounded network timeouts, and a retry loop. GitHub-hosted runners resolve `archive.ubuntu.com` through an ordered mirror list (`/etc/apt/apt-mirrors.txt`); when the first mirror (`azure.archive.ubuntu.com`) is unreachable-but-hanging, stock apt waits out a timeout for **every** index fetch before falling back — observed in CI as ten-plus minutes of `Ign:` lines on a plain `sudo apt-get update` while the job's actual tests never started. Bounded timeouts alone don't fix that mode: 15 s × 3 retries × ~20 index files still serializes into minutes per attempt.
+
+Three layers, none of which mask real failures: each configured mirror is health-probed once with a 5-second cap and the reachable ones are written to the runner's mirror list in order (apt then falls back across healthy mirrors natively, per fetch; if nothing answers, the list is left untouched); every fetch is capped (`Acquire::http::Timeout=15`, `Acquire::Retries=3`) so a mirror that degrades mid-run costs seconds; and the update+install pair retries as one unit with backoff, because a failed install often means a stale index. A genuinely missing package or dependency conflict still fails on the final attempt with the real apt error. Steps that add a third-party APT repo keep that setup in their own step — the mirror list only governs the Ubuntu archive, and other sources are never touched.
 
 **Inputs:**
 
 | Name | Default | Description |
 |------|---------|-------------|
 | `packages` | (required) | Whitespace- or newline-separated package names to install. |
+| `mirrors` | Azure mirror, then `archive.ubuntu.com` | Ordered Ubuntu archive mirror base URLs. First healthy mirror is primary; later entries are apt's native per-fetch fallbacks. Add regional mirrors here for more fallback depth. |
 | `no-install-recommends` | `false` | Pass `"true"` to install with `--no-install-recommends`. |
 | `attempts` | `3` | Total update+install attempts. Set to `1` to disable retries. |
 | `delay` | `15` | Seconds to sleep between attempts. |

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -5,6 +5,7 @@ Reusable GitHub Actions composite actions shared across multiple CI workflows. I
 ## Table of Contents
 
 - [Actions](#actions)
+  - [`apt-install-with-retry`](#apt-install-with-retry)
   - [`build-image-with-retry`](#build-image-with-retry)
   - [`build-lambda-package`](#build-lambda-package)
   - [`docker-build-with-retry`](#docker-build-with-retry)
@@ -16,6 +17,30 @@ Reusable GitHub Actions composite actions shared across multiple CI workflows. I
 - [Adding a New Action](#adding-a-new-action)
 
 ## Actions
+
+### `apt-install-with-retry`
+
+Runs `apt-get update` + `apt-get install` with bounded network timeouts and a retry loop. GitHub-hosted runners resolve `archive.ubuntu.com` through an Azure-internal mirror list, and when `azure.archive.ubuntu.com` is unreachable, stock apt retries every index fetch against it with 120-second default timeouts before falling back — observed in CI as ten minutes of `Ign:` lines on a plain `sudo apt-get update` while the job's actual tests never started. This action caps each connection attempt at seconds (`Acquire::http::Timeout=15`, `Acquire::Retries=3`), and re-runs the update+install pair with backoff so a mid-install mirror blip or stale index is self-healing. `update` and `install` retry as one unit because a failed install often means a stale index. A genuinely missing package or dependency conflict is not masked — it still fails on the final attempt with the real apt error.
+
+**Inputs:**
+
+| Name | Default | Description |
+|------|---------|-------------|
+| `packages` | (required) | Whitespace- or newline-separated package names to install. |
+| `no-install-recommends` | `false` | Pass `"true"` to install with `--no-install-recommends`. |
+| `attempts` | `3` | Total update+install attempts. Set to `1` to disable retries. |
+| `delay` | `15` | Seconds to sleep between attempts. |
+
+**Used by:** `unit-tests.yml` (`unit:bats:shell`), `deps-scan.yml` (system tooling), and `integration-tests.yml` (`integration:dev-alias:podman`, `integration:dev-alias:finch`) — every job that installs Ubuntu packages on a hosted runner. Steps that add a third-party APT repo first (the Finch job) keep that setup in their own step; this action's `update` then indexes the new source before installing from it.
+
+**Usage:**
+
+```yaml
+- name: Install bats + deps (with retry)
+  uses: ./.github/actions/apt-install-with-retry
+  with:
+    packages: bats jq python3-yaml
+```
 
 ### `build-image-with-retry`
 

--- a/.github/actions/apt-install-with-retry/action.yml
+++ b/.github/actions/apt-install-with-retry/action.yml
@@ -1,31 +1,51 @@
 name: "APT Install (with retry)"
 description: |
-  Runs `apt-get update` + `apt-get install` with bounded network timeouts and
-  a retry loop, so one flaky Ubuntu mirror cannot stall a job.
+  Runs `apt-get update` + `apt-get install` with ordered fallback mirrors,
+  bounded network timeouts, and a retry loop, so one flaky Ubuntu mirror
+  cannot stall or fail a job.
 
-  GitHub-hosted runners resolve archive.ubuntu.com through an Azure-internal
-  mirror list (/etc/apt/apt-mirrors.txt). When azure.archive.ubuntu.com is
-  unreachable, stock apt retries every index fetch against it with its default
-  120-second timeouts before falling back — observed in CI as ten minutes of
-  `Ign:` lines on `sudo apt-get update` while the job's actual tests never
-  ran, burning most of a 15-minute job timeout on a network fault the build
-  does not control.
+  GitHub-hosted runners resolve archive.ubuntu.com through an ordered
+  mirror list (/etc/apt/apt-mirrors.txt, the `mirror+file:` scheme in
+  ubuntu.sources). When the first mirror (azure.archive.ubuntu.com) is
+  unreachable-but-hanging, stock apt waits out a timeout for EVERY index
+  fetch before falling back, and `update` fetches 15-25 index files —
+  observed in CI as 10+ minutes of `Ign:` lines while the job's actual
+  tests never ran. Bounded timeouts alone are not enough: 15s x 3 retries
+  x ~20 files still serializes into minutes per attempt.
 
-  This action bounds each connection attempt to seconds instead of minutes,
-  lets apt retry individual fetches, and re-runs the update+install pair with
-  backoff so a mid-install mirror blip (or a stale index causing 404s) is
-  self-healing. A genuinely missing package or broken dependency is not
-  masked — it still fails on the final attempt with the real apt error.
+  Three layers make this self-healing without masking real failures:
 
-  `apt-get update` and `apt-get install` are retried as one unit because a
-  failed install often means the index is stale; refreshing before every
-  install attempt is what makes the retry meaningful.
+  1. Mirror health probe — each configured mirror is probed once with a
+     5-second cap; the reachable ones are written to the runner's mirror
+     list in the given order. apt then falls back across healthy mirrors
+     natively, per fetch, and a dead mirror costs one probe instead of a
+     timeout per index file. If no mirror answers, the list is left
+     untouched (an empty mirror list would be worse than a slow one).
+  2. Bounded fetch timeouts — a mirror that degrades mid-run costs
+     seconds per fetch, not apt's 120-second default.
+  3. update+install retried as one unit with backoff — a failed install
+     often means a stale index, so every retry refreshes first.
+
+  A genuinely missing package or dependency conflict still fails on the
+  final attempt with the real apt error.
 inputs:
   packages:
     description: |
       Whitespace- or newline-separated package names to install, e.g.
       `bats jq python3-yaml`.
     required: true
+  mirrors:
+    description: |
+      Ordered, whitespace- or newline-separated Ubuntu archive mirror base
+      URLs. The first healthy mirror is primary; later entries are apt's
+      native per-fetch fallbacks. The default keeps the runner's fast
+      Azure-internal mirror first with the canonical archive behind it.
+      Only applied when the runner resolves apt through a mirror list
+      (/etc/apt/apt-mirrors.txt); third-party repos are never touched.
+    required: false
+    default: |
+      http://azure.archive.ubuntu.com/ubuntu/
+      https://archive.ubuntu.com/ubuntu/
   no-install-recommends:
     description: |
       Pass "true" to install with --no-install-recommends. Off by default so
@@ -48,20 +68,49 @@ runs:
       shell: bash
       env:
         PACKAGES: ${{ inputs.packages }}
+        MIRRORS: ${{ inputs.mirrors }}
         NO_INSTALL_RECOMMENDS: ${{ inputs.no-install-recommends }}
         ATTEMPTS: ${{ inputs.attempts }}
         DELAY: ${{ inputs.delay }}
         DEBIAN_FRONTEND: noninteractive
       run: |
         set -euo pipefail
+        # APT_MIRRORS_FILE is overridable for the action's own offline tests;
+        # the default is the file ubuntu.sources references via mirror+file.
+        APT_MIRRORS_FILE="${APT_MIRRORS_FILE:-/etc/apt/apt-mirrors.txt}"
         if [ -z "${PACKAGES// /}" ]; then
           echo "::error::apt-install-with-retry: no packages supplied"
           exit 1
         fi
+        # ------------------------------------------------------------------
+        # Mirror fallback management. Probe each configured mirror once,
+        # fast, and write the healthy ones (in order) to the runner's
+        # mirror list. Any HTTP response counts as alive — curl fails only
+        # on transport errors (timeout, refused, no route), which is
+        # exactly the hang-forever mode this guards against.
+        # ------------------------------------------------------------------
+        if [ -f "$APT_MIRRORS_FILE" ] && [ -n "${MIRRORS// /}" ]; then
+          healthy=()
+          for mirror in $MIRRORS; do
+            if curl -sS --max-time 5 -o /dev/null "$mirror" 2>/dev/null; then
+              healthy+=("$mirror")
+              echo "mirror probe: $mirror is reachable"
+            else
+              echo "::warning::mirror probe: ${mirror} is unreachable; skipping it this run."
+            fi
+          done
+          if [ "${#healthy[@]}" -gt 0 ]; then
+            printf '%s\n' "${healthy[@]}" | sudo tee "$APT_MIRRORS_FILE" >/dev/null
+            echo "apt mirror order: ${healthy[*]}"
+          else
+            echo "::warning::no configured mirror answered its probe;" \
+              "leaving ${APT_MIRRORS_FILE} untouched and relying on timeouts + retries."
+          fi
+        fi
         # Bound every network operation: apt's default per-connection timeout
-        # is 120s, which turns one dead mirror into minutes of Ign: retries.
-        # Acquire::Retries lets apt itself retry an individual fetch (it falls
-        # back to the next mirror in the runner's mirror list on failure).
+        # is 120s. With the mirror list pre-probed these caps are defense in
+        # depth against a mirror that degrades mid-run, and Acquire::Retries
+        # lets apt retry an individual fetch against the next mirror.
         apt_opts=(
           -o Acquire::Retries=3
           -o Acquire::http::Timeout=15

--- a/.github/actions/apt-install-with-retry/action.yml
+++ b/.github/actions/apt-install-with-retry/action.yml
@@ -1,0 +1,96 @@
+name: "APT Install (with retry)"
+description: |
+  Runs `apt-get update` + `apt-get install` with bounded network timeouts and
+  a retry loop, so one flaky Ubuntu mirror cannot stall a job.
+
+  GitHub-hosted runners resolve archive.ubuntu.com through an Azure-internal
+  mirror list (/etc/apt/apt-mirrors.txt). When azure.archive.ubuntu.com is
+  unreachable, stock apt retries every index fetch against it with its default
+  120-second timeouts before falling back — observed in CI as ten minutes of
+  `Ign:` lines on `sudo apt-get update` while the job's actual tests never
+  ran, burning most of a 15-minute job timeout on a network fault the build
+  does not control.
+
+  This action bounds each connection attempt to seconds instead of minutes,
+  lets apt retry individual fetches, and re-runs the update+install pair with
+  backoff so a mid-install mirror blip (or a stale index causing 404s) is
+  self-healing. A genuinely missing package or broken dependency is not
+  masked — it still fails on the final attempt with the real apt error.
+
+  `apt-get update` and `apt-get install` are retried as one unit because a
+  failed install often means the index is stale; refreshing before every
+  install attempt is what makes the retry meaningful.
+inputs:
+  packages:
+    description: |
+      Whitespace- or newline-separated package names to install, e.g.
+      `bats jq python3-yaml`.
+    required: true
+  no-install-recommends:
+    description: |
+      Pass "true" to install with --no-install-recommends. Off by default so
+      call sites keep the exact package set they installed before adopting
+      this action (some packages rely on their recommends).
+    required: false
+    default: "false"
+  attempts:
+    description: "Total update+install attempts (default 3). Set to 1 to disable retries."
+    required: false
+    default: "3"
+  delay:
+    description: "Seconds to sleep between attempts (default 15)."
+    required: false
+    default: "15"
+runs:
+  using: "composite"
+  steps:
+    - name: apt-get update + install with retry
+      shell: bash
+      env:
+        PACKAGES: ${{ inputs.packages }}
+        NO_INSTALL_RECOMMENDS: ${{ inputs.no-install-recommends }}
+        ATTEMPTS: ${{ inputs.attempts }}
+        DELAY: ${{ inputs.delay }}
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        set -euo pipefail
+        if [ -z "${PACKAGES// /}" ]; then
+          echo "::error::apt-install-with-retry: no packages supplied"
+          exit 1
+        fi
+        # Bound every network operation: apt's default per-connection timeout
+        # is 120s, which turns one dead mirror into minutes of Ign: retries.
+        # Acquire::Retries lets apt itself retry an individual fetch (it falls
+        # back to the next mirror in the runner's mirror list on failure).
+        apt_opts=(
+          -o Acquire::Retries=3
+          -o Acquire::http::Timeout=15
+          -o Acquire::https::Timeout=15
+          -o Acquire::ConnectionAttemptDelayMsec=250
+        )
+        install_opts=(-y)
+        if [ "${NO_INSTALL_RECOMMENDS}" = "true" ]; then
+          install_opts+=(--no-install-recommends)
+        fi
+        # Word-splitting PACKAGES is intentional: one package per word.
+        # shellcheck disable=SC2086
+        set -- $PACKAGES
+        attempt=1
+        while true; do
+          echo "::group::apt-get update + install (attempt ${attempt}/${ATTEMPTS})"
+          if sudo -E apt-get "${apt_opts[@]}" update \
+             && sudo -E apt-get "${apt_opts[@]}" "${install_opts[@]}" install "$@"; then
+            echo "::endgroup::"
+            break
+          fi
+          echo "::endgroup::"
+          if [ "$attempt" -ge "$ATTEMPTS" ]; then
+            echo "::error::apt-get install of '$*' failed after ${ATTEMPTS} attempt(s)."
+            exit 1
+          fi
+          echo "::warning::apt-get update/install failed" \
+            "(attempt ${attempt}/${ATTEMPTS}); retrying in ${DELAY}s." \
+            "Usually a transient Ubuntu-mirror/network error."
+          sleep "$DELAY"
+          attempt=$((attempt + 1))
+        done

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,7 +28,8 @@ Workflows outside the four badged gates above. Most are schedule- or dispatch-dr
 
 | File | Trigger | Description |
 |------|---------|-------------|
-| `release.yml` | `workflow_dispatch` | Bump version, tag, create GitHub Release with auto-generated notes |
+| `release.yml` | `workflow_dispatch` | Stage 1 of the release: bump version files on a `release/vX.Y.Z` branch, open the release PR, and dispatch the PR-gating CI workflows against the branch (pushes/PRs made with `GITHUB_TOKEN` don't trigger `push:`/`pull_request:` runs, so required checks are attached via `workflow_dispatch` — the documented exception). Never writes to `main` |
+| `release-publish.yml` | `push`: `main` (`VERSION` only), manual | Stage 2 of the release: on the squash-merged release PR, create the annotated `vX.Y.Z` tag and the GitHub Release with auto-generated notes. Idempotent (safe to re-dispatch after a partial failure), refuses to move an existing tag, and skips VERSION changes whose commit subject isn't `Release vX.Y.Z` |
 | `deps-scan.yml` | Monthly cron + manual | Check pinned dependencies (including the autopilot Claude Code pin and companion MCP server liveness), offline accelerator/NodePool policy, and online [EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html) accelerator-catalog drift; update one rolling issue when findings exist |
 | `cve-scan.yml` | Weekly cron + manual | Re-run trivy against current CVE databases |
 | `pages.yml` | `workflow_run` after Unit Tests on `main` | Publish the project site to GitHub Pages: the MkDocs wiki (`wiki/`) at the root, the HTML coverage report at `/coverage/`, and the shields.io badge JSON at the site root. Split out of Unit Tests so a Pages outage (or wiki build failure) can't fail the test gate; `lint:mkdocs:strict` runs the same build on PRs |

--- a/.github/workflows/deps-scan.yml
+++ b/.github/workflows/deps-scan.yml
@@ -99,10 +99,11 @@ jobs:
           python-version-file: ".python-version"
           cache: "pip"
           cache-dependency-path: "requirements-lock.txt"
-      - name: Install system tooling
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends jq skopeo curl
+      - name: Install system tooling (with retry)
+        uses: ./.github/actions/apt-install-with-retry
+        with:
+          packages: jq skopeo curl
+          no-install-recommends: "true"
       - name: Install Python security tooling + AWS CLI
         run: |
           pip install -e ".[security]"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2256,11 +2256,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
-      - name: Install the latest Podman
+      - name: Install the latest Podman (with retry)
+        uses: ./.github/actions/apt-install-with-retry
+        with:
+          packages: podman
+      - name: Configure rootless Podman for CI
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y podman
           podman version
           # Rootless podman in CI has no systemd user session, so crun's sd-bus
           # calls fail ("Interactive authentication required") during build/run.
@@ -2321,7 +2323,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
-      - name: Install the latest Finch (runfinch APT repo)
+      - name: Prepare the runfinch APT repo
         run: |
           set -euo pipefail
           # runfinch-finch depends on the distro `containerd` (+ runc >= 1.1.5),
@@ -2354,9 +2356,12 @@ jobs:
           rm -f "${finch_key}"
           echo "deb [signed-by=/usr/share/keyrings/runfinch-finch-archive-keyring.gpg arch=amd64] https://artifact.runfinch.com/deb noble main" \
             | sudo tee /etc/apt/sources.list.d/runfinch-finch.list
-          sudo apt-get update
-          sudo apt-get install -y runfinch-finch
-          sudo finch --version
+      - name: Install the latest Finch (with retry)
+        uses: ./.github/actions/apt-install-with-retry
+        with:
+          packages: runfinch-finch
+      - name: Verify the Finch CLI
+        run: sudo finch --version
       - name: Start the Finch daemon stack and wait for it
         run: |
           set -uo pipefail

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,152 @@
+# =============================================================================
+# release-publish.yml — Stage 2 of 2: tag the merged release and publish
+# =============================================================================
+#
+# Fires when a push to main changes VERSION — normally the squash-merge of a
+# release/vX.Y.Z pull request opened by release.yml (stage 1). It creates the
+# annotated v-tag on the merge commit and publishes the GitHub Release with
+# generated notes. Both actions are idempotent, so a failed run can be
+# re-dispatched (workflow_dispatch) and it finishes whatever is missing.
+#
+# Guard rails:
+#   * The version files must agree (VERSION is the source of truth;
+#     gco/_version.py and cli/__init__.py must mirror it) — a drifted merge
+#     fails loudly instead of tagging an inconsistent tree.
+#   * On push events the head commit subject must be `Release vX.Y.Z`
+#     (optionally with the squash-merge `(#N)` suffix). A VERSION edit that
+#     arrives any other way is deliberately NOT auto-tagged; an operator can
+#     still publish it explicitly via workflow_dispatch after review.
+#   * A v-tag that already exists pointing at a different commit is an
+#     immutability violation and fails the run; pointing at this commit is
+#     the resume case and skips tag creation.
+#
+# Concurrency:
+#   Shares the `release` group with stage 1 so a publish never interleaves
+#   with the next release's branch cut.
+#
+# Permissions model:
+#   `contents: write` on the built-in GITHUB_TOKEN covers the tag push and
+#   the release creation. The v* tag ruleset grants the GitHub Actions app
+#   bypass for tag creation; humans cannot create or move v-tags by hand.
+#
+# =============================================================================
+
+name: Release Publish
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - VERSION
+  # Manual re-publish for a merged release whose publish run failed midway.
+  # Every step is idempotent, so re-running completes only the missing half.
+  workflow_dispatch:
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: "release:publish"
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Full history + tags: the immutability check compares any existing
+          # v-tag against the commit being published, and the annotated tag
+          # needs an authenticated push.
+          fetch-depth: 0
+          persist-credentials: true
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Resolve and verify the version
+        id: version
+        run: |
+          set -euo pipefail
+          new_version=$(tr -d '[:space:]' < VERSION)
+          mirrored=$(python3 -c "from gco._version import __version__; print(__version__)")
+          if [ "$new_version" != "$mirrored" ]; then
+            echo "VERSION ($new_version) and gco/_version.py ($mirrored) disagree; refusing to tag" >&2
+            exit 1
+          fi
+          # cli/__init__.py's literal fallback assignment (used when gco is
+          # not importable) must mirror VERSION too.
+          cli_mirrored=$(sed -n 's/^ *__version__ = "\(.*\)"$/\1/p' cli/__init__.py | head -1)
+          if [ "$new_version" != "$cli_mirrored" ]; then
+            echo "VERSION ($new_version) and cli/__init__.py ($cli_mirrored) disagree; refusing to tag" >&2
+            exit 1
+          fi
+          echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
+          echo "Publishing v$new_version"
+      - name: Require a release commit subject (push events only)
+        id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          NEW_VERSION: ${{ steps.version.outputs.new_version }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" != "push" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "workflow_dispatch: operator explicitly requested publish"
+            exit 0
+          fi
+          subject=$(git log -1 --format=%s)
+          pattern="^Release v${NEW_VERSION//./\\.}( \(#[0-9]+\))?$"
+          if printf '%s\n' "$subject" | grep -qE "$pattern"; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Release publish skipped"
+              echo ""
+              echo "VERSION changed on main, but the commit subject is:"
+              echo ""
+              echo "    ${subject}"
+              echo ""
+              echo "not \`Release v${NEW_VERSION}\`, so this was not a release PR merge."
+              echo "To publish it anyway, re-run this workflow via workflow_dispatch."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Create and push the annotated tag (idempotent)
+        if: steps.gate.outputs.publish == 'true'
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new_version }}
+        run: |
+          set -euo pipefail
+          tag="v${NEW_VERSION}"
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            tagged_commit=$(git rev-parse "${tag}^{commit}")
+            if [ "$tagged_commit" != "$GITHUB_SHA" ]; then
+              echo "Tag ${tag} already exists at ${tagged_commit}, not ${GITHUB_SHA}." >&2
+              echo "Released tags are immutable; bump the version again instead." >&2
+              exit 1
+            fi
+            echo "Tag ${tag} already points at ${GITHUB_SHA}; skipping tag creation"
+          else
+            git tag -a "v${NEW_VERSION}" -m "Release v${NEW_VERSION}" "$GITHUB_SHA"
+            git push origin "refs/tags/v${NEW_VERSION}"
+          fi
+      - name: Create GitHub Release with generated notes (idempotent)
+        if: steps.gate.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_VERSION: ${{ steps.version.outputs.new_version }}
+        # Release notes are categorized by PR label per .github/release.yml.
+        run: |
+          set -euo pipefail
+          if gh release view "v${NEW_VERSION}" >/dev/null 2>&1; then
+            echo "Release v${NEW_VERSION} already exists; skipping creation"
+            exit 0
+          fi
+          gh release create "v${NEW_VERSION}" \
+            --title "v${NEW_VERSION}" \
+            --verify-tag \
+            --generate-notes

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -26,8 +26,11 @@
 #
 # Permissions model:
 #   `contents: write` on the built-in GITHUB_TOKEN covers the tag push and
-#   the release creation. The v* tag ruleset grants the GitHub Actions app
-#   bypass for tag creation; humans cannot create or move v-tags by hand.
+#   the release creation. The v* tag ruleset blocks update, deletion, and
+#   force-push with no bypass actors, so a published tag is immutable for
+#   everyone; creation stays open (enterprise policy prevents granting the
+#   Actions app a ruleset bypass), and this workflow's existing-tag check is
+#   what refuses to re-point a released version.
 #
 # =============================================================================
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           persist-credentials: true
       - uses: actions/setup-python@v7.0.0
         with:
-          python-version: "3.14"
+          python-version-file: ".python-version"
           cache: "pip"
           cache-dependency-path: "requirements-lock.txt"
       - name: Configure git identity

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,35 @@
 # =============================================================================
-# release.yml — Manual version bump + GitHub Release
+# release.yml — Stage 1 of 2: open the version-bump release pull request
 # =============================================================================
 #
-# Replaces the GitLab "release:patch/minor/major" manual jobs. Triggered
-# from Actions → Release → Run workflow, with a `bump` input (patch/minor/major).
+# Triggered from Actions → Release → Run workflow, with a `bump` input
+# (patch/minor/major). Stage 1 never writes to main: it bumps the version
+# files on a `release/vX.Y.Z` branch, opens a pull request, and pre-dispatches
+# the PR-gating CI workflows against that branch. The release lands on main
+# through the same review-and-required-checks gate as every other change.
+#
+# Stage 2 — release-publish.yml — fires on the merge commit (push to main
+# touching VERSION) and publishes the annotated tag + GitHub Release.
+#
+# Why the explicit CI dispatch step exists:
+#   Pushes and pull requests created with the built-in GITHUB_TOKEN do not
+#   trigger `push:`/`pull_request:` workflow runs (GitHub suppresses them to
+#   prevent recursive workflows). workflow_dispatch is the documented
+#   exception, so this workflow dispatches each PR-gating workflow against
+#   the release branch; their check runs attach to the branch head SHA and
+#   satisfy the pull request's required status checks.
 #
 # Concurrency:
-#   Release runs are serialized repository-wide. A half-run release is worse
-#   than a slow one, so queued runs wait and in-progress runs are never canceled.
+#   Release runs are serialized repository-wide (shared group with stage 2).
+#   A half-run release is worse than a slow one, so queued runs wait and
+#   in-progress runs are never canceled.
 #
 # Permissions model:
-#   `contents: write` on the built-in GITHUB_TOKEN is enough for the push
-#   and the release creation. No long-lived PAT is required (unlike the
-#   retired GitLab RELEASE_TOKEN).
+#   The built-in GITHUB_TOKEN needs `contents: write` (push the release
+#   branch), `pull-requests: write` (open the release PR — also requires the
+#   repository setting "Allow GitHub Actions to create and approve pull
+#   requests"), and `actions: write` (dispatch the CI workflows). No
+#   long-lived PAT is required.
 #
 # =============================================================================
 
@@ -30,32 +47,36 @@ on:
           - minor
           - major
 
-# Serialize every release regardless of the selected ref. A second dispatch
-# waits for the active release instead of racing its version commit and tag.
+# Serialize every release, sharing one group with release-publish.yml. A
+# second dispatch waits for the active release instead of racing its
+# version branch and PR.
 concurrency:
   group: release
   cancel-in-progress: false
 
 permissions:
   contents: write
+  pull-requests: write
+  actions: write
 
 jobs:
-  release:
-    # A dispatch may select any branch or tag. Only a protected branch may
-    # receive a release commit; tags and unprotected branches are fail-closed.
-    if: github.ref_type == 'branch' && github.ref_protected
+  open-release-pr:
+    name: "release:open-pr"
+    # Releases always cut from main. A dispatch that selected a tag or any
+    # other branch is fail-closed.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
         with:
-          # Need full history + tags so git tag -a can see them, and the
-          # token must persist so the subsequent push is authenticated.
+          # Full history + tags so the bump commit sits on the real branch
+          # tip, and the token must persist so the branch push authenticates.
           fetch-depth: 0
           persist-credentials: true
       - uses: actions/setup-python@v7.0.0
         with:
-          python-version-file: ".python-version"
+          python-version: "3.14"
           cache: "pip"
           cache-dependency-path: "requirements-lock.txt"
       - name: Configure git identity
@@ -78,23 +99,84 @@ jobs:
           new_version=$(python -c "from gco._version import __version__; print(__version__)")
           echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
           echo "Bumped to v$new_version"
-      - name: Commit, tag, push
+      - name: Push release branch
         env:
           NEW_VERSION: ${{ steps.bump.outputs.new_version }}
         run: |
           set -euo pipefail
+          BRANCH="release/v${NEW_VERSION}"
+          # Refuse to release a version that already shipped. The tag is the
+          # immutable record; a duplicate means the bump input was wrong.
+          if git rev-parse -q --verify "refs/tags/v${NEW_VERSION}" >/dev/null; then
+            echo "Tag v${NEW_VERSION} already exists; refusing to open a duplicate release PR" >&2
+            exit 1
+          fi
+          git checkout -b "$BRANCH"
           git add VERSION gco/_version.py cli/__init__.py
           git commit -m "Release v${NEW_VERSION}"
-          git tag -a "v${NEW_VERSION}" -m "Release v${NEW_VERSION}"
-          # Publish the commit and its annotated tag as one transaction so a
-          # rejected ref cannot leave a branch-only or tag-only release behind.
-          git push --atomic origin "HEAD:${GITHUB_REF}" "refs/tags/v${NEW_VERSION}"
-      - name: Create GitHub Release with generated notes
+          git push origin "HEAD:refs/heads/${BRANCH}"
+      - name: Open release pull request
+        id: pr
         env:
           GH_TOKEN: ${{ github.token }}
           NEW_VERSION: ${{ steps.bump.outputs.new_version }}
-        # Release notes are categorized by PR label per .github/release.yml.
         run: |
-          gh release create "v${NEW_VERSION}" \
-            --title "v${NEW_VERSION}" \
-            --generate-notes
+          set -euo pipefail
+          BRANCH="release/v${NEW_VERSION}"
+          {
+            echo "Version bump to v${NEW_VERSION} via the two-stage release flow."
+            echo ""
+            echo "On merge, release-publish.yml tags the merge commit as v${NEW_VERSION}"
+            echo "and creates the GitHub Release with generated notes."
+            echo ""
+            echo "Merge with **squash** so the commit subject stays 'Release v${NEW_VERSION}';"
+            echo "the publish stage verifies that subject before tagging."
+          } > "${RUNNER_TEMP}/release-pr-body.md"
+          pr_url=$(gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Release v${NEW_VERSION}" \
+            --body-file "${RUNNER_TEMP}/release-pr-body.md")
+          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+          # The release PR is process noise in the next release's generated
+          # notes; the ignore-for-release label excludes it (.github/release.yml).
+          # Label application is best-effort so a missing label never blocks
+          # a release.
+          gh pr edit "$pr_url" --add-label ignore-for-release \
+            || echo "ignore-for-release label missing; continuing without it"
+      - name: Dispatch required CI on the release branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+        run: |
+          set -euo pipefail
+          BRANCH="release/v${NEW_VERSION}"
+          # Every workflow whose checks are required on main-bound PRs.
+          # grafana-dashboards.yml is deliberately absent: it is
+          # paths-filtered and not a required check, and a version-files-only
+          # diff can never touch its paths.
+          for workflow in \
+            unit-tests.yml \
+            lint.yml \
+            security.yml \
+            integration-tests.yml \
+            floci-tests.yml \
+            inference-streaming-proxy.yml \
+            mooncake-image.yml; do
+            gh workflow run "$workflow" --ref "$BRANCH"
+            echo "Dispatched $workflow on $BRANCH"
+          done
+      - name: Write run summary
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Release v${NEW_VERSION} PR opened"
+            echo ""
+            echo "- Pull request: ${PR_URL}"
+            echo "- CI was dispatched against the release branch; required checks appear on the PR as runs complete."
+            echo "- Next step: review, approve, and **squash-merge** the PR."
+            echo "- On merge, release-publish.yml tags the merge commit and publishes the GitHub Release."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -315,10 +315,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
-      - name: Install bats + deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y bats jq python3 python3-yaml bash
+      - name: Install bats + deps (with retry)
+        uses: ./.github/actions/apt-install-with-retry
+        with:
+          packages: bats jq python3 python3-yaml bash
       - name: Run BATS suite
         run: bats tests/BATS/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -719,7 +719,7 @@ No long-lived tokens are required for the GitHub Actions pipeline. The release a
 - `release-publish.yml` (stage 2) needs `contents: write` to push the release tag and create the GitHub Release. Each workflow declares its permissions at the top of the file.
 - `deps-scan.yml` needs `issues: write` to open a dependency-drift issue. Also declared at the top of the file.
 
-If you fork and run your own copy, no PAT setup is needed — the tokens are generated per-run by GitHub. Do enable the Actions PR-creation setting above, and keep a `v*` tag ruleset (with GitHub Actions as a bypass actor) if you want released tags immutable for humans.
+If you fork and run your own copy, no PAT setup is needed — the tokens are generated per-run by GitHub. Do enable the Actions PR-creation setting above, and keep a `v*` tag ruleset blocking update/deletion/force-push (no bypass actors) so released tags stay immutable; tag creation stays open for the publish workflow, whose existing-tag check refuses to re-point a released version.
 
 ### Creating a Release
 
@@ -768,9 +768,16 @@ gh pr create --base main --title "Release v1.2.3" \
 # and creates the GitHub Release with generated notes.
 ```
 
-Direct pushes of release commits or `v*` tags to `main` are blocked by
-branch protection and the `v*` tag ruleset; only the publish workflow
-creates release tags.
+Direct pushes of release commits to `main` are blocked by branch
+protection, and existing `v*` tags cannot be moved or deleted (tag
+ruleset with no bypass actors). Publishing through the workflow is the
+supported path; its guards are what keep manual mistakes out of the tag
+namespace.
+
+When a new required status check is introduced (for example a new
+cdk-nag matrix entry), add it to the branch protection required-checks
+list on `main` as part of the same PR review; a check that reports on
+every PR but isn't required is a silent gap in the merge gate.
 
 After releasing, confirm the auto-generated GitHub Release notes read well (they are categorized by PR label per `.github/release.yml`), then deploy to production environments. The GitHub Releases page is GCO's changelog — there is no separate `CHANGELOG.md` to maintain.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -713,46 +713,64 @@ We use semantic versioning (MAJOR.MINOR.PATCH):
 
 ### CI/CD Token Setup
 
-No long-lived tokens are required for the GitHub Actions pipeline. Both the release and dependency-scan workflows use the built-in `GITHUB_TOKEN`:
+No long-lived tokens are required for the GitHub Actions pipeline. The release and dependency-scan workflows use the built-in `GITHUB_TOKEN`:
 
-- `release.yml` needs `contents: write` to push the version commit, tag, and create the GitHub Release. The workflow declares this at the top of the file.
+- `release.yml` (stage 1) needs `contents: write` to push the `release/vX.Y.Z` branch, `pull-requests: write` to open the release PR, and `actions: write` to dispatch the PR-gating CI workflows against that branch. It also requires the repository Actions setting "Allow GitHub Actions to create and approve pull requests" to be enabled.
+- `release-publish.yml` (stage 2) needs `contents: write` to push the release tag and create the GitHub Release. Each workflow declares its permissions at the top of the file.
 - `deps-scan.yml` needs `issues: write` to open a dependency-drift issue. Also declared at the top of the file.
 
-If you fork and run your own copy, no setup is needed — the tokens are generated per-run by GitHub.
+If you fork and run your own copy, no PAT setup is needed — the tokens are generated per-run by GitHub. Do enable the Actions PR-creation setting above, and keep a `v*` tag ruleset (with GitHub Actions as a bypass actor) if you want released tags immutable for humans.
 
 ### Creating a Release
 
-Releases are triggered from the Actions tab:
+Releases run in two stages so `main` stays fully branch-protected — nothing,
+including the release automation, pushes to it directly.
 
 1. Go to the repository on GitHub → Actions → Release.
-2. Click "Run workflow".
-3. Pick the bump type (`patch`, `minor`, or `major`) and click "Run workflow".
+2. Click "Run workflow" on `main`, pick the bump type (`patch`, `minor`, or
+   `major`), and run it.
+3. Stage 1 (`release.yml`) bumps the version files on a `release/vX.Y.Z`
+   branch, opens a pull request titled `Release vX.Y.Z`, and dispatches the
+   PR-gating CI workflows against that branch (required checks appear on the
+   PR as those runs finish).
+4. Review, approve, and **squash-merge** the release PR. Squash keeps the
+   merge commit subject `Release vX.Y.Z (#N)`, which stage 2 verifies before
+   tagging.
+5. Stage 2 (`release-publish.yml`) fires on the merge, creates the annotated
+   `vX.Y.Z` tag on the merge commit, and creates the GitHub Release with
+   auto-generated notes (categorized per `.github/release.yml`).
 
-The workflow will:
-
-- Run `scripts/bump_version.py` with the chosen bump type.
-- Commit the version change to `main` (as `github-actions[bot]`).
-- Create and push a `v<new-version>` git tag.
-- Create a GitHub Release with auto-generated notes (categorized per `.github/release.yml`).
+If stage 2 fails partway (for example, the tag pushed but the Release wasn't
+created), re-run it from Actions → Release Publish → "Run workflow" on
+`main`; every step is idempotent and completes only what's missing. A
+VERSION change that reaches `main` without a `Release vX.Y.Z` commit subject
+is deliberately not auto-tagged — publish it explicitly the same way after
+review.
 
 #### Manual Release (Alternative)
 
-If you need to release manually:
+If you need to release without stage 1, open the version-bump PR by hand;
+merging it still triggers stage 2:
 
 ```bash
-# Bump version
+# Bump version on a release branch
+git checkout -b release/v1.2.3 main
 python scripts/bump_version.py patch  # or minor/major
 
-# Commit and tag
+# Commit and open the PR (title must stay "Release v1.2.3")
 git add VERSION gco/_version.py cli/__init__.py
 git commit -m "Release v1.2.3"
-git tag -a v1.2.3 -m "Release v1.2.3"
-git push origin main
-git push origin v1.2.3
+git push -u origin release/v1.2.3
+gh pr create --base main --title "Release v1.2.3" \
+  --body "Manual version bump. release-publish.yml tags on merge."
 
-# Create the GitHub Release with generated notes
-gh release create v1.2.3 --generate-notes
+# After approval, squash-merge; release-publish.yml tags the merge commit
+# and creates the GitHub Release with generated notes.
 ```
+
+Direct pushes of release commits or `v*` tags to `main` are blocked by
+branch protection and the `v*` tag ruleset; only the publish workflow
+creates release tags.
 
 After releasing, confirm the auto-generated GitHub Release notes read well (they are categorized by PR label per `.github/release.yml`), then deploy to production environments. The GitHub Releases page is GCO's changelog — there is no separate `CHANGELOG.md` to maintain.
 

--- a/tests/test_supply_chain_integrity.py
+++ b/tests/test_supply_chain_integrity.py
@@ -305,12 +305,61 @@ def test_incomplete_reports_do_not_claim_zero_count_surfaces_are_current() -> No
     assert "Zero-count surfaces are provisional, not confirmed current." in scanner
 
 
-def test_release_publishes_branch_and_tag_atomically() -> None:
+def test_release_stage_one_never_writes_to_main() -> None:
+    """Stage 1 (release.yml) must go through the PR gate like any other change.
+
+    The version bump lands on a release/vX.Y.Z branch and merges through
+    review + required checks. Direct pushes to the dispatching ref, tag
+    creation, and GitHub Release creation are stage-2 concerns; any of them
+    reappearing here would bypass branch protection.
+    """
     workflow = _read(".github/workflows/release.yml")
 
-    assert ('git push --atomic origin "HEAD:${GITHUB_REF}" "refs/tags/v${NEW_VERSION}"') in workflow
-    assert 'git push origin "HEAD:${GITHUB_REF}"' not in workflow
-    assert 'git push origin "v${NEW_VERSION}"' not in workflow
+    assert 'git push origin "HEAD:refs/heads/${BRANCH}"' in workflow
+    assert "HEAD:${GITHUB_REF}" not in workflow
+    assert "HEAD:refs/heads/main" not in workflow
+    assert "git tag" not in workflow
+    assert "gh release create" not in workflow
+    # Only from main: a dispatch on a tag or side branch is fail-closed.
+    assert "if: github.ref == 'refs/heads/main'" in workflow
+
+
+def test_release_stage_two_publishes_only_the_merged_release_commit() -> None:
+    """Stage 2 (release-publish.yml) tags main's merge commit, idempotently.
+
+    It reacts only to main pushes that change VERSION, refuses to move an
+    existing v-tag (immutability), verifies every version mirror agrees
+    before tagging, and gates push-event publishes on the `Release vX.Y.Z`
+    commit subject so a stray VERSION edit is never auto-tagged.
+    """
+    workflow = _read(".github/workflows/release-publish.yml")
+
+    assert "branches: [main]" in workflow
+    assert "- VERSION" in workflow
+    assert 'git tag -a "v${NEW_VERSION}" -m "Release v${NEW_VERSION}" "$GITHUB_SHA"' in workflow
+    assert 'git push origin "refs/tags/v${NEW_VERSION}"' in workflow
+    assert "--verify-tag" in workflow
+    # Immutability + idempotency guards.
+    assert "Released tags are immutable" in workflow
+    assert "already points at" in workflow
+    assert "gh release view" in workflow
+    # Version mirrors must agree before anything is published.
+    assert "refusing to tag" in workflow
+    # Push-event publishes require a release commit subject.
+    assert 'pattern="^Release v${NEW_VERSION//./\\\\.}( \\(#[0-9]+\\))?$"' in workflow
+
+
+def test_release_workflows_share_one_serialized_concurrency_group() -> None:
+    """Both stages share `group: release` and never cancel in-flight runs.
+
+    A publish interleaving with the next release's branch cut (or a canceled
+    half-publish) is exactly the torn state the old single-stage atomic push
+    protected against; the shared no-cancel group is its replacement.
+    """
+    for path in (".github/workflows/release.yml", ".github/workflows/release-publish.yml"):
+        workflow = _read(path)
+        assert "group: release" in workflow, path
+        assert "cancel-in-progress: false" in workflow, path
 
 
 def test_model_sync_uses_an_immutable_official_aws_cli_image() -> None:


### PR DESCRIPTION
## Summary

Enacting production-grade branch protection on `main` (required PRs, 1 approval, required status checks, no bypass actors) breaks the current release workflow, which pushes the `Release vX.Y.Z` commit and tag directly to `main`. This PR splits the release into two stages that go through the same gate as every other change:

- **`release.yml` (stage 1)** — dispatched from `main`: bumps the version files on a `release/vX.Y.Z` branch, opens the release PR, and dispatches the PR-gating CI workflows against the branch. `GITHUB_TOKEN`-created pushes/PRs never trigger `push:`/`pull_request:` runs, so required checks are attached via `workflow_dispatch` (the documented exception). Fails closed if the target tag already exists.
- **`release-publish.yml` (stage 2, new)** — on `main` pushes touching `VERSION` (plus manual re-dispatch): verifies all three version mirrors agree, requires the `Release vX.Y.Z` commit subject on push events (a stray VERSION edit is never auto-tagged), creates the annotated tag on the merge commit (refuses to move an existing tag), and creates the GitHub Release with generated notes. Idempotent end to end.

Both stages share the no-cancel `release` concurrency group, replacing the old atomic branch+tag push as the torn-release protection. Supply-chain tests now pin the new invariants (stage 1 never writes to main/tags/releases; stage 2 immutability + idempotency + subject gate). Docs updated: `.github/CI.md`, `.github/workflows/README.md`, `CONTRIBUTING.md`.

Repo-settings companion (applied outside this PR): squash-only merges, auto-delete head branches, Actions allowed to create PRs, a `v*` tag ruleset with GitHub Actions as the only bypass actor, and classic branch protection on `main` with the 80 always-reporting checks required.

## Type of change

- [x] `ci:` CI / tooling change

## Testing

- [x] `pytest tests/test_supply_chain_integrity.py tests/test_live_release_validation.py tests/test_ci_config_paths.py` — 162 passed
- [x] `actionlint` + `yamllint` (repo config) clean on both workflows
- [x] `markdownlint-cli2` (repo config) clean on the three touched docs
- [x] Stage-2 guard logic (subject regex, version-mirror extraction) exercised locally against real repo files

## Live release validation

- [x] Not required (explain the applicability decision below)

**Applicability rationale:** CI/workflow + docs + test changes only; no deployed infrastructure, lifecycle, permission, or runtime behavior changes.

## Checklist

- [x] Documentation updated (README, `docs/`, inline docstrings) as needed
- [x] No secrets, credentials, or customer data committed
- [x] `requirements-lock.txt` regenerated if `pyproject.toml` changed (not applicable)
- [x] Changes align with the architecture described in `docs/ARCHITECTURE.md`