### PR TITLE
test: cover the OIDC provider app and the code-diagram support modules; fix an over-matching ratchet entry (99 → 95)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -483,8 +483,12 @@ omit = [
     # Progress is printed by the ``unit:pytest:core`` job, which reports the
     # omitted files separately so their coverage stays visible while it climbs.
     # ------------------------------------------------------------------
-    ".github/oidc_provider/app.py",
-    ".github/oidc_provider/stack.py",
+    # Spelled "./app.py" deliberately: coverage expands a bare "app.py" into
+    # BOTH the absolutised path and a bare glob, and the glob matches any
+    # app.py at any depth — which silently omitted
+    # .github/oidc_provider/app.py from the gate too. The "./" prefix keeps
+    # this entry pointing at the repository-root CDK entry point only.
+    "./app.py",
     ".github/scripts/apply_pr_type_labels.py",
     ".github/scripts/autopilot_ci_contract.py",
     ".github/scripts/validate_demo_gifs.py",
@@ -495,7 +499,6 @@ omit = [
     ".github/scripts/verify_container_tool_versions.py",
     ".github/scripts/verify_inference_streaming_bundle_freshness.py",
     ".github/scripts/verify_lambda_imports.py",
-    "app.py",
     "diagrams/code_diagrams/_renderer.py",
     "diagrams/code_diagrams/_source_marker.py",
     "diagrams/code_diagrams/_timestamp.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -500,8 +500,6 @@ omit = [
     ".github/scripts/verify_inference_streaming_bundle_freshness.py",
     ".github/scripts/verify_lambda_imports.py",
     "diagrams/code_diagrams/_renderer.py",
-    "diagrams/code_diagrams/_source_marker.py",
-    "diagrams/code_diagrams/_timestamp.py",
     "diagrams/code_diagrams/generate.py",
     "diagrams/generate.py",
     "diagrams/infra_diagrams/generate.py",

--- a/tests/test_code_diagrams_generator.py
+++ b/tests/test_code_diagrams_generator.py
@@ -29,10 +29,13 @@ covered by the pyflowchart import in the renderer's unit tests below.
 from __future__ import annotations
 
 import ast
+import builtins
 import hashlib
 import importlib.util
 import json
 import subprocess
+import sys
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -232,6 +235,24 @@ class TestGenerationTimestamp:
         monkeypatch.setenv("SOURCE_DATE_EPOCH", "not-an-integer")
         with pytest.raises(ValueError, match="integer Unix timestamp"):
             generation_timestamp_utc()
+
+    def test_absent_source_date_epoch_stamps_the_current_time(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reproducibility is opt-in: without the variable, record "now".
+
+        A local run has no SOURCE_DATE_EPOCH, so this is the path humans
+        actually take, and it must not raise the way a malformed value does.
+        """
+        monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
+        before = datetime.now(UTC).replace(microsecond=0)
+
+        stamped = generation_timestamp_utc()
+
+        after = datetime.now(UTC).replace(microsecond=0)
+        assert stamped.endswith("Z")
+        parsed = datetime.strptime(stamped, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+        assert before <= parsed <= after, f"{stamped} is outside the window it was taken in"
 
     def test_source_commit_is_exact_and_normalized(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("GCO_DIAGRAM_SOURCE_COMMIT", "A" * 40)
@@ -1280,3 +1301,219 @@ class TestProvenanceSchemaVersions:
         )
         with pytest.raises(RuntimeError, match="must record"):
             generate_mod.load_provenance_manifest(tmp_path)
+
+
+class TestSourceMarkerEdgeCases:
+    """The paths a normal regeneration never takes.
+
+    Marker insertion rewrites files that are under version control, so the
+    interesting cases are the ones where it must *not* write, must not reformat,
+    or must refuse outright. A silent write here shows up as unexplained diff
+    noise in someone else's pull request.
+    """
+
+    @staticmethod
+    def _result(
+        tmp_path: Path,
+        *,
+        function: str = "mod.func",
+        png: bool = True,
+        generated_at: str = "2026-07-16T12:00:00Z",
+        source_commit: str = "a" * 40,
+    ) -> object:
+        html_path = tmp_path / "artifacts" / f"{function.replace('.', '_')}.html"
+        html_path.parent.mkdir(parents=True, exist_ok=True)
+        html_path.write_text("<html></html>", encoding="utf-8")
+        png_path = None
+        if png:
+            png_path = html_path.with_suffix(".png")
+            png_path.write_bytes(b"\x89PNG")
+        return RenderedTarget(
+            target=Target(source="pkg/mod.py", function=function),
+            html_path=html_path,
+            png_path=png_path,
+            generated_at=generated_at,
+            source_commit=source_commit,
+        )
+
+    def test_reinserting_an_identical_block_writes_nothing(self, tmp_path: Path) -> None:
+        """Idempotence is what keeps regeneration out of unrelated diffs."""
+        source_path = tmp_path / "pkg" / "mod.py"
+        source_path.parent.mkdir(parents=True)
+        source_path.write_text("import os\n\n\ndef func():\n    return os\n", encoding="utf-8")
+        result = self._result(tmp_path)
+
+        assert (
+            _update_marker_file(source_path=source_path, results=[result], project_root=tmp_path)
+            is True
+        )
+        after_first = source_path.read_text(encoding="utf-8")
+
+        assert (
+            _update_marker_file(source_path=source_path, results=[result], project_root=tmp_path)
+            is False
+        )
+        assert source_path.read_text(encoding="utf-8") == after_first
+
+    def test_upsert_skips_formatting_when_no_file_changed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No write means no ``ruff format`` invocation at all."""
+        source_path = tmp_path / "pkg" / "mod.py"
+        source_path.parent.mkdir(parents=True)
+        source_path.write_text("import os\n\n\ndef func():\n    return os\n", encoding="utf-8")
+        result = self._result(tmp_path)
+
+        # Stubbed for both runs: the real ruff would reformat the file after the
+        # first insertion, so the second run would legitimately have something to
+        # rewrite and the point being tested here would be lost.
+        calls: list[object] = []
+        monkeypatch.setattr(source_marker_mod, "_ruff_format", lambda *a, **k: calls.append((a, k)))
+
+        upsert_markers([result], project_root=tmp_path)
+        assert len(calls) == 1, "the first insertion should have triggered formatting"
+
+        upsert_markers([result], project_root=tmp_path)
+        assert len(calls) == 1, "ruff format ran again even though nothing was rewritten"
+
+    def test_ruff_format_warns_and_returns_when_ruff_is_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing ruff degrades to a warning; generation still has to succeed."""
+        monkeypatch.setitem(sys.modules, "ruff", None)
+        real_import = builtins.__import__
+
+        def _no_ruff(name: str, *args: object, **kwargs: object) -> object:
+            if name == "ruff":
+                raise ImportError("no ruff")
+            return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(builtins, "__import__", _no_ruff)
+        ran: list[object] = []
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: ran.append(a))
+
+        with pytest.warns(UserWarning, match="ruff is not installed"):
+            _ruff_format([tmp_path / "pkg" / "mod.py"], project_root=tmp_path)
+
+        assert ran == [], "ruff was invoked despite being unimportable"
+
+    def test_results_disagreeing_on_the_source_commit_are_refused(self, tmp_path: Path) -> None:
+        """One block records one commit; two would make the marker a lie."""
+        source_path = tmp_path / "pkg" / "mod.py"
+        source_path.parent.mkdir(parents=True)
+        source_path.write_text("import os\n", encoding="utf-8")
+        results = [
+            self._result(tmp_path, function="mod.one", source_commit="a" * 40),
+            self._result(tmp_path, function="mod.two", source_commit="b" * 40),
+        ]
+
+        with pytest.raises(ValueError, match="one Git source commit"):
+            _update_marker_file(source_path=source_path, results=results, project_root=tmp_path)
+
+    def test_a_target_without_a_png_is_listed_without_one(self, tmp_path: Path) -> None:
+        """HTML-only runs are normal (no Playwright), and must still mark up."""
+        source_path = tmp_path / "pkg" / "mod.py"
+        source_path.parent.mkdir(parents=True)
+        source_path.write_text("import os\n", encoding="utf-8")
+
+        _update_marker_file(
+            source_path=source_path,
+            results=[self._result(tmp_path, png=False)],
+            project_root=tmp_path,
+        )
+        marked = source_path.read_text(encoding="utf-8")
+
+        assert "mod.func" in marked
+        assert "(PNG:" not in marked
+
+    def test_strip_all_markers_ignores_unmarked_and_missing_files(self, tmp_path: Path) -> None:
+        """Only files actually carrying a marker may be rewritten."""
+        for package in ("gco", "cli", "gco_mcp", "lambda"):
+            (tmp_path / package).mkdir()
+        unmarked = tmp_path / "gco" / "plain.py"
+        unmarked.write_text("import os\n", encoding="utf-8")
+        before = unmarked.read_text(encoding="utf-8")
+
+        marked = tmp_path / "cli" / "marked.py"
+        marked.write_text(
+            f"import os\n\n# <{SENTINEL}> BEGIN - auto-inserted, do not edit\n# <{SENTINEL}> END\n",
+            encoding="utf-8",
+        )
+        # A build directory that must be skipped even though it carries a marker.
+        build = tmp_path / "lambda" / "helm-installer-build"
+        build.mkdir()
+        skipped = build / "copy.py"
+        skipped.write_text(marked.read_text(encoding="utf-8"), encoding="utf-8")
+
+        modified = strip_all_markers(tmp_path)
+
+        assert modified == 1, "expected exactly the one eligible marked file to change"
+        assert unmarked.read_text(encoding="utf-8") == before
+        assert SENTINEL not in marked.read_text(encoding="utf-8")
+        assert SENTINEL in skipped.read_text(encoding="utf-8"), "a build copy was rewritten"
+
+    def test_a_bare_sentinel_mention_is_not_treated_as_a_block(self, tmp_path: Path) -> None:
+        """Only a complete BEGIN/END block is strippable.
+
+        The sentinel string also appears in prose — this module's own docstrings
+        mention it — so seeing the word is not sufficient reason to rewrite a
+        file. Stripping must be a no-op when there is no delimited block.
+        """
+        for package in ("gco", "cli", "gco_mcp", "lambda"):
+            (tmp_path / package).mkdir()
+        mentions = tmp_path / "gco" / "prose.py"
+        mentions.write_text(
+            f'"""A module that merely talks about {SENTINEL} blocks."""\n\nimport os\n',
+            encoding="utf-8",
+        )
+        before = mentions.read_text(encoding="utf-8")
+
+        assert strip_all_markers(tmp_path) == 0
+        assert mentions.read_text(encoding="utf-8") == before
+
+
+class TestMarkerInsertionPoint:
+    """Where the block lands, for files that are all prelude or have none."""
+
+    def test_a_file_that_is_only_imports_appends_at_the_end(self, tmp_path: Path) -> None:
+        """The import walk can finish without ever hitting a non-import node."""
+        source_path = tmp_path / "pkg" / "mod.py"
+        source_path.parent.mkdir(parents=True)
+        source_path.write_text("import os\nimport sys\n", encoding="utf-8")
+
+        _update_marker_file(
+            source_path=source_path,
+            results=[TestSourceMarkerEdgeCases._result(tmp_path)],
+            project_root=tmp_path,
+        )
+        marked = source_path.read_text(encoding="utf-8")
+
+        assert marked.startswith("import os\nimport sys\n")
+        assert SENTINEL in marked
+
+    def test_a_prelude_with_no_trailing_newline_still_marks_up(self, tmp_path: Path) -> None:
+        """A file whose last prelude line lacks a newline must not lose the block."""
+        source_path = tmp_path / "pkg" / "mod.py"
+        source_path.parent.mkdir(parents=True)
+        source_path.write_text("import os", encoding="utf-8")
+
+        _update_marker_file(
+            source_path=source_path,
+            results=[TestSourceMarkerEdgeCases._result(tmp_path)],
+            project_root=tmp_path,
+        )
+
+        assert SENTINEL in source_path.read_text(encoding="utf-8")
+
+    def test_a_file_with_no_prelude_marks_at_the_top(self, tmp_path: Path) -> None:
+        source_path = tmp_path / "pkg" / "mod.py"
+        source_path.parent.mkdir(parents=True)
+        source_path.write_text("x = 1\n", encoding="utf-8")
+
+        _update_marker_file(
+            source_path=source_path,
+            results=[TestSourceMarkerEdgeCases._result(tmp_path)],
+            project_root=tmp_path,
+        )
+
+        assert SENTINEL in source_path.read_text(encoding="utf-8")

--- a/tests/test_coverage_ratchet.py
+++ b/tests/test_coverage_ratchet.py
@@ -91,6 +91,47 @@ def test_ratchet_never_covers_the_already_enforced_packages() -> None:
     )
 
 
+def test_no_ratchet_entry_excuses_a_file_it_does_not_name() -> None:
+    """Each entry must omit exactly the one file it names — nothing else.
+
+    coverage expands a pattern with no directory separator into *two* patterns:
+    the absolutised path, and the bare pattern itself. The bare one is a glob, so
+    a lone ``app.py`` also matches ``.github/oidc_provider/app.py`` and every
+    other ``app.py`` in the tree — silently excusing files nobody listed. That
+    really happened here, which is why this asserts against coverage's own
+    matcher rather than against a spelling convention.
+    """
+    from coverage.files import GlobMatcher, abs_file, prep_patterns
+
+    tracked = [
+        path
+        for path in PROJECT_ROOT.rglob("*.py")
+        if not any(
+            part in {".git", ".venv", ".worktrees", "cdk.out", "build", "dist", "__pycache__"}
+            or part.endswith(".egg-info")
+            for part in path.relative_to(PROJECT_ROOT).parts
+        )
+    ]
+
+    overreaching: dict[str, list[str]] = {}
+    for entry in _ratchet_entries():
+        matcher = GlobMatcher(prep_patterns([entry]))
+        intended = abs_file(str(PROJECT_ROOT / entry.removeprefix("./")))
+        collateral = [
+            str(path.relative_to(PROJECT_ROOT))
+            for path in tracked
+            if matcher.match(abs_file(str(path))) and abs_file(str(path)) != intended
+        ]
+        if collateral:
+            overreaching[entry] = sorted(collateral)
+
+    assert not overreaching, (
+        "coverage ratchet entries omit files they do not name: "
+        f"{overreaching}. Prefix a repository-root entry with './' so its bare "
+        "glob cannot match the same basename deeper in the tree."
+    )
+
+
 def test_ratchet_is_sorted_and_unique() -> None:
     """Keeps review diffs one-line-per-change and blocks accidental repeats."""
     entries = _ratchet_entries()

--- a/tests/test_oidc_stack.py
+++ b/tests/test_oidc_stack.py
@@ -5,6 +5,7 @@ Verifies that the standalone stack synthesizes correctly and produces
 the expected IAM resources with proper trust policies and permissions.
 """
 
+import importlib.util
 import json
 import sys
 from pathlib import Path
@@ -492,3 +493,156 @@ class TestPolicyJsonFile:
                     f"Action '{action}' is not read-only. "
                     "Default CI policy should only contain Describe/Get/List actions."
                 )
+
+
+class TestSubjectPrefixValidation:
+    """The guardrails on ``github_repo`` / ``github_subject_prefix``.
+
+    This validation is the only thing standing between a copied-and-pasted ID
+    pair and a trust policy that authorises a *different* repository to assume
+    the CI role, so each rejection path is pinned individually rather than
+    inferred from the happy path.
+    """
+
+    @pytest.mark.parametrize(
+        "repo",
+        [
+            pytest.param("noslash", id="no-separator"),
+            pytest.param("owner/repo/extra", id="too-many-segments"),
+            pytest.param("/repo", id="empty-owner"),
+            pytest.param("owner/", id="empty-repo"),
+        ],
+    )
+    def test_malformed_github_repo_is_rejected(self, repo: str):
+        """A repo that is not exactly ``owner/repo`` cannot yield a valid subject."""
+        with pytest.raises(ValueError, match="github_repo must use owner/repo format"):
+            _synth_stack(github_repo=repo)
+
+    def test_non_string_subject_prefix_is_rejected(self):
+        """Context values come from cdk.json, where a number is easy to write."""
+        with pytest.raises(ValueError, match="github_subject_prefix must be a string"):
+            _synth_stack(
+                github_repo="my-org/my-repo",
+                github_subject_prefix=12345,  # type: ignore[arg-type]
+            )
+
+    def test_explicit_mutable_prefix_is_accepted_unchanged(self):
+        """Spelling out the mutable prefix must behave exactly like omitting it."""
+        explicit = _synth_stack(
+            github_repo="my-org/my-repo",
+            github_subject_prefix="repo:my-org/my-repo",
+        ).to_json()
+        implicit = _synth_stack(github_repo="my-org/my-repo").to_json()
+
+        assert explicit == implicit
+
+    def test_trailing_whitespace_prefix_is_rejected(self):
+        """A prefix is compared literally, so untrimmed input must not slip through."""
+        with pytest.raises(ValueError, match="non-empty trimmed string"):
+            _synth_stack(
+                github_repo="my-org/my-repo",
+                github_subject_prefix="repo:my-org/my-repo ",
+            )
+
+
+class TestCDKAppEntryPoint:
+    """The standalone ``app.py`` that turns cdk.json context into the stack.
+
+    Its whole job is reading context and applying defaults, and a wrong default
+    here is a silent authorisation change — an unset ``github_branch`` must mean
+    "main only", never "any branch". Executed rather than imported so each case
+    gets a fresh module with its own context.
+    """
+
+    @staticmethod
+    def _run_app(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch, context: dict[str, object]
+    ) -> dict:
+        """Execute app.py with the given CDK context and return what it synthesized.
+
+        ``app.py`` constructs ``cdk.App()`` with no arguments, so both the
+        context it reads and the directory it writes to have to be supplied from
+        outside. Wrapping ``aws_cdk.App`` to fill in ``context`` and ``outdir``
+        does that without touching the app: ``context`` is the same constructor
+        argument the CDK CLI populates from ``cdk.json``, so
+        ``try_get_context`` is exercised exactly as it is in a real deploy, and
+        ``outdir`` only decides where the template lands (CDK otherwise picks a
+        random temporary directory the test could not find).
+        """
+        outdir = tmp_path / "cdk.out"
+        original_app = cdk.App
+
+        def _app_with_context_and_outdir(*args: object, **kwargs: object) -> cdk.App:
+            kwargs.setdefault("context", context)
+            kwargs.setdefault("outdir", str(outdir))
+            return original_app(*args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(cdk, "App", _app_with_context_and_outdir)
+
+        app_path = Path(__file__).parent.parent / ".github" / "oidc_provider" / "app.py"
+        spec = importlib.util.spec_from_file_location("_oidc_app_under_test", app_path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        # Registered before exec so coverage attributes app.py's lines to the
+        # file on disk; a module exec'd without a sys.modules entry is invisible
+        # to the repository-root measurement.
+        sys.modules[spec.name] = module
+        try:
+            spec.loader.exec_module(module)
+        finally:
+            sys.modules.pop(spec.name, None)
+
+        template_path = outdir / "GCOGitHubOIDCStack.template.json"
+        assert template_path.is_file(), f"app.py synthesized no template at {template_path}"
+        return dict(json.loads(template_path.read_text(encoding="utf-8")))
+
+    def _trust_conditions(self, template: dict) -> dict:
+        roles = [
+            resource
+            for resource in template["Resources"].values()
+            if resource["Type"] == "AWS::IAM::Role"
+            and "Federated" in json.dumps(resource["Properties"]["AssumeRolePolicyDocument"])
+        ]
+        assert len(roles) == 1, "expected exactly one federated role"
+        statement = roles[0]["Properties"]["AssumeRolePolicyDocument"]["Statement"][0]
+        return dict(statement["Condition"])
+
+    def test_empty_context_defaults_to_upstream_repo_on_main_only(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """No context at all must still produce a main-only trust policy."""
+        template = self._run_app(tmp_path, monkeypatch, {})
+        conditions = self._trust_conditions(template)
+
+        assert "StringEquals" in conditions, "an unset branch must pin exactly one ref"
+        assert "StringLike" not in conditions
+        subject = json.dumps(conditions["StringEquals"])
+        assert "aws-solutions-library-samples/global-capacity-orchestrator-on-aws" in subject
+        assert "refs/heads/main" in subject
+
+    def test_context_overrides_are_applied(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Each context key must reach the stack, not just the repo."""
+        template = self._run_app(
+            tmp_path,
+            monkeypatch,
+            {
+                "github_repo": "my-org/my-repo",
+                "github_subject_prefix": "repo:my-org@12345/my-repo@67890",
+                "github_branch": "*",
+            },
+        )
+        conditions = self._trust_conditions(template)
+
+        # A wildcard branch is an explicit opt-in and must widen the operator.
+        assert "StringLike" in conditions
+        subject = json.dumps(conditions["StringLike"])
+        assert "repo:my-org@12345/my-repo@67890" in subject
+
+    def test_the_checked_in_cdk_json_context_synthesizes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The committed context is what a deploy actually uses, so it must work."""
+        template = self._run_app(tmp_path, monkeypatch, dict(_OIDC_CONTEXT))
+        conditions = self._trust_conditions(template)
+
+        assert _UPSTREAM_SUBJECT_PREFIX in json.dumps(conditions)


### PR DESCRIPTION
## Summary

First tranche off the Python coverage ratchet, and a hole in the gate that this work uncovered.

The standalone GitHub OIDC provider app is now at 100% and out of the omit list. **Ratchet: 99 → 97**, and with #368 (the code-diagram support modules, squash-merged into this branch) **→ 95**.

> **Update:** #366 merged, so this PR is rebased onto `main` and now carries two commits — the OIDC tranche below and the #368 squash (see that PR for its write-up). #369 stacks on this one.

## The gate had a hole

The ratchet entry was spelled `app.py`, intended for the repository-root CDK entry point. But coverage expands a pattern with no directory separator into **two** patterns — the absolutised path *and* the bare pattern as a glob:

```
prep_patterns(["app.py"]) -> ['app.py', '/…/repo/app.py']
```

That bare glob matches any `app.py` at any depth. So the entry was also silently omitting `.github/oidc_provider/app.py`, which is exactly why that file measured **0% while sitting outside the ratchet** — it looked covered because nothing was looking at it.

Fixed by spelling it `./app.py`, which matches the root file only (verified against coverage's own matcher). The entry moves to the head of the block, since `./app.py` now sorts first.

Rather than encode a spelling convention, a new test asserts the underlying property: for every ratchet entry, the set of files coverage's matcher would omit must be exactly the one file that entry names. Any future entry that over-reaches fails loudly, including ones nobody thought to check.

## What got covered

**`stack.py`, 88.41% → 100%.** The uncovered lines were all rejection paths in `_validated_subject_prefix`. That function is the only thing standing between a copied-and-pasted ID pair and a trust policy authorising a *different* repository to assume the CI role, so each path is pinned individually rather than inferred from the happy path:

- malformed `github_repo` — no separator, too many segments, empty owner, empty repo
- a non-string prefix, which is easy to write in `cdk.json`
- an untrimmed prefix, since prefixes are compared literally
- the explicit-mutable-prefix passthrough, asserted to synthesize *identically* to omitting it

**`app.py`, 0% → 100%.** Its whole job is turning `cdk.json` context into the stack, so a wrong default is a silent authorisation change — an unset `github_branch` must mean "main only", never "any branch". It's now executed for real and the synthesized trust policy asserted: an empty context still pins exactly one ref (`StringEquals`, no `StringLike`), context overrides all reach the stack, and the committed `cdk.json` context synthesizes.

Two things are supplied from outside, both narrow. `app.py` calls `cdk.App()` with no arguments, so `aws_cdk.App` is wrapped to fill in `context` and `outdir`. `context` is the same constructor argument the CDK CLI populates from `cdk.json`, so `try_get_context` is exercised as in a real deploy; `outdir` only decides where the template lands, since CDK otherwise writes to a random temp directory the test can't find. Neither changes what the app builds.

For the record, two approaches that don't work here and cost time to rule out: `CDK_OUTDIR` and `CDK_CONTEXT_JSON` are both ignored by this CDK version — the app still wrote to a random temp dir and still saw no context.

## Verification

- Both files at **100%** under the *real* project config (not just a scoped override) — `app.py` 8/8 statements, `stack.py` 53 statements + 16 branches.
- `tests/test_coverage_ratchet.py` at 8 tests, including the new over-matching guard.
- 221 targeted tests pass; `ruff check` / `ruff format --check` clean.

## Remaining ratchet

97 entries: `scripts/` 58, `lambda/` 19, `.github/` 10, `diagrams/` 6, `dockerfiles/` 2, root `app.py`, `docs/` 1. Measured for planning: `diagrams/` sits at 65.98% with 285 statements outstanding (`_renderer.py` at 42.58% is the Playwright one), so it wants a tranche of its own rather than being bolted on here.

