### PR TITLE
docs: acknowledge Solutions Library help, internal advocates, and early testers

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -20,4 +20,12 @@ This project would not have been possible without the support of some incredible
 
 **Anindith Reddy Bujala** — For getting the solution published to the AWS Solutions Library and helping land the project in its new home under `aws-solutions-library-samples`.
 
+**John Dzialo** — For being an early tester and adopter of the project.
+
+**Mark Vinciguerra** — For being an early tester and adopter of the project.
+
+**Pascal Dao** — For being an early tester and adopter of the project.
+
+**Sagar Dubey** — For being an early tester and adopter of the project.
+
 And to the countless other AWS colleagues who contributed feedback, tested early versions, and helped navigate the open-source process — thank you.

--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -16,4 +16,8 @@ This project would not have been possible without the support of some incredible
 
 **Carlos Manzanedo Rueda** — For helping navigate security reviews and getting the project released.
 
+**Daniel Zilberman** — For getting the solution published to the AWS Solutions Library and helping land the project in its new home under `aws-solutions-library-samples`.
+
+**Anindith Reddy Bujala** — For getting the solution published to the AWS Solutions Library and helping land the project in its new home under `aws-solutions-library-samples`.
+
 And to the countless other AWS colleagues who contributed feedback, tested early versions, and helped navigate the open-source process — thank you.

--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -20,6 +20,10 @@ This project would not have been possible without the support of some incredible
 
 **Anindith Reddy Bujala** — For getting the solution published to the AWS Solutions Library and helping land the repository in its new GitHub home.
 
+**Joshua Yoon** — For being an important internal advocate for the project.
+
+**Luka Ralic** — For being an important internal advocate for the project.
+
 **John Dzialo** — For being an early tester and adopter of the project.
 
 **Mark Vinciguerra** — For being an early tester and adopter of the project.

--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -16,9 +16,9 @@ This project would not have been possible without the support of some incredible
 
 **Carlos Manzanedo Rueda** — For helping navigate security reviews and getting the project released.
 
-**Daniel Zilberman** — For getting the solution published to the AWS Solutions Library and helping land the project in its new home under `aws-solutions-library-samples`.
+**Daniel Zilberman** — For getting the solution published to the AWS Solutions Library and helping land the repository in its new GitHub home.
 
-**Anindith Reddy Bujala** — For getting the solution published to the AWS Solutions Library and helping land the project in its new home under `aws-solutions-library-samples`.
+**Anindith Reddy Bujala** — For getting the solution published to the AWS Solutions Library and helping land the repository in its new GitHub home.
 
 **John Dzialo** — For being an early tester and adopter of the project.
 


### PR DESCRIPTION
## Summary

Three additions to `ACKNOWLEDGMENTS.md`.

**Solutions Library and the repository move** — @dzilbermanvmw and @anindith123, for getting the solution published to the [AWS Solutions Library](https://docs.aws.amazon.com/solutions/eks-automode-clusters-with-global-capacity-orchestrator-on-aws/) and helping land the repository in its new GitHub home.

**Internal advocates** — Joshua Yoon and Luka Ralic, for advocating for the project internally.

**Early testers and adopters** — John Dzialo (@JohnDzialo), Mark Vinciguerra (@mvinci12), Pascal Dao, and Sagar Dubey (@sagarneeldubey), for running the project before it was public and feeding back what they found.

All follow the existing entry style for this file: one entry per person, name plus contribution, no titles. Appended ahead of the closing catch-all paragraph, leaving the original entries and their order untouched.

Names were verified against GitHub profiles rather than transcribed — this corrected one spelling. Handles are omitted where the person could not be identified unambiguously (Pascal Dao matches two accounts; Joshua Yoon matches several; Luka Ralic matches none).

### Note on the reworded org reference

The first draft described the new home as `` `aws-solutions-library-samples` `` literally, which failed `test_every_upstream_reference_is_classified`: every occurrence of the upstream org name must be claimed by a rule in `scripts/migrate_fork.py`, and a bare mention in prose matches none of them. These were the only such mentions outside the three `SELF_REFERENTIAL_PATHS` files.

Reworded rather than adding a rule. Adding this file to `SELF_REFERENTIAL_PATHS` would misuse a set reserved for files describing the migration tool itself and would exempt it from genuine future rewrites, and a catch-all preservation rule would blunt a gate whose value is failing loudly on an unclassified form. Naming the org literally added nothing to the credit.

## Type of change

- [x] `docs:` Documentation only

## Testing

- [x] `markdownlint-cli2` clean against the repo config (0 issues)
- [x] `tests/test_migrate_fork.py` (29) and `tests/test_docs_coverage.py` (4) pass

## Checklist

- [x] No secrets, credentials, or customer data committed