### PR TITLE
chore(deps): bump codeql-action atomically; group lockstep dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,15 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    # codeql-action's subpath actions (init, analyze) live in one repo and
+    # must move to one commit together: lint:actions:pinning requires every
+    # reference to an action repo to resolve to a single SHA, so per-subpath
+    # PRs (observed as #287/#284) can never pass CI individually. Grouping
+    # makes Dependabot open one atomic PR for the whole repo.
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
 
   # Composite actions under .github/actions/*/action.yml.
   #
@@ -52,6 +61,12 @@ updates:
       - "github-actions"
 
   # Locked repository tooling (AWS CDK CLI, cdk-dia, markdownlint-cli2).
+  #
+  # Grouped for CI economy: these are independent tools, but their
+  # minor/patch updates are low-risk and each separate PR costs a full
+  # ~90-check CI run plus a lockfile rebase of every sibling PR. Majors are
+  # deliberately excluded from the group so a breaking bump still arrives
+  # as its own reviewable PR.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -61,8 +76,21 @@ updates:
     open-pull-requests-limit: 3
     labels:
       - "dependencies"
+    groups:
+      repo-tooling-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Bundled AWS SDK clients for the inference response-streaming Lambda.
+  #
+  # The @aws-sdk/* clients version in lockstep from one monorepo release
+  # train; ungrouped they arrive as one PR per client (observed as
+  # #286/#285/#283 for a single release), each invalidating the others'
+  # package-lock.json. One grouped PR is the semantically honest unit.
+  # Majors stay individual for scrutiny.
   - package-ecosystem: "npm"
     directory: "/lambda/inference-streaming-proxy"
     schedule:
@@ -72,6 +100,13 @@ updates:
     open-pull-requests-limit: 3
     labels:
       - "dependencies"
+    groups:
+      aws-sdk-minor-patch:
+        patterns:
+          - "@aws-sdk/*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Service image base layers.
   - package-ecosystem: "docker"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -538,7 +538,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
         with:
           languages: ${{ matrix.language }}
           # Pins paths, paths-ignore, and query-filters used by the scan.
@@ -549,7 +549,7 @@ jobs:
       # (``NotADirectoryError`` on single-file ``paths:`` entries) so
       # we avoid invoking it.
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
         with:
           category: "/language:${{ matrix.language }}"
 
@@ -568,11 +568,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
         with:
           languages: javascript-typescript
           config-file: ./.github/codeql/codeql-config.yml
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
         with:
           category: "/language:javascript-typescript"


### PR DESCRIPTION
## Summary

Dependabot's per-subpath PRs for `github/codeql-action` (#287, #284) can never pass CI individually: `lint:actions:pinning` requires every reference to one action repo to resolve to a single commit, and each PR leaves `init`/`analyze` split across v4.37.6/v4.37.7 (the CodeQL jobs themselves fail on the mix too).

- Bumps all four `codeql-action` references to v4.37.7 in one commit; the pinned SHA `ff2f1c62…` was verified upstream (the `v4.37.7` annotated tag resolves to exactly that commit)
- Adds a Dependabot `groups` entry for `github/codeql-action*` so future bumps arrive as one atomic PR
- Groups minor/patch npm updates in both ecosystems: the streaming Lambda's `@aws-sdk/*` clients version in lockstep from one monorepo release train (one release recently arrived as three mutually lockfile-invalidating PRs: #286/#285/#283), and root tooling PRs each cost a full CI run. Majors are excluded from every group so breaking bumps still arrive as individual PRs
- Python intentionally stays out of Dependabot (pip-compile-owned lock + monthly scan), per the existing header comment

## Testing

- `python .github/scripts/verify_action_pins.py --verify-upstream` → OK (150 refs, upstream-resolved)
- `yamllint` on both files clean; `actionlint` on security.yml clean
- `tests/test_workflow_security_contract.py` → 113 passed (includes the dependabot-coverage contract)

Closes #287. Closes #284.
