### PR TITLE
docs: add latest-release badge to the README badge row

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -280,12 +280,13 @@ The scan runs as an Advanced Setup workflow rather than Default Setup so the fil
 
 ## README badges
 
-The README's badge row has three parts, in order — five dynamic health
-signals, then a navigation link:
+The README's badge row has four parts, in order — five dynamic health
+signals, a release pointer, then a navigation link:
 
 1. **Four workflow-status badges** (`Unit Tests`, `Integration Tests`, `Security`, `Linting`) from GitHub's native `badge.svg` endpoint.
 2. **A coverage badge** rendered by shields.io from the endpoint JSON that `pages.yml` publishes at the Pages site root (`/coverage-badge.json`), generated from the same run whose HTML report is served at `/coverage/` — the badge links there. Badge, report, and the exact 100% gate all describe one run.
-3. **A wiki badge** — a static shields.io badge linking to the Pages site root, where `pages.yml` serves the MkDocs wiki. It sits last so the dynamic quality signals stay grouped.
+3. **A latest-release badge** rendered by shields.io from the GitHub Releases API (`img.shields.io/github/v/release/<owner>/<repo>?sort=semver&display_name=tag`), linking to `/releases/latest`. It shows the newest semver tag automatically, so nothing in the repo needs bumping when a release is published. `scripts/migrate_fork.py` rewrites its owner/repo path for forks (the `shields-release-badge-path` rule); on a fork with no published releases it renders `release: no releases` until the first one exists.
+4. **A wiki badge** — a static shields.io badge linking to the Pages site root, where `pages.yml` serves the MkDocs wiki. It sits last so the dynamic quality signals stay grouped.
 
 ### "repo or workflow not found" on fresh or private repositories
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <a href="https://github.com/aws-solutions-library-samples/global-capacity-orchestrator-on-aws/actions/workflows/security.yml"><img src="https://github.com/aws-solutions-library-samples/global-capacity-orchestrator-on-aws/actions/workflows/security.yml/badge.svg?branch=main" alt="Security"></a>
   <a href="https://github.com/aws-solutions-library-samples/global-capacity-orchestrator-on-aws/actions/workflows/lint.yml"><img src="https://github.com/aws-solutions-library-samples/global-capacity-orchestrator-on-aws/actions/workflows/lint.yml/badge.svg?branch=main" alt="Linting"></a>
   <a href="https://aws-solutions-library-samples.github.io/global-capacity-orchestrator-on-aws/coverage/"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Faws-solutions-library-samples.github.io%2Fglobal-capacity-orchestrator-on-aws%2Fcoverage-badge.json" alt="Coverage"></a>
+  <a href="https://github.com/aws-solutions-library-samples/global-capacity-orchestrator-on-aws/releases/latest"><img src="https://img.shields.io/github/v/release/aws-solutions-library-samples/global-capacity-orchestrator-on-aws?sort=semver&display_name=tag" alt="Latest Release"></a>
   <a href="https://aws-solutions-library-samples.github.io/global-capacity-orchestrator-on-aws/"><img src="https://img.shields.io/badge/docs-wiki-blue" alt="Wiki"></a>
 </p>
 <!-- END BADGE TABLE -->

--- a/scripts/migrate_fork.py
+++ b/scripts/migrate_fork.py
@@ -193,6 +193,18 @@ def _build_rules(owner: str, repo: str) -> tuple[Rule, ...]:
             why="GitHub REST API repository path",
         ),
         Rule(
+            name="shields-release-badge-path",
+            # The README's latest-release badge embeds the slug inside a
+            # shields.io URL (img.shields.io/github/v/release/<owner>/<repo>)
+            # rather than a github.com one. The bare-slug rule cannot claim it
+            # (the preceding "/" blocks its lookbehind), and without this rule
+            # only the repo name would be rewritten — leaving a fork's badge
+            # reporting the upstream repository's releases.
+            pattern=re.compile(rf"github/v/release/{up_owner}/{up_repo}"),
+            replacement=f"github/v/release/{owner}/{repo}",
+            why="shields.io latest-release badge path",
+        ),
+        Rule(
             name="repo-url",
             pattern=re.compile(rf"github\.com/{up_owner}/{up_repo}"),
             replacement=f"github.com/{owner}/{repo}",

--- a/tests/test_migrate_fork.py
+++ b/tests/test_migrate_fork.py
@@ -202,6 +202,13 @@ def test_mcp_package_names_are_preserved(migrate: Any, rules: tuple[Any, ...]) -
             "config=%7B%22--from%22%2C%22git%2Bhttps%3A%2F%2Fgithub.com%2Faws-solutions-library-samples%2Fglobal-capacity-orchestrator-on-aws.git%40v7.6.1%22%7D",
             "config=%7B%22--from%22%2C%22git%2Bhttps%3A%2F%2Fgithub.com%2Facme-labs%2Fgco-fork.git%40v7.6.1%22%7D",
         ),
+        # The README's latest-release badge embeds the slug in a shields.io
+        # path (not a github.com URL). Both the owner and the repo segment
+        # must move, or a fork's badge keeps reporting upstream's releases.
+        (
+            "https://img.shields.io/github/v/release/aws-solutions-library-samples/global-capacity-orchestrator-on-aws?sort=semver",
+            "https://img.shields.io/github/v/release/acme-labs/gco-fork?sort=semver",
+        ),
         # The OIDC trust-policy subject is a bare owner/repo slug.
         (
             '"github_repo": "aws-solutions-library-samples/global-capacity-orchestrator-on-aws",',


### PR DESCRIPTION
## Summary

Adds a shields.io badge to the README badge row, between the coverage and wiki
badges, showing the newest published semver tag and linking to
`/releases/latest`. It reads the GitHub Releases API, so publishing a release
updates the badge with no repository edit.

`scripts/migrate_fork.py` gains a `shields-release-badge-path` rule. The badge
embeds the repository slug inside a shields.io URL rather than a github.com
one, which the existing bare-slug rule cannot claim — its lookbehind is blocked
by the preceding slash. Without the new rule a fork's badge would keep
reporting the upstream repository's releases.

`.github/CI.md` "README badges" now documents four parts instead of three.

## Type of change

- [x] `docs:` Documentation only

## Testing

- [x] New tests added for new behavior

Verified locally (targeted, not the full suite):

- `tests/test_migrate_fork.py` + `tests/test_documentation_consistency.py` — 45 passed
- `markdownlint-cli2` across all 125 Markdown files — 0 issues

On a fork with no published releases the badge renders `release: no releases`
until the first one exists; that is noted in `.github/CI.md`.

## Live release validation

- [x] Not required (explain the applicability decision below)

**Applicability rationale:** Documentation-only change. No deployed
infrastructure, lifecycle, or AWS runtime integration is touched; the only
executable change is a string-rewrite rule in the fork-migration helper, which
is covered by unit tests.

## Checklist

- [x] Documentation updated (README, `docs/`, inline docstrings) as needed
- [x] No secrets, credentials, or customer data committed
- [x] `requirements-lock.txt` regenerated if `pyproject.toml` changed (n/a — `pyproject.toml` unchanged)
- [x] Changes align with the architecture described in `docs/ARCHITECTURE.md`