### PR TITLE
fix: ignore volumes EC2 is already deleting in the residual-volume gate

### DIFF
--- a/scripts/live_release_validation/inventory/scanners.py
+++ b/scripts/live_release_validation/inventory/scanners.py
@@ -275,6 +275,11 @@ def _ec2_items(client: Any, operation: str, response_key: str) -> list[dict[str,
 
 _CLUSTER_TAG_PREFIX = "kubernetes.io/cluster/"
 
+#: Volume states that mean EC2 is already removing the volume, so it is not
+#: residual. Everything else -- ``available``, ``in-use``, ``creating``,
+#: ``error`` -- counts against the all-zero teardown gate.
+_VOLUME_TERMINAL_STATES = frozenset({"deleting", "deleted"})
+
 
 def _list_cluster_volumes(session: Any, region: str, project_name: str) -> list[str]:
     """Return EBS volumes tagged for a project cluster by the EKS CSI driver.
@@ -288,9 +293,16 @@ def _list_cluster_volumes(session: Any, region: str, project_name: str) -> list[
 
     Ownership is decided from the cluster name inside the tag key, which is the
     regional stack name, so a volume belonging to another project's cluster in
-    the same account is never claimed. State is deliberately not filtered: any
-    surviving volume tagged for a project cluster is residual, whether it is
-    ``available``, still detaching, or in ``error``.
+    the same account is never claimed.
+
+    Volumes EC2 is already removing (``deleting``/``deleted``) are not counted.
+    The cluster tag is not exclusive to CSI-provisioned PersistentVolumes: EKS
+    Auto Mode writes it onto node root volumes too, which live and die with
+    their instances. Those pass through ``deleting`` while a cluster tears
+    down, and a run that observed one mid-transition would fail the all-zero
+    gate for a volume that was already on its way out. Every other state --
+    ``available``, ``in-use``, ``creating``, ``error`` -- still counts, because
+    after teardown nothing should be holding a cluster-tagged volume at all.
 
     Enumerates unfiltered and matches client-side, like the other EC2 scanners
     here. A server-side ``tag-key`` filter would need wildcard semantics to
@@ -303,6 +315,8 @@ def _list_cluster_volumes(session: Any, region: str, project_name: str) -> list[
         volume_id = str(volume.get("VolumeId") or "")
         if not volume_id:
             raise RuntimeError(f"EC2 returned a volume without an ID in {region}")
+        if str(volume.get("State") or "") in _VOLUME_TERMINAL_STATES:
+            continue
         for key in _tags_to_dict(volume.get("Tags", [])):
             if not key.startswith(_CLUSTER_TAG_PREFIX):
                 continue

--- a/tests/test_floci_harness_inventory.py
+++ b/tests/test_floci_harness_inventory.py
@@ -178,6 +178,56 @@ class TestProjectResourceScanners:
         )
 
 
+class TestClusterVolumeResidualScoping:
+    """The cluster tag is shared with node root volumes, which are not leaks."""
+
+    def test_a_volume_already_being_deleted_is_not_residual(self, harness_session, floci_account):
+        from scripts.live_release_validation.inventory.project import (
+            collect_project_resources,
+            project_resources_are_absent,
+        )
+
+        project = unique_name("gcovolstate").replace("-", "")[:14]
+        region = "us-east-1"
+        ec2 = boto3.client("ec2", region_name=region)
+        zone = ec2.describe_availability_zones()["AvailabilityZones"][0]["ZoneName"]
+        volume_id = ec2.create_volume(
+            AvailabilityZone=zone,
+            Size=1,
+            VolumeType="gp3",
+            TagSpecifications=[
+                {
+                    "ResourceType": "volume",
+                    "Tags": [
+                        {"Key": f"kubernetes.io/cluster/{project}-{region}", "Value": "owned"}
+                    ],
+                }
+            ],
+        )["VolumeId"]
+        ec2.get_waiter("volume_available").wait(VolumeIds=[volume_id])
+
+        def inventory():
+            return collect_project_resources(
+                harness_session,
+                enabled_regions=[region],
+                expected_account=floci_account,
+                project_name=project,
+                seed_region=region,
+            )
+
+        # While it exists it is residual and must fail the gate.
+        assert project_resources_are_absent(inventory()) is False
+
+        # Once EC2 is removing it, it must not. An EKS Auto Mode node root
+        # volume carries the same tag and passes through this state on every
+        # teardown; counting it would fail the gate for a volume already gone.
+        ec2.delete_volume(VolumeId=volume_id)
+        ec2.get_waiter("volume_deleted").wait(VolumeIds=[volume_id])
+        assert project_resources_are_absent(inventory()) is True, (
+            "a volume EC2 has finished removing must not count against the all-zero teardown gate"
+        )
+
+
 class TestProtectedBaseline:
     def test_baseline_is_stable_and_detects_protected_stack_loss(self, harness_session):
         from scripts.live_release_validation.inventory.project import (

--- a/tests/test_live_release_validation.py
+++ b/tests/test_live_release_validation.py
@@ -2938,10 +2938,61 @@ class TestProtectedBaselineIdentity:
         assert volumes == ["vol-00000000000000001"]
         ec2.get_paginator.assert_called_once_with("describe_volumes")
         # Enumerated unfiltered and matched client-side, like the sibling EC2
-        # scanners: no dependence on server-side tag-key wildcard semantics, and
-        # no state filter, since a volume still detaching or in error is just as
-        # residual as an available one.
+        # scanners: no dependence on server-side tag-key wildcard semantics.
         paginator.paginate.assert_called_once_with()
+
+    def test_cluster_volume_scanner_ignores_volumes_already_being_deleted(self) -> None:
+        """EKS Auto Mode node root volumes share the cluster tag and die with
+        their instances; one observed mid-``deleting`` is not a leak."""
+        ec2 = MagicMock()
+        ec2.get_paginator.return_value.paginate.return_value = [
+            {
+                "Volumes": [
+                    {
+                        "VolumeId": "vol-00000000000000010",
+                        "State": "deleting",
+                        "Tags": [
+                            {"Key": "kubernetes.io/cluster/gco-live-us-east-1", "Value": "owned"}
+                        ],
+                    },
+                    {
+                        "VolumeId": "vol-00000000000000011",
+                        "State": "deleted",
+                        "Tags": [
+                            {"Key": "kubernetes.io/cluster/gco-live-us-east-1", "Value": "owned"}
+                        ],
+                    },
+                ]
+            }
+        ]
+        session = MagicMock()
+        session.client.return_value = ec2
+
+        assert inventory_scanners._list_cluster_volumes(session, self._REGION, "gco-live") == []
+
+    @pytest.mark.parametrize("state", ["available", "in-use", "creating", "error"])
+    def test_cluster_volume_scanner_counts_every_non_terminal_state(self, state: str) -> None:
+        """After teardown nothing should hold a cluster-tagged volume at all."""
+        ec2 = MagicMock()
+        ec2.get_paginator.return_value.paginate.return_value = [
+            {
+                "Volumes": [
+                    {
+                        "VolumeId": "vol-00000000000000020",
+                        "State": state,
+                        "Tags": [
+                            {"Key": "kubernetes.io/cluster/gco-live-us-east-1", "Value": "owned"}
+                        ],
+                    }
+                ]
+            }
+        ]
+        session = MagicMock()
+        session.client.return_value = ec2
+
+        volumes = inventory_scanners._list_cluster_volumes(session, self._REGION, "gco-live")
+
+        assert volumes == ["vol-00000000000000020"]
 
     def test_cluster_volume_scanner_rejects_a_volume_without_an_id(self) -> None:
         ec2 = MagicMock()


### PR DESCRIPTION
## Summary

Follow-up to #297 (shipped in v6.5.0), fixing a false-positive risk in the validation gate that PR introduced.

The `cluster_volumes` scanner counted any volume tagged `kubernetes.io/cluster/<cluster>` as residual regardless of state. That tag is not exclusive to CSI-provisioned PersistentVolumes — **EKS Auto Mode writes it onto node root volumes too**, which live and die with their instances and pass through `deleting` on every teardown. A run that happened to observe one mid-transition would have failed the all-zero `final-inventory` gate for a volume that was already on its way out.

Volumes in `deleting` or `deleted` are now skipped. Every other state still counts — `available`, `in-use`, `creating`, `error` — because after teardown nothing should be holding a cluster-tagged volume at all.

### Scope

**Harness-only. No runtime behavior changes.** The sweep in `cli/stacks.py` was never affected: it requires `available` plus zero attachments, so attached node volumes were always skipped. The live validation of #297 confirmed this empirically — node root volumes (80 GiB and 4 GiB, `in-use`) were left untouched while both stranded PersistentVolumes were deleted.

### How this surfaced

This came out of the live validation run for #297, not from review. Node root volumes sharing the CSI driver's cluster tag is not something the mocked tests could reveal, because the fixtures only ever contained volumes the tests themselves created. It is the kind of thing only a real deploy shows you.

## Type of change

- [x] `fix:` Bug fix (non-breaking)

## Testing

- [x] New tests added for new behavior
- [x] `ruff check`, `ruff format --check`, strict `mypy` clean
- [x] 379 targeted tests pass (`test_live_release_validation`, `..._structure`, `test_stacks_extended_coverage`, `test_stacks_destroy_hardening`, `test_docs_coverage`)

- **Unit:** a test for both terminal states (`deleting`, `deleted`) yielding an empty result, and a parametrized test pinning the four states that still count.
- **Floci:** `TestClusterVolumeResidualScoping` creates a real cluster-tagged volume, asserts the all-zero gate *fails* while it exists, deletes it, waits on `volume_deleted`, and asserts the gate then passes. Verified green against a local `floci/floci:1.7.0` (10/10 floci tests).

`requirements-lock.txt` not regenerated: no dependency changes.

## Live release validation

- [x] Required and completed for this exact SHA (`df94acf`); sanitized `PASSED` summary posted on this PR

**Result:** all 12 actions passed against a real account (2h59m). Mid-teardown the Region held both stranded PersistentVolumes (`available`) and four EKS Auto Mode node root volumes (`in-use`) under the same cluster tag — the exact shared-tag condition this patch addresses. The sweep deleted only the two stranded PVs (55 GiB, same split as the v6.5.0 run but different volume IDs and AZ, so the leak reproduces as a property of StatefulSet `volumeClaimTemplates` rather than one deployment). `final-inventory` passed all-zero with `cluster_volumes: 0`, and a post-teardown scan returns 0.

## Checklist

- [x] Documentation updated (inline docstrings)
- [x] No secrets, credentials, or customer data committed

Refs #268
