### PR TITLE
chore: pin cross-stack reference strength to "strong"

### DIFF
--- a/.github/config/.trivyignore
+++ b/.github/config/.trivyignore
@@ -78,6 +78,35 @@ CVE-2026-42506 exp:2026-09-22
 # drop this entry. Advisory: https://avd.aquasec.com/nvd/cve-2026-34040
 CVE-2026-34040 exp:2026-09-22
 
+# CVE-2026-17106 (GHSA-hfg8-hc9c-6c3h) — github.com/moby/go-archive v0.2.1: a
+# crafted tar archive can write outside the extraction directory during
+# untar. Statically linked into the docker-buildx CLI plugin that
+# Dockerfile.dev installs (ARG BUILDX_VERSION). Surfaced by
+# security:trivy:container-scan on the GCO dev image — the only scanned image
+# that carries the Buildx plugin. Fixed in moby/go-archive 0.3.0.
+#
+# Not introduced by any change of ours: the GHSA was published
+# 2026-08-18T21:17Z and reached the Trivy DB in the following hours. The
+# Security workflow was green on main at eeeab67 (2026-08-18T20:50Z), 27
+# minutes before publication, so this appeared on an unchanged buildx binary.
+#
+# Not clearable by a pin bump: checked 2026-08-19 — v0.36.1 (the release this
+# ARG already pins) is the latest buildx on any dist-tag, and its go.mod
+# requires moby/go-archive v0.2.1. buildx master is on v0.2.0, older still, so
+# the bump to >= 0.3.0 has not landed upstream at all yet — there is no
+# release or branch to move to.
+#
+# Low runtime risk: the flagged path is tar extraction. buildx is a
+# build-time CLI plugin that extracts contexts and cache artifacts authored by
+# the contributor or CI invoking it, plus the version-pinned images it pulls —
+# not attacker-supplied archives. The dev image is a contributor/CI tool that
+# is never deployed to a cluster.
+#
+# Clears when a buildx release ships requiring moby/go-archive >= 0.3.0: bump
+# BUILDX_VERSION in Dockerfile.dev (the monthly deps-scan tracks it) and drop
+# this entry. Advisory: https://avd.aquasec.com/nvd/cve-2026-17106
+CVE-2026-17106 exp:2026-10-15
+
 # CVE-2026-14257 (GHSA-mh99-v99m-4gvg) — brace-expansion denial of service via
 # unbounded expansion length, causing an out-of-memory process crash. Present in
 # the copy npm vendors inside its own node_modules

--- a/cdk.json
+++ b/cdk.json
@@ -441,6 +441,8 @@
     "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
     "@aws-cdk/aws-stepfunctions-tasks:enableLogging": true,
     "@aws-cdk/core:checkSecretUsage": true,
+    "_comment_defaultCrossStackReferences": "Strength of cross-stack references. Pinned to 'strong' (CDK's own default) to lock in producer-protecting behavior and silence the unset-flag warning — synthesized templates are unchanged from every prior GCO release. 'strong' means same-region references use Fn::ImportValue and cross-region references (GCOMonitoringStack consuming FSx/Aurora identifiers from the regional stacks via cross_region_references=True) use a pair of ExportWriter/ExportReader custom resources, whose CloudFormation response bodies are capped at 4096 bytes. Migrating to 'weak' would swap all of that for Fn::GetStackOutput — no custom resources, no size cap, no deadly embrace — but it is NOT a drop-in edit: existing deployments must go 'strong' -> 'both' -> deploy every stack in every Region -> 'weak' -> deploy again, and Fn::GetStackOutput availability outside the commercial 'aws' partition must be confirmed first. Do not change this value without that migration.",
+    "@aws-cdk/core:defaultCrossStackReferences": "strong",
     "@aws-cdk/core:enablePartitionLiterals": true,
     "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
     "@aws-cdk/core:stackRelativeExports": true,


### PR DESCRIPTION
## Summary

CDK started emitting this on every synth:

```text
No cross-stack-reference strength configured, defaulting to "strong". We recommend you set
feature flag "@aws-cdk/core:defaultCrossStackReferences" to "both", then deploy everywhere,
then set it to "weak". Alternatively, set it to "strong" explicitly to lock in the current
producer-protecting behavior.
```

This pins the flag to `"strong"` — CDK's own fallback when the key is absent — so the warning
goes away **without changing what deploys**. Two lines in `cdk.json`: the flag plus a
`_comment_` sibling following the file's documented convention.

This is deliberately only the no-op half of the warning's advice. See below for why the rest
is not in scope.

### Why not go straight to `"weak"`

`"weak"` is genuinely better for GCO. `GCOMonitoringStack` sets `cross_region_references=True`
to pull FSx file system IDs and Aurora cluster identifiers out of the regional stacks. Under
`"strong"` that is realized as an `ExportWriter`/`ExportReader` custom-resource pair, whose
CloudFormation response bodies are capped at 4096 bytes, and which this repo already documents
as racy — `gco/stacks/monitoring_stack.py` records abandoning one such reference because it
"races the custom-resource response pipeline". `"weak"` replaces all of it with
`Fn::GetStackOutput`: no custom resources, no size cap, no deadly embrace.

It is not a drop-in edit, though:

1. Existing deployments must go `"strong"` -> `"both"` -> deploy every stack in every Region ->
   `"weak"` -> deploy again. Jumping straight to `"weak"` breaks in-place upgrades.
2. `"both"` is not silent either — it swaps this warning for a `crossStackReferencesBothTransitional`
   one, so the middle step is noisy until the migration lands.
3. `Fn::GetStackOutput` availability outside the commercial `aws` partition needs confirming
   first, given GCO's partition-awareness commitments.

That migration deserves its own change. The `_comment_` sibling records the procedure so the
next person does not attempt it as a one-liner.

## Type of change

- [x] `chore:` Maintenance (dep bumps, etc.)

## Testing

- [x] `pytest tests/` passes locally — `tests/test_cdk_config_consumption.py`, 31 passed. Confirms
      both the `@aws-cdk` flag and the `_comment_` key are correctly exempted from the dead-config guard.
- [ ] `cdk synth` succeeds (if CDK code changed) — **see note below**
- [ ] New tests added for new behavior
- [ ] Ran the change against a real AWS account (describe below)

### Verification detail

`cdk synth` does not currently run on my machine, for reasons unrelated to this change.
`gco/stacks/nag_suppressions.py:238` calls `AwsSolutionsChecks(scope, verbose=verbose)` and the
locally installed cdk-nag rejects that positional signature:

```text
TypeError: AwsSolutionsChecks.__init__() takes 1 positional argument but 2 positional arguments
(and 1 keyword-only argument) were given
```

I confirmed this is pre-existing by stashing the flag and re-synthing the untouched baseline —
identical failure. Looks like local dependency drift under Python 3.14 rather than something CI
would hit, but flagging it in case others see it. **Relying on CI for the full-synth signal here.**

To verify the actual claim, I built a throwaway two-stack app that reads the real `cdk.json`
context and synthesizes a same-region cross-stack reference both with and without the pin:

| | warnings | `Fn::ImportValue` | `Fn::GetStackOutput` |
|---|---|---|---|
| with pin | 0 | yes | no |
| without pin | 1 (this exact warning) | yes | no |

Warning silenced, templates identical. That is the claim that matters — the pin changes nothing
about what deploys. I also read the emission logic in `aws-cdk-lib/core/lib/private/refs.js` to
confirm the semantics written into the `_comment_`: `"strong"` is the fallback when the key is
unset, `"both"` carries its own transitional nag, and cross-region strong references route through
`createCrossRegionImportValue` / `ExportWriter`.

## Live release validation

- [x] Not required (explain the applicability decision below)

**Applicability rationale:** Configuration-only change to a CDK feature flag, pinned to the value
CDK already defaults to when the key is absent. Synthesized templates are unchanged, so there is
no deployed effect to validate. The change that *would* need live validation is the future
`"strong"` -> `"both"` -> `"weak"` migration, which is explicitly not in this PR.

## Checklist

- [x] Documentation updated (README, `docs/`, inline docstrings) as needed — `_comment_` sibling in `cdk.json`
- [x] No secrets, credentials, or customer data committed
- [x] `requirements-lock.txt` regenerated if `pyproject.toml` changed — n/a, no dependency change
- [x] Changes align with the architecture described in `docs/ARCHITECTURE.md`


---

## Addendum: unblocking `security:trivy:container-scan (dev, Dockerfile.dev)`

The first CI run on this branch went 58 pass / 1 fail. The failure is unrelated to the flag pin
and would hit any PR opened right now:

```text
github.com/moby/go-archive  CVE-2026-17106  HIGH  fixed  v0.2.1  ->  0.3.0
  moby/go-archive: Crafted tar archive can write outside the extraction directory
usr/local/lib/docker/cli-plugins/docker-buildx (gobinary)
```

Not introduced by this branch. `GHSA-hfg8-hc9c-6c3h` published `2026-08-18T21:17Z`; the Security
workflow was green on `main` at `eeeab67` at `2026-08-18T20:50Z` — 27 minutes earlier, on the same
unchanged buildx binary. The Trivy DB picked it up in between.

**Tried the bump first; it does not exist yet.** `Dockerfile.dev` already pins
`BUILDX_VERSION=v0.36.1`, which is the newest buildx release (2026-08-04), and its `go.mod`
requires `moby/go-archive v0.2.1` — precisely the flagged version. buildx `master` is on `v0.2.0`,
older still. So the move to the fixed `0.3.0` has not landed upstream on any release or branch,
and there is nothing to bump to.

Added a dated suppression to `.github/config/.trivyignore` instead, following that file's rules:
advisory link, the version evidence above, runtime-risk rationale, and the condition that clears it
(`exp:2026-10-15`). Risk rationale in short — the flagged path is tar extraction, buildx extracts
contexts and cache artifacts authored by the contributor or CI invoking it plus version-pinned
images rather than attacker-supplied archives, and the dev image is contributor/CI tooling that is
never deployed to a cluster.

Verified with `tests/test_trivyignore_validator.py` and `tests/test_dependency_pin_consistency.py`,
7 passed, which enforce the `exp:` marker and non-expiry across all 23 entries.

If you would rather keep this PR to the single-line flag pin, I am happy to split the suppression
into its own PR — it is a self-contained second commit (`9154126`).
