### PR TITLE
fix: stage MCP README in release bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,11 @@ jobs:
             exit 1
           fi
           git checkout -b "$BRANCH"
-          git add VERSION gco/_version.py cli/__init__.py
+          git add VERSION gco_mcp/README.md gco/_version.py cli/__init__.py
+          # The bumper owns this complete tracked output set. If it gains a
+          # target without this workflow staging it, fail before opening a
+          # release PR whose VERSION disagrees with its maintained mirrors.
+          git diff --exit-code
           git commit -m "Release v${NEW_VERSION}"
           git push origin "HEAD:refs/heads/${BRANCH}"
       - name: Open release pull request

--- a/tests/test_supply_chain_integrity.py
+++ b/tests/test_supply_chain_integrity.py
@@ -601,6 +601,21 @@ def test_incomplete_reports_do_not_claim_zero_count_surfaces_are_current() -> No
     assert "Zero-count surfaces are provisional, not confirmed current." in scanner
 
 
+def test_release_stage_one_commits_every_version_bump_output() -> None:
+    """The workflow must stage every tracked file the bumper maintains."""
+    step = _workflow_step(".github/workflows/release.yml", "Push release branch")
+    matches = re.findall(r"^\s*git add (.+)$", step, re.MULTILINE)
+
+    assert len(matches) == 1
+    assert set(matches[0].split()) == {
+        "VERSION",
+        "gco/_version.py",
+        "cli/__init__.py",
+        "gco_mcp/README.md",
+    }
+    assert step.index("git add ") < step.index("git diff --exit-code") < step.index("git commit ")
+
+
 def test_release_stage_one_never_writes_to_main() -> None:
     """Stage 1 (release.yml) must go through the PR gate like any other change.
 


### PR DESCRIPTION
## Summary

- Fix the stage-one release workflow so its explicit `git add` includes all four tracked outputs maintained by `scripts/bump_version.py`: `VERSION`, `gco_mcp/README.md`, `gco/_version.py`, and `cli/__init__.py`.
- Add a fail-closed `git diff --exit-code` check after staging and before commit so any future tracked bump target omitted from the allowlist stops the release before opening a torn-version PR.
- Add a supply-chain workflow contract that compares the staged paths as a set and pins add/guard/commit ordering.

This fixes the omission behind failed release PR #346, where `VERSION` moved to 7.5.0 but the 25 maintained MCP launch refs remained at 7.4.0 because the workflow did not commit the README update the bumper had already made.

## Type of change

- [ ] `feat:` New feature (non-breaking)
- [x] `fix:` Bug fix (non-breaking)
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactor (no behavior change)
- [ ] `perf:` Performance improvement
- [x] `test:` Test-only change
- [x] `ci:` CI / tooling change
- [ ] `chore:` Maintenance (dep bumps, etc.)
- [ ] `breaking:` Breaking change (major version bump)

## Testing

- [ ] `pytest tests/` passes locally
- [ ] `cdk synth` succeeds (if CDK code changed)
- [x] New tests added for new behavior
- [ ] Ran the change against a real AWS account
- [ ] If `examples/` changed: static/live example validation

Local verification:

- 211 passed: bump-version, supply-chain integrity, documentation consistency, and workflow security contracts.
- Ruff check/format passed.
- Repository yamllint passed for `.github/workflows/release.yml`.
- `python scripts/bump_version.py patch --dry-run` reports all four maintained outputs, including `gco_mcp/README.md`.
- Semantic review approved with no high/medium findings.

## Live release validation

- [x] Not required (explain the applicability decision below)
- [ ] Required and completed locally with `--actions all` for this exact SHA
- [ ] Required but pending explicit validation-account and KMS-deletion authorization

**Applicability rationale:** This changes only the GitHub release workflow staging contract and an offline workflow test. It does not change deployed infrastructure or runtime behavior.

**Sanitized validation summary or comment link:** Not applicable.

## Checklist

- [x] Documentation updated as needed (the bumper and manual release instructions were already correct)
- [x] No secrets, credentials, or customer data committed
- [x] `requirements-lock.txt` regenerated if `pyproject.toml` changed (not applicable)
- [x] Changes align with the architecture described in `docs/ARCHITECTURE.md`

## Related issues

- Follow-up to failed release PR #346.
- Before rerunning the 7.5.0 release after this merges, close #346 and delete/retire the existing remote `release/v7.5.0` branch so the new non-force push can create the corrected branch cleanly.