### PR TITLE
fix: suppress the Buildx grpc-go OOM CVE blocking main

### DIFF
--- a/.github/config/.trivyignore
+++ b/.github/config/.trivyignore
@@ -315,3 +315,39 @@ CVE-2026-46600 exp:2026-11-14
 #             https://avd.aquasec.com/nvd/cve-2026-56865
 CVE-2026-56864 exp:2026-11-14
 CVE-2026-56865 exp:2026-11-14
+
+# CVE-2026-84304 — google.golang.org/grpc heap memory exhaustion. Prior to
+# 1.83.1, internal/transport/transport.go stores every fragmented HTTP/2 DATA
+# frame as a separate recvMsg in recvBuffer, so millions of one-byte frames
+# consume disproportionate heap even while staying inside the connection and
+# stream flow-control windows. An unauthenticated remote peer can drive a
+# gRPC *server* to a panic or OOM through concurrent multiplexed streams.
+# Statically linked into the docker-buildx CLI plugin Dockerfile.dev installs
+# (ARG BUILDX_VERSION), so only security:trivy:container-scan on the dev image
+# surfaces it — the same binary already carrying CVE-2026-56854 and the x/mod
+# pair below.
+#
+# Not introduced by any change of ours: the entry reached the Trivy DB between
+# the green pull-request run of #322 and the push run of the identical commit
+# on main, so it appeared on a dev image whose Buildx pin did not move.
+#
+# Not clearable by a stable pin bump — upstream checked 2026-09-02: the latest
+# stable Buildx v0.36.1 requires grpc v1.82.1. v0.37.0-rc2 already carries
+# v1.83.2, but this release deliberately consumes stable tooling only, and an
+# availability-only defect in contributor tooling does not justify shipping a
+# release candidate as every contributor's and CI job's build toolchain.
+#
+# Low runtime risk, and availability-only: CVSS 4.0 records VC:N/VI:N/VA:H
+# with no confidentiality or integrity impact. Reaching it requires being a
+# gRPC server that accepts connections from a hostile peer. buildx is a
+# client: it dials a BuildKit instance the developer already controls over a
+# local socket, and exposes no gRPC listener to untrusted input. The dev image
+# is contributor/CI tooling and is never deployed.
+#
+# Clears when a stable Buildx release requires grpc >= 1.83.1: bump
+# ARG BUILDX_VERSION in Dockerfile.dev with its reviewed per-architecture
+# checksums (the monthly deps-scan tracks the pin) and drop this entry. Dated
+# to 2026-10-01 to land in the same review as CVE-2026-56854, the other
+# suppression waiting on exactly that stable Buildx release.
+# Advisory: https://avd.aquasec.com/nvd/cve-2026-84304
+CVE-2026-84304 exp:2026-10-01


### PR DESCRIPTION
## Summary

`security:trivy:container-scan (dev, Dockerfile.dev)` is failing on `main`. Every other
workflow on that commit is green.

Nothing in the tree changed to cause it. **CVE-2026-84304** reached the Trivy vulnerability
DB between the green pull-request run of #322 and the push run of that *identical* commit on
`main`, so it landed on a dev image whose Buildx pin never moved.

## The finding is real

gRPC-Go before 1.83.1 stores every fragmented HTTP/2 DATA frame as a separate `recvMsg` in
`recvBuffer`, so millions of one-byte frames consume disproportionate heap even while staying
inside the connection and stream flow-control windows. An unauthenticated remote peer can
drive a gRPC **server** to a panic or OOM through concurrent multiplexed streams.

It is statically linked into the `docker-buildx` CLI plugin that `Dockerfile.dev` installs
(`ARG BUILDX_VERSION`), which is why only the dev-image container scan surfaces it — the same
binary already carrying `CVE-2026-56854` and the x/mod pair.

## Why not just bump the pin

Checked upstream 2026-09-02:

| Buildx | grpc-go | |
|---|---|---|
| v0.36.1 (latest **stable**) | v1.82.1 | vulnerable |
| v0.37.0-rc2 (prerelease) | v1.83.2 | fixed |

There is no stable Buildx release with the fix. Shipping a release candidate as every
contributor's and CI job's build toolchain, to clear an availability-only defect in tooling
that is never deployed, is the worse trade — and it's the same call already recorded in this
file for `CVE-2026-56854` on this exact binary.

## Risk assessment

- CVSS 4.0 records **`VC:N/VI:N/VA:H`** — availability only, no confidentiality or integrity
  impact.
- Reaching it requires *being a gRPC server* that accepts connections from a hostile peer.
  buildx is a **client**: it dials a BuildKit instance the developer already controls over a
  local socket and exposes no gRPC listener to untrusted input.
- The dev image is contributor/CI tooling and is never deployed.

## What this does

Adds the standard dated suppression with justification, following the existing format and the
precedent set by the other Buildx entries.

Dated **2026-10-01** deliberately — the same date as `CVE-2026-56854`, which waits on exactly
the same stable Buildx release. One future pin bump clears both in one review, rather than
staggering two reviews of the same binary.

## Testing

- [x] `pytest tests/` passes locally (relevant subset — see below)
- [x] New tests added for new behavior — n/a, this is a data file governed by an existing validator

Verified:

- the failing job passes `--ignorefile .github/config/.trivyignore`, so the suppression
  applies to that exact scan
- `tests/test_trivyignore_validator.py` — 6 passed; the committed file validates against today
- `parse_suppression_expiries` reads the entry as `CVE-2026-84304|2026-10-01`, so the monthly
  deps-scan surfaces it 30 days before expiry rather than letting it lapse silently
- 72 tests across the trivyignore, pip-audit-ignore, and supply-chain guards pass
- `trivy` itself parses the file with no errors or warnings
- no test asserts a fixed suppression count

The authoritative proof is this PR's own `security:trivy:container-scan (dev, Dockerfile.dev)`
job, since CI pins its own Trivy version and DB source.

## Type of change

- [x] `fix:` Bug fix (non-breaking)

## Live release validation

- [x] Not required (explain the applicability decision below)

**Applicability rationale:** changes one CI suppression data file. No deployed
infrastructure, no runtime code path, no pin that reaches a shipped image.

## Related issues

Unblocks `main`. The suppression is self-expiring; when a stable Buildx ships grpc-go
>= 1.83.1, bump `ARG BUILDX_VERSION` in `Dockerfile.dev` with its reviewed per-architecture
checksums and drop this entry together with `CVE-2026-56854`.
