### PR TITLE
Fix regional API discovery error reporting

### DIFF
--- a/cli/aws_client.py
+++ b/cli/aws_client.py
@@ -8,16 +8,20 @@ stack discovery, and region management.
 import ast
 import json
 import logging
+import os
+import re
 import time
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 
 import boto3
 import requests
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
+from botocore.exceptions import ClientError
+from botocore.session import get_session as get_botocore_session
 
 from .config import GCOConfig, get_config
 
@@ -35,6 +39,84 @@ class APIRequestError(RuntimeError):
     def __init__(self, status_code: int, message: str):
         super().__init__(f"API request failed: {message}")
         self.status_code = status_code
+
+
+class RegionalApiDiscoveryError(RuntimeError):
+    """Regional endpoint discovery failed without confirming stack absence."""
+
+
+def _cloudformation_stack_missing(exc: ClientError) -> bool:
+    """Return whether CloudFormation authoritatively reports an absent stack."""
+    error = exc.response.get("Error", {})
+    return bool(
+        error.get("Code") == "ValidationError"
+        and "does not exist" in str(error.get("Message", "")).lower()
+    )
+
+
+def _aws_credential_context(session: Any) -> str:
+    """Describe configured profile/role hints without claiming provider selection."""
+    hints = []
+    profile_name = getattr(session, "profile_name", None)
+    if isinstance(profile_name, str) and profile_name.strip():
+        hints.append(f"session profile {profile_name.strip()[:128]!r}")
+
+    role_arn = os.getenv("AWS_ROLE_ARN", "").strip()
+    if role_arn:
+        hints.append(f"AWS_ROLE_ARN is set to {role_arn[:256]!r}")
+
+    return "; ".join(hints) or "no profile or role hint is available"
+
+
+def _safe_aws_error_message(error: dict[str, Any]) -> str:
+    """Return bounded service-provided detail without terminal control bytes."""
+    raw_message = error.get("Message")
+    if not isinstance(raw_message, str):
+        return "AWS did not return an error message"
+    printable = "".join(
+        character if character.isprintable() and character != "\x1b" else " "
+        for character in raw_message
+    )
+    normalized = " ".join(printable.split())
+    return normalized[:512] or "AWS did not return an error message"
+
+
+def _execute_api_service_hostname(region: str) -> str:
+    """Resolve the partition-correct execute-api hostname from botocore data."""
+    resolver = get_botocore_session().get_component("endpoint_resolver")
+    endpoint = resolver.construct_endpoint("execute-api", region)
+    hostname = endpoint.get("hostname") if isinstance(endpoint, dict) else None
+    if not isinstance(hostname, str):
+        raise ValueError("execute-api endpoint metadata is unavailable")
+    return hostname.lower()
+
+
+def _normalize_regional_api_endpoint(value: Any, region: str) -> tuple[str, str]:
+    """Validate a regional stack output as this region's execute-api prod URL."""
+    if not isinstance(value, str):
+        raise ValueError("regional endpoint output is not a string")
+    try:
+        parsed = urlsplit(value.strip())
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("regional endpoint output is not a valid URL") from exc
+
+    host = (parsed.hostname or "").lower()
+    service_hostname = _execute_api_service_hostname(region)
+    host_suffix = f".{service_hostname}"
+    api_id = host[: -len(host_suffix)] if host.endswith(host_suffix) else ""
+    if (
+        parsed.scheme != "https"
+        or parsed.username is not None
+        or parsed.password is not None
+        or port not in {None, 443}
+        or re.fullmatch(r"[a-z0-9]+", api_id) is None
+        or parsed.path.rstrip("/") != "/prod"
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("regional endpoint output is not an execute-api prod URL")
+    return f"https://{host}/prod", api_id
 
 
 def _validate_max_attempts(max_attempts: int | None) -> None:
@@ -133,51 +215,110 @@ class GCOAWSClient:
     def get_regional_api_endpoint(
         self, region: str, force_refresh: bool = False
     ) -> ApiEndpoint | None:
-        """
-        Get the regional API Gateway endpoint for a specific region.
+        """Get the regional API Gateway endpoint for a specific region.
 
-        Regional APIs are used when public access is disabled and the ALB
-        is internal-only.
+        ``None`` is reserved for CloudFormation's authoritative confirmation
+        that the regional API stack does not exist. Credential, authorization,
+        transport, and malformed-response failures raise instead, so callers
+        never misreport an observation failure as missing infrastructure.
 
         Args:
             region: AWS region
             force_refresh: Force refresh from CloudFormation
 
         Returns:
-            ApiEndpoint with URL and metadata, or None if not found
+            ApiEndpoint with URL and metadata, or None when CloudFormation
+            confirms the regional API stack is absent
+
+        Raises:
+            RegionalApiDiscoveryError: If discovery cannot run or the existing
+                stack does not publish a usable endpoint
         """
         if not force_refresh and region in self._regional_api_cache and self._is_cache_valid():
             return self._regional_api_cache[region]
 
-        cfn = self._session.client("cloudformation", region_name=region)
         stack_name = f"{self.config.project_name}-regional-api-{region}"
+        credential_context = _aws_credential_context(self._session)
 
         try:
+            cfn = self._session.client("cloudformation", region_name=region)
             response = cfn.describe_stacks(StackName=stack_name)
-            stack = response["Stacks"][0]
-
-            api_url = None
-            for output in stack.get("Outputs", []):
-                if output["OutputKey"] == "RegionalApiEndpoint":
-                    api_url = output["OutputValue"].rstrip("/")
-                    break
-
-            if not api_url:
+        except ClientError as exc:
+            if _cloudformation_stack_missing(exc):
                 return None
+            error = exc.response.get("Error", {})
+            raw_error_code = error.get("Code")
+            error_code = (
+                raw_error_code
+                if isinstance(raw_error_code, str)
+                and re.fullmatch(r"[A-Za-z0-9_.-]{1,128}", raw_error_code)
+                else "ClientError"
+            )
+            error_message = _safe_aws_error_message(error)
+            raise RegionalApiDiscoveryError(
+                f"Regional API endpoint discovery could not run for stack '{stack_name}' "
+                f"in {region}. Credential context: {credential_context}. "
+                f"AWS error {error_code}: {error_message}"
+            ) from exc
+        except Exception as exc:
+            failure_type = re.sub(r"[^A-Za-z0-9_.-]", "", type(exc).__name__)[:128]
+            raise RegionalApiDiscoveryError(
+                f"Regional API endpoint discovery could not run for stack '{stack_name}' "
+                f"in {region}. Credential context: {credential_context}. Discovery failed "
+                f"with {failure_type or 'UnexpectedError'}; check AWS credential and network "
+                "configuration"
+            ) from exc
 
-            # Extract API ID from URL
-            api_id = api_url.split(".")[0].replace("https://", "")
+        if not isinstance(response, dict):
+            raise RegionalApiDiscoveryError(
+                f"Regional API endpoint discovery returned an invalid CloudFormation "
+                f"response for stack '{stack_name}' in {region}"
+            )
+        stacks = response.get("Stacks")
+        if not isinstance(stacks, list) or len(stacks) != 1 or not isinstance(stacks[0], dict):
+            raise RegionalApiDiscoveryError(
+                f"Regional API endpoint discovery returned no unique usable stack record for "
+                f"'{stack_name}' in {region}"
+            )
+        stack = stacks[0]
 
-            endpoint = ApiEndpoint(url=api_url, region=region, api_id=api_id, is_regional=True)
-            self._regional_api_cache[region] = endpoint
-            return endpoint
+        outputs = stack.get("Outputs", [])
+        if not isinstance(outputs, list):
+            raise RegionalApiDiscoveryError(
+                f"Regional API endpoint discovery returned malformed CloudFormation Outputs "
+                f"for stack '{stack_name}' in {region}"
+            )
 
-        except cfn.exceptions.ClientError:
-            # Stack doesn't exist
-            return None
-        except Exception as e:
-            logger.debug("Failed to get regional API endpoint for %s: %s", region, e)
-            return None
+        endpoint_output: Any = None
+        endpoint_output_found = False
+        for output in outputs:
+            if not isinstance(output, dict) or not isinstance(output.get("OutputKey"), str):
+                raise RegionalApiDiscoveryError(
+                    f"Regional API endpoint discovery returned malformed CloudFormation "
+                    f"Outputs for stack '{stack_name}' in {region}"
+                )
+            if output["OutputKey"] == "RegionalApiEndpoint":
+                endpoint_output_found = True
+                endpoint_output = output.get("OutputValue")
+                break
+
+        if not endpoint_output_found:
+            raise RegionalApiDiscoveryError(
+                f"Regional API stack '{stack_name}' exists in {region} but does not publish "
+                "a RegionalApiEndpoint output; the bridge deployment may be incomplete"
+            )
+
+        try:
+            api_url, api_id = _normalize_regional_api_endpoint(endpoint_output, region)
+        except Exception as exc:
+            raise RegionalApiDiscoveryError(
+                f"Regional API stack '{stack_name}' in {region} publishes an invalid "
+                "RegionalApiEndpoint output"
+            ) from exc
+
+        endpoint = ApiEndpoint(url=api_url, region=region, api_id=api_id, is_regional=True)
+        self._regional_api_cache[region] = endpoint
+        return endpoint
 
     def get_api_endpoint(self, force_refresh: bool = False) -> ApiEndpoint:
         """

--- a/tests/test_aws_client.py
+++ b/tests/test_aws_client.py
@@ -2249,10 +2249,10 @@ class TestGCOAWSClientOptimizedDiscovery:
 
 
 class TestGCOAWSClientGetRegionalApiEndpoint:
-    """Tests for get_regional_api_endpoint covering lines 117, 133, 145-146."""
+    """Tests for authoritative regional API endpoint discovery semantics."""
 
     def test_get_regional_api_endpoint_success(self):
-        """Test successful regional API endpoint discovery (line 117+)."""
+        """A stack output resolves to a normalized regional endpoint."""
         from cli.aws_client import GCOAWSClient
 
         with patch("cli.aws_client.get_config") as mock_config:
@@ -2288,7 +2288,7 @@ class TestGCOAWSClientGetRegionalApiEndpoint:
                 assert endpoint.api_id == "abc123"
 
     def test_get_regional_api_endpoint_cached(self):
-        """Test that cached regional endpoint is returned (line 117 cache hit)."""
+        """A fresh cached endpoint avoids another CloudFormation lookup."""
         from cli.aws_client import ApiEndpoint, GCOAWSClient
 
         with patch("cli.aws_client.get_config") as mock_config:
@@ -2312,9 +2312,9 @@ class TestGCOAWSClientGetRegionalApiEndpoint:
                 result = client.get_regional_api_endpoint("us-east-1")
                 assert result == cached_endpoint
 
-    def test_get_regional_api_endpoint_no_output(self):
-        """Test regional endpoint when stack has no RegionalApiEndpoint output (line 133)."""
-        from cli.aws_client import GCOAWSClient
+    def test_existing_stack_without_endpoint_is_not_reported_as_absent(self):
+        """A present but incomplete bridge stack is not a missing deployment."""
+        from cli.aws_client import GCOAWSClient, RegionalApiDiscoveryError
 
         with patch("cli.aws_client.get_config") as mock_config:
             mock_config.return_value = MagicMock(
@@ -2341,11 +2341,81 @@ class TestGCOAWSClientGetRegionalApiEndpoint:
                 mock_session.return_value.client.return_value = mock_cfn
 
                 client = GCOAWSClient()
-                result = client.get_regional_api_endpoint("us-east-1")
-                assert result is None
+                with pytest.raises(RegionalApiDiscoveryError) as exc_info:
+                    client.get_regional_api_endpoint("us-east-1")
 
-    def test_get_regional_api_endpoint_client_error(self):
-        """Test regional endpoint when stack doesn't exist (line 145)."""
+        message = str(exc_info.value)
+        assert "stack 'gco-regional-api-us-east-1' exists" in message
+        assert "does not publish a RegionalApiEndpoint" in message
+        assert "endpoint is not deployed" not in message
+
+    @pytest.mark.parametrize(
+        ("outputs", "expected_message"),
+        [
+            ({}, "malformed CloudFormation Outputs"),
+            ([None], "malformed CloudFormation Outputs"),
+            (
+                [{"OutputKey": 123, "OutputValue": "unexpected"}],
+                "malformed CloudFormation Outputs",
+            ),
+            (
+                [{"OutputKey": "RegionalApiEndpoint", "OutputValue": 123}],
+                "invalid RegionalApiEndpoint output",
+            ),
+            (
+                [{"OutputKey": "RegionalApiEndpoint", "OutputValue": "not-a-url"}],
+                "invalid RegionalApiEndpoint output",
+            ),
+            (
+                [
+                    {
+                        "OutputKey": "RegionalApiEndpoint",
+                        "OutputValue": "https://abc123.execute-api.us-east-1.evil.example/prod",
+                    }
+                ],
+                "invalid RegionalApiEndpoint output",
+            ),
+            (
+                [
+                    {
+                        "OutputKey": "RegionalApiEndpoint",
+                        "OutputValue": (
+                            "https://user:super-secret@abc123.execute-api.us-east-1."
+                            "amazonaws.com/prod"
+                        ),
+                    }
+                ],
+                "invalid RegionalApiEndpoint output",
+            ),
+        ],
+    )
+    def test_malformed_endpoint_outputs_fail_closed(self, outputs, expected_message):
+        """Malformed stack records never become trusted SigV4 request targets."""
+        from cli.aws_client import GCOAWSClient, RegionalApiDiscoveryError
+
+        with patch("cli.aws_client.get_config") as mock_config:
+            mock_config.return_value = MagicMock(
+                project_name="gco",
+                cache_ttl_seconds=300,
+            )
+            with patch("boto3.Session") as mock_session:
+                mock_cfn = MagicMock()
+                mock_cfn.describe_stacks.return_value = {
+                    "Stacks": [{"StackStatus": "CREATE_COMPLETE", "Outputs": outputs}]
+                }
+                mock_session.return_value.client.return_value = mock_cfn
+
+                client = GCOAWSClient()
+                with pytest.raises(RegionalApiDiscoveryError) as exc_info:
+                    client.get_regional_api_endpoint("us-east-1")
+
+        message = str(exc_info.value)
+        assert expected_message in message
+        assert "super-secret" not in message
+        assert "endpoint is not deployed" not in message
+
+    def test_only_confirmed_missing_stack_returns_none(self):
+        """CloudFormation's service-shaped missing-stack response means absence."""
         from botocore.exceptions import ClientError
 
         from cli.aws_client import GCOAWSClient
@@ -2359,21 +2429,74 @@ class TestGCOAWSClientGetRegionalApiEndpoint:
 
             with patch("boto3.Session") as mock_session:
                 mock_cfn = MagicMock()
-                mock_cfn.exceptions.ClientError = ClientError
                 mock_cfn.describe_stacks.side_effect = ClientError(
-                    {"Error": {"Code": "ValidationError", "Message": "Stack not found"}},
+                    {
+                        "Error": {
+                            "Code": "ValidationError",
+                            "Message": ("Stack with id gco-regional-api-us-east-1 does not exist"),
+                        }
+                    },
                     "DescribeStacks",
                 )
                 mock_session.return_value.client.return_value = mock_cfn
 
                 client = GCOAWSClient()
                 result = client.get_regional_api_endpoint("us-east-1")
-                assert result is None
 
-    def test_get_regional_api_endpoint_generic_exception(self):
-        """Test regional endpoint when unexpected error occurs (line 146)."""
-        from cli.aws_client import GCOAWSClient
+        assert result is None
 
+    @pytest.mark.parametrize(
+        ("error_code", "error_message"),
+        [
+            ("ExpiredToken", "The security token included in the request is expired"),
+            ("AccessDenied", "Not authorized to perform cloudformation:DescribeStacks"),
+            ("ValidationError", "DescribeStacks rejected the request"),
+        ],
+    )
+    def test_service_errors_surface_with_credential_context(self, error_code, error_message):
+        """Auth and unrelated validation failures never masquerade as absence."""
+        from botocore.exceptions import ClientError
+
+        from cli.aws_client import GCOAWSClient, RegionalApiDiscoveryError
+
+        role_arn = "arn:aws:iam::123456789012:role/ExampleOperatorRole"
+        with (
+            patch("cli.aws_client.get_config") as mock_config,
+            patch("boto3.Session") as mock_session,
+            patch.dict("os.environ", {"AWS_ROLE_ARN": role_arn}),
+        ):
+            mock_config.return_value = MagicMock(
+                regional_stack_prefix="gco",
+                project_name="gco",
+                cache_ttl_seconds=300,
+            )
+            mock_session.return_value.profile_name = "temporary-admin"
+            mock_cfn = MagicMock()
+            service_error = ClientError(
+                {"Error": {"Code": error_code, "Message": error_message}},
+                "DescribeStacks",
+            )
+            mock_cfn.describe_stacks.side_effect = service_error
+            mock_session.return_value.client.return_value = mock_cfn
+
+            client = GCOAWSClient()
+            with pytest.raises(RegionalApiDiscoveryError) as exc_info:
+                client.get_regional_api_endpoint("us-west-2")
+
+        message = str(exc_info.value)
+        assert "Regional API endpoint discovery could not run" in message
+        assert "gco-regional-api-us-west-2" in message
+        assert "Credential context: session profile 'temporary-admin'" in message
+        assert f"AWS_ROLE_ARN is set to {role_arn!r}" in message
+        assert f"AWS error {error_code}: {error_message}" in message
+        assert "endpoint is not deployed" not in message
+        assert exc_info.value.__cause__ is service_error
+
+    def test_unexpected_discovery_error_is_bounded_and_redacted(self):
+        """Transport failures remain distinct without exposing provider secrets."""
+        from cli.aws_client import GCOAWSClient, RegionalApiDiscoveryError
+
+        secret = "super-secret-provider-token"
         with patch("cli.aws_client.get_config") as mock_config:
             mock_config.return_value = MagicMock(
                 regional_stack_prefix="gco",
@@ -2382,14 +2505,27 @@ class TestGCOAWSClientGetRegionalApiEndpoint:
             )
 
             with patch("boto3.Session") as mock_session:
+                mock_session.return_value.profile_name = "temporary-admin"
                 mock_cfn = MagicMock()
-                mock_cfn.exceptions.ClientError = Exception
-                mock_cfn.describe_stacks.side_effect = RuntimeError("Unexpected error")
+                unexpected_error = RuntimeError(
+                    f"proxy=https://user:{secret}@proxy.example token={secret}"
+                )
+                mock_cfn.describe_stacks.side_effect = unexpected_error
                 mock_session.return_value.client.return_value = mock_cfn
 
                 client = GCOAWSClient()
-                result = client.get_regional_api_endpoint("us-east-1")
-                assert result is None
+                with pytest.raises(RegionalApiDiscoveryError) as exc_info:
+                    client.get_regional_api_endpoint("us-east-1")
+
+        message = str(exc_info.value)
+        assert "discovery could not run" in message
+        assert "Credential context: session profile 'temporary-admin'" in message
+        assert "Discovery failed with RuntimeError" in message
+        assert "check AWS credential and network configuration" in message
+        assert secret not in message
+        assert "proxy.example" not in message
+        assert "endpoint is not deployed" not in message
+        assert exc_info.value.__cause__ is unexpected_error
 
 
 class TestGCOAWSClientDiscoverRegionalStacksFallback:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -156,6 +156,47 @@ class TestJobsCommands:
         # The old behavior collapsed this failure into "Job ... not found".
         assert "not found" not in result.output.lower()
 
+    def test_jobs_get_discovery_auth_errors_are_not_reported_as_missing_bridge(self):
+        """C10: failed discovery names the credentials and preserves the AWS error."""
+        from botocore.exceptions import ClientError
+
+        from cli.main import cli
+
+        role_arn = "arn:aws:iam::123456789012:role/ExampleOperatorRole"
+        cases = [
+            ("ExpiredToken", "The security token included in the request is expired"),
+            ("AccessDenied", "Not authorized to perform cloudformation:DescribeStacks"),
+        ]
+
+        for error_code, error_message in cases:
+            session = MagicMock()
+            session.profile_name = "temporary-admin"
+            cfn = MagicMock()
+            cfn.describe_stacks.side_effect = ClientError(
+                {"Error": {"Code": error_code, "Message": error_message}},
+                "DescribeStacks",
+            )
+            session.client.return_value = cfn
+
+            with (
+                patch("cli.aws_client.boto3.Session", return_value=session),
+                patch.dict("os.environ", {"AWS_ROLE_ARN": role_arn}),
+            ):
+                runner = CliRunner()
+                result = runner.invoke(
+                    cli,
+                    ["jobs", "get", "gpu-test-job", "--region", "us-west-2"],
+                )
+
+            assert result.exit_code == 1
+            assert "Failed to get job:" in result.output
+            assert "Regional API endpoint discovery could not run" in result.output
+            assert "Credential context: session profile 'temporary-admin'" in result.output
+            assert f"AWS_ROLE_ARN is set to {role_arn!r}" in result.output
+            assert f"AWS error {error_code}: {error_message}" in result.output
+            assert "Regional API endpoint is not deployed" not in result.output
+            assert "Job gpu-test-job not found" not in result.output
+
     @patch("cli.commands.jobs_cmd.get_job_manager")
     @patch("cli.commands.jobs_cmd.get_output_formatter")
     def test_jobs_logs(self, mock_formatter, mock_manager):

--- a/tests/test_regional_api_gateway_stack.py
+++ b/tests/test_regional_api_gateway_stack.py
@@ -795,17 +795,23 @@ class TestRegionalApiClientIntegration:
         assert client._use_regional_api is False
 
     def test_get_regional_api_endpoint_not_found(self):
-        """Test getting regional API endpoint when stack doesn't exist."""
+        """A confirmed missing regional API stack returns no endpoint."""
+        from botocore.exceptions import ClientError
+
         from cli.aws_client import GCOAWSClient
 
         client = GCOAWSClient()
 
         with patch.object(client, "_session") as mock_session:
             mock_cfn = MagicMock()
-            # Create a proper exception class for ClientError
-            mock_cfn.exceptions.ClientError = type("ClientError", (Exception,), {})
-            mock_cfn.describe_stacks.side_effect = mock_cfn.exceptions.ClientError(
-                "Stack not found"
+            mock_cfn.describe_stacks.side_effect = ClientError(
+                {
+                    "Error": {
+                        "Code": "ValidationError",
+                        "Message": ("Stack with id gco-regional-api-us-east-1 does not exist"),
+                    }
+                },
+                "DescribeStacks",
             )
             mock_session.client.return_value = mock_cfn
 


### PR DESCRIPTION
## Summary
- reserve the regional API "not deployed" result for CloudFormation-confirmed stack absence
- surface expired-token, access-denied, transport, and malformed-discovery failures with bounded credential context instead of collapsing them into missing infrastructure
- validate CloudFormation response shape and partition-correct execute-api URLs before SigV4 signing
- keep generic HTTP 502 failures evidence-neutral because the client has no authoritative bridge warm-up signal

## Validation
- `ruff check` and `ruff format --check` on all changed files
- `mypy cli/aws_client.py`
- `pytest --noconftest -q tests/test_aws_client.py` (130 passed)
- `pytest --noconftest -q tests/test_cli_commands.py tests/test_regional_api_gateway_stack.py::TestRegionalApiClientIntegration` (45 passed)
- semantic diff review: approved with no critical, high, medium, or low findings

## Local environment note
The repository-wide autouse asset fixture requires npm 12.0.2, while this host has npm 11.18.0, so the focused suites were run with `--noconftest`. CI provides the repository-pinned npm environment.